### PR TITLE
Suppress unused `id` warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ fn main() -> Result<()> {
     })?;
 
     for person in person_iter {
-        println!("Found person {:?}", person.unwrap());
+        let p = person.unwrap();
+        println!("ID: {}", p.id);
+        println!("Found person {:?}", p);
     }
 
     // query table by arrow


### PR DESCRIPTION
Use `id` in the code to suppress the warning.