### PR TITLE
Make Statement.stmt a RefCell

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
     )?;
 
     // query table by rows
-    let mut stmt = conn.prepare("SELECT id, name, data FROM person")?;
+    let stmt = conn.prepare("SELECT id, name, data FROM person")?;
     let person_iter = stmt.query_map([], |row| {
         Ok(Person {
             _id: row.get(0)?,

--- a/src/arrow_batch.rs
+++ b/src/arrow_batch.rs
@@ -18,7 +18,7 @@ impl<'stmt> Arrow<'stmt> {
     /// return arrow schema
     #[inline]
     pub fn get_schema(&self) -> SchemaRef {
-        self.stmt.unwrap().stmt.schema()
+        self.stmt.unwrap().stmt.borrow().schema()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,7 +158,7 @@ mod test {
         let db = Connection::open_in_memory_with_flags(config)?;
         db.execute_batch("CREATE TABLE foo(x Text)")?;
 
-        let mut stmt = db.prepare("INSERT INTO foo(x) VALUES (?)")?;
+        let stmt = db.prepare("INSERT INTO foo(x) VALUES (?)")?;
         stmt.execute([&"a"])?;
         stmt.execute([&"b"])?;
         stmt.execute([&"c"])?;
@@ -197,7 +197,7 @@ mod test {
         let db = Connection::open_in_memory_with_flags(config)?;
         db.execute_batch("CREATE TABLE foo(x Text)")?;
 
-        let mut stmt = db.prepare("INSERT INTO foo(x) VALUES (?)")?;
+        let stmt = db.prepare("INSERT INTO foo(x) VALUES (?)")?;
         stmt.execute([&"a"])?;
         stmt.execute([&"b"])?;
         stmt.execute([&"c"])?;

--- a/src/params.rs
+++ b/src/params.rs
@@ -124,7 +124,7 @@ pub trait Params: Sealed {
     //
     // For now, just hide the function in the docs...
     #[doc(hidden)]
-    fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()>;
+    fn __bind_in(self, stmt: &Statement<'_>) -> Result<()>;
 }
 
 // Explicitly impl for empty array. Critically, for `conn.execute([])` to be
@@ -133,7 +133,7 @@ pub trait Params: Sealed {
 impl Sealed for [&dyn ToSql; 0] {}
 impl Params for [&dyn ToSql; 0] {
     #[inline]
-    fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+    fn __bind_in(self, stmt: &Statement<'_>) -> Result<()> {
         // Note: Can't just return `Ok(())` — `Statement::bind_parameters`
         // checks that the right number of params were passed too.
         // TODO: we should have tests for `Error::InvalidParameterCount`...
@@ -144,7 +144,7 @@ impl Params for [&dyn ToSql; 0] {
 impl Sealed for &[&dyn ToSql] {}
 impl Params for &[&dyn ToSql] {
     #[inline]
-    fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+    fn __bind_in(self, stmt: &Statement<'_>) -> Result<()> {
         stmt.bind_parameters(self)
     }
 }
@@ -155,14 +155,14 @@ macro_rules! impl_for_array_ref {
         // avoid the compile time hit from making them all inline for now.
         impl<T: ToSql + ?Sized> Sealed for &[&T; $N] {}
         impl<T: ToSql + ?Sized> Params for &[&T; $N] {
-            fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+            fn __bind_in(self, stmt: &Statement<'_>) -> Result<()> {
                 stmt.bind_parameters(self)
             }
         }
         impl<T: ToSql> Sealed for [T; $N] {}
         impl<T: ToSql> Params for [T; $N] {
             #[inline]
-            fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+            fn __bind_in(self, stmt: &Statement<'_>) -> Result<()> {
                 stmt.bind_parameters(&self)
             }
         }
@@ -299,7 +299,7 @@ where
     I::Item: ToSql,
 {
     #[inline]
-    fn __bind_in(self, stmt: &mut Statement<'_>) -> Result<()> {
+    fn __bind_in(self, stmt: &Statement<'_>) -> Result<()> {
         stmt.bind_parameters(self.0)
     }
 }

--- a/src/pragma.rs
+++ b/src/pragma.rs
@@ -168,7 +168,7 @@ impl Connection {
     {
         let mut query = Sql::new();
         query.push_pragma(schema_name, pragma_name)?;
-        let mut stmt = self.prepare(&query)?;
+        let stmt = self.prepare(&query)?;
         let mut rows = stmt.query([])?;
         while let Some(result_row) = rows.next()? {
             f(result_row)?;
@@ -203,7 +203,7 @@ impl Connection {
         sql.open_brace();
         sql.push_value(pragma_value)?;
         sql.close_brace();
-        let mut stmt = self.prepare(&sql)?;
+        let stmt = self.prepare(&sql)?;
         let mut rows = stmt.query([])?;
         while let Some(result_row) = rows.next()? {
             let row = result_row;

--- a/src/raw_statement.rs
+++ b/src/raw_statement.rs
@@ -189,7 +189,7 @@ impl RawStatement {
         if idx >= self.column_count() {
             return None;
         }
-        Some(self.schema.as_ref().unwrap().field(idx).name())
+        Some(self.schema.as_ref()?.field(idx).name())
     }
 
     #[allow(dead_code)]

--- a/src/row.rs
+++ b/src/row.rs
@@ -48,6 +48,11 @@ impl<'stmt> Rows<'stmt> {
         Ok((*self).get())
     }
 
+    /// The statement that created this `Rows`.
+    pub fn stmt(&self) -> Option<&Statement<'stmt>> {
+        self.stmt
+    }
+
     #[inline]
     fn batch_row_count(&self) -> usize {
         if self.arr.is_none() {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -261,7 +261,7 @@ mod test {
         db.execute("INSERT INTO foo(t) VALUES (?)", [&s])?;
         db.execute("INSERT INTO foo(b) VALUES (?)", [&b])?;
 
-        let mut stmt = db.prepare("SELECT t, b FROM foo ORDER BY ROWID ASC")?;
+        let stmt = db.prepare("SELECT t, b FROM foo ORDER BY ROWID ASC")?;
         let mut rows = stmt.query([])?;
 
         {
@@ -294,7 +294,7 @@ mod test {
 
         db.execute("INSERT INTO foo(b, t, i, f) VALUES (X'0102', 'text', 1, 1.5)", [])?;
 
-        let mut stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
+        let stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
         let mut rows = stmt.query([])?;
 
         let row = rows.next()?.unwrap();
@@ -361,7 +361,7 @@ mod test {
 
         db.execute("INSERT INTO foo(b, t, i, f) VALUES (X'0102', 'text', 1, 1.5)", [])?;
 
-        let mut stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
+        let stmt = db.prepare("SELECT b, t, i, f, n FROM foo")?;
         let mut rows = stmt.query([])?;
 
         let row = rows.next()?.unwrap();
@@ -421,7 +421,7 @@ mod test {
             delete_statement: Statement<'conn>,
         }
 
-        let mut db_etc = DbEtc {
+        let db_etc = DbEtc {
             insert_statement: db.prepare("INSERT INTO foo VALUES (?1)")?,
             query_statement: db.prepare("SELECT x FROM foo")?,
             delete_statement: db.prepare("DELETE FROM foo")?,

--- a/src/types/to_sql.rs
+++ b/src/types/to_sql.rs
@@ -316,7 +316,7 @@ mod test {
 
         db.execute("INSERT INTO foo (id) VALUES (gen_random_uuid())", [])?;
 
-        let mut stmt = db.prepare("SELECT id FROM foo")?;
+        let stmt = db.prepare("SELECT id FROM foo")?;
         let mut rows = stmt.query([])?;
         let row = rows.next()?.unwrap();
         let found_id: String = row.get_unwrap(0);


### PR DESCRIPTION
Interior mutability allows the use of methods on `Statement` that use `RawStatement::schema` (e.g. `column_names`, `column_type`) which is only `Some(_)` after calling `execute()`