### PR TITLE
Added union type support in arrow feature

### DIFF
--- a/src/vtab/arrow.rs
+++ b/src/vtab/arrow.rs
@@ -1,13 +1,13 @@
 use super::{
     vector::{FlatVector, ListVector, Vector},
-    BindInfo, DataChunk, Free, FunctionInfo, InitInfo, LogicalType, LogicalTypeId, VTab,
+    BindInfo, DataChunk, Free, FunctionInfo, InitInfo, LogicalType, LogicalTypeId, StructVector, VTab,
 };
 
 use crate::vtab::vector::Inserter;
 use arrow::array::{
-    as_boolean_array, as_large_list_array, as_list_array, as_primitive_array, as_string_array, Array, ArrayData,
-    BooleanArray, Decimal128Array, FixedSizeListArray, GenericListArray, OffsetSizeTrait, PrimitiveArray, StringArray,
-    StructArray,
+    as_boolean_array, as_large_list_array, as_list_array, as_primitive_array, as_string_array, as_struct_array, Array,
+    ArrayData, BooleanArray, Decimal128Array, FixedSizeListArray, GenericListArray, OffsetSizeTrait, PrimitiveArray,
+    StringArray, StructArray,
 };
 
 use arrow::{
@@ -172,15 +172,12 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalType, Box<d
         Ok(LogicalType::new(to_duckdb_type_id(data_type)?))
     } else if let DataType::Dictionary(_, value_type) = data_type {
         to_duckdb_logical_type(value_type)
-    // } else if let DataType::Struct(fields) = data_type {
-    //     let mut shape = vec![];
-    //     for field in fields.iter() {
-    //         shape.push((
-    //             field.name().as_str(),
-    //             to_duckdb_logical_type(field.data_type())?,
-    //         ));
-    //     }
-    //     Ok(LogicalType::struct_type(shape.as_slice()))
+    } else if let DataType::Struct(fields) = data_type {
+        let mut shape = vec![];
+        for field in fields.iter() {
+            shape.push((field.name().as_str(), to_duckdb_logical_type(field.data_type())?));
+        }
+        Ok(LogicalType::struct_type(shape.as_slice()))
     } else if let DataType::List(child) = data_type {
         Ok(LogicalType::list(&to_duckdb_logical_type(child.data_type())?))
     } else if let DataType::LargeList(child) = data_type {
@@ -188,8 +185,9 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalType, Box<d
     } else if let DataType::FixedSizeList(child, _) = data_type {
         Ok(LogicalType::list(&to_duckdb_logical_type(child.data_type())?))
     } else {
-        println!("Unsupported data type: {data_type}, please file an issue https://github.com/wangfenjin/duckdb-rs");
-        todo!()
+        unimplemented!(
+            "Unsupported data type: {data_type}, please file an issue https://github.com/wangfenjin/duckdb-rs"
+        )
     }
 }
 
@@ -224,17 +222,16 @@ pub fn record_batch_to_duckdb_data_chunk(
             DataType::FixedSizeList(_, _) => {
                 fixed_size_list_array_to_vector(as_fixed_size_list_array(col.as_ref()), &mut chunk.list_vector(i));
             }
-            // DataType::Struct(_) => {
-            //     let struct_array = as_struct_array(col.as_ref());
-            //     let mut struct_vector = chunk.struct_vector(i);
-            //     struct_array_to_vector(struct_array, &mut struct_vector);
-            // }
+            DataType::Struct(_) => {
+                let struct_array = as_struct_array(col.as_ref());
+                let mut struct_vector = chunk.struct_vector(i);
+                struct_array_to_vector(struct_array, &mut struct_vector);
+            }
             _ => {
-                println!(
+                unimplemented!(
                     "column {} is not supported yet, please file an issue https://github.com/wangfenjin/duckdb-rs",
                     batch.schema().field(i)
                 );
-                todo!()
             }
         }
     }
@@ -406,46 +403,42 @@ fn as_fixed_size_list_array(arr: &dyn Array) -> &FixedSizeListArray {
     arr.as_any().downcast_ref::<FixedSizeListArray>().unwrap()
 }
 
-// fn struct_array_to_vector(array: &StructArray, out: &mut StructVector) {
-//     for i in 0..array.num_columns() {
-//         let column = array.column(i);
-//         match column.data_type() {
-//             dt if dt.is_primitive() || matches!(dt, DataType::Boolean) => {
-//                 primitive_array_to_vector(column, &mut out.child(i));
-//             }
-//             DataType::Utf8 => {
-//                 string_array_to_vector(as_string_array(column.as_ref()), &mut out.child(i));
-//             }
-//             DataType::List(_) => {
-//                 list_array_to_vector(
-//                     as_list_array(column.as_ref()),
-//                     &mut out.list_vector_child(i),
-//                 );
-//             }
-//             DataType::LargeList(_) => {
-//                 list_array_to_vector(
-//                     as_large_list_array(column.as_ref()),
-//                     &mut out.list_vector_child(i),
-//                 );
-//             }
-//             DataType::FixedSizeList(_, _) => {
-//                 fixed_size_list_array_to_vector(
-//                     as_fixed_size_list_array(column.as_ref()),
-//                     &mut out.list_vector_child(i),
-//                 );
-//             }
-//             DataType::Struct(_) => {
-//                 let struct_array = as_struct_array(column.as_ref());
-//                 let mut struct_vector = out.struct_vector_child(i);
-//                 struct_array_to_vector(struct_array, &mut struct_vector);
-//             }
-//             _ => {
-//                 println!("Unsupported data type: {}, please file an issue https://github.com/wangfenjin/duckdb-rs", column.data_type());
-//                 todo!()
-//             }
-//         }
-//     }
-// }
+fn struct_array_to_vector(array: &StructArray, out: &mut StructVector) {
+    for i in 0..array.num_columns() {
+        let column = array.column(i);
+        match column.data_type() {
+            dt if dt.is_primitive() || matches!(dt, DataType::Boolean) => {
+                primitive_array_to_vector(column, &mut out.child(i));
+            }
+            DataType::Utf8 => {
+                string_array_to_vector(as_string_array(column.as_ref()), &mut out.child(i));
+            }
+            DataType::List(_) => {
+                list_array_to_vector(as_list_array(column.as_ref()), &mut out.list_vector_child(i));
+            }
+            DataType::LargeList(_) => {
+                list_array_to_vector(as_large_list_array(column.as_ref()), &mut out.list_vector_child(i));
+            }
+            DataType::FixedSizeList(_, _) => {
+                fixed_size_list_array_to_vector(
+                    as_fixed_size_list_array(column.as_ref()),
+                    &mut out.list_vector_child(i),
+                );
+            }
+            DataType::Struct(_) => {
+                let struct_array = as_struct_array(column.as_ref());
+                let mut struct_vector = out.struct_vector_child(i);
+                struct_array_to_vector(struct_array, &mut struct_vector);
+            }
+            _ => {
+                unimplemented!(
+                    "Unsupported data type: {}, please file an issue https://github.com/wangfenjin/duckdb-rs",
+                    column.data_type()
+                );
+            }
+        }
+    }
+}
 
 /// Pass RecordBatch to duckdb.
 ///
@@ -485,8 +478,8 @@ mod test {
     use super::{arrow_recordbatch_to_query_params, ArrowVTab};
     use crate::{Connection, Result};
     use arrow::{
-        array::{Float64Array, Int32Array},
-        datatypes::{DataType, Field, Schema},
+        array::{ArrayRef, Float64Array, Int32Array, StringArray, StructArray},
+        datatypes::{DataType, Field, Fields, Schema},
         record_batch::RecordBatch,
     };
     use std::{error::Error, sync::Arc};
@@ -529,6 +522,41 @@ mod test {
         let column = rb.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(column.len(), 1);
         assert_eq!(column.value(0), 15);
+        Ok(())
+    }
+
+    #[test]
+    fn test_append_struct() -> Result<(), Box<dyn Error>> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE t1 (s STRUCT(v VARCHAR, i INTEGER))")?;
+        {
+            let struct_array = StructArray::from(vec![
+                (
+                    Arc::new(Field::new("v", DataType::Utf8, true)),
+                    Arc::new(StringArray::from(vec![Some("foo"), Some("bar")])) as ArrayRef,
+                ),
+                (
+                    Arc::new(Field::new("i", DataType::Int32, true)),
+                    Arc::new(Int32Array::from(vec![Some(1), Some(2)])) as ArrayRef,
+                ),
+            ]);
+
+            let schema = Schema::new(vec![Field::new(
+                "s",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("v", DataType::Utf8, true),
+                    Field::new("i", DataType::Int32, true),
+                ])),
+                true,
+            )]);
+
+            let record_batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array)])?;
+            let mut app = db.appender("t1")?;
+            app.append_record_batch(record_batch)?;
+        }
+        let mut stmt = db.prepare("SELECT s FROM t1")?;
+        let rbs: Vec<RecordBatch> = stmt.query_arrow([])?.collect();
+        assert_eq!(rbs.iter().map(|op| op.num_rows()).sum::<usize>(), 2);
         Ok(())
     }
 }

--- a/src/vtab/data_chunk.rs
+++ b/src/vtab/data_chunk.rs
@@ -1,6 +1,6 @@
 use super::{
     logical_type::LogicalType,
-    vector::{FlatVector, ListVector, StructVector},
+    vector::{FlatVector, ListVector, StructVector, UnionVector},
 };
 use crate::ffi::{
     duckdb_create_data_chunk, duckdb_data_chunk, duckdb_data_chunk_get_column_count, duckdb_data_chunk_get_size,
@@ -38,6 +38,11 @@ impl DataChunk {
     /// Get struct vector at the column index: `idx`.
     pub fn struct_vector(&self, idx: usize) -> StructVector {
         StructVector::from(unsafe { duckdb_data_chunk_get_vector(self.ptr, idx as u64) })
+    }
+
+    /// Get union vector at the column index: `idx`.
+    pub fn union_vector(&self, idx: usize) -> UnionVector {
+        UnionVector::from(unsafe { duckdb_data_chunk_get_vector(self.ptr, idx as u64) })
     }
 
     /// Set the size of the data chunk


### PR DESCRIPTION
This adds an MVP support for union types for use in appender via arrows. 
The insertion works fine currently for primitive and string types (more types can be added in the future).

However the retrieval is failing, possibly due to https://github.com/duckdb/duckdb/pull/11326 ? 

```shell
ok: CDataInterface("The datatype \"Union([(0, Field { name: \"num\", data_type: Int32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }), (1, Field { name: \"str\", data_type: Utf8, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} })], Sparse)\" expects 1 buffer, but requested 1. Please verify that the C data interface is correctly implemented.")
```

Thanks @Tishj for giving me pointers.