### PR TITLE
Support UTF8 in nested Apache Arrow data types (e.g. List)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ pretty_assertions = "1.4.0"
 path = "libduckdb-sys"
 version = "0.10.1"
 
+
 [package.metadata.docs.rs]
 features = ['vtab', 'chrono']
 all-features = false

--- a/src/vtab/arrow.rs
+++ b/src/vtab/arrow.rs
@@ -687,58 +687,46 @@ mod test {
     fn check_generic_array_roundtrip<T>(
         arry: GenericListArray<T>,
     ) -> Result<(), Box<dyn Error>> where T: OffsetSizeTrait{
-
+    
         let expected_output_array = arry.clone();    
-
+    
         let db = Connection::open_in_memory()?;
         db.register_table_function::<ArrowVTab>("arrow")?;
-
+    
         // Roundtrip a record batch from Rust to DuckDB and back to Rust
         let schema = Schema::new(vec![Field::new("a", arry.data_type().clone(), false)]);
-
+    
         let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arry.clone())])?;
         let param = arrow_recordbatch_to_query_params(rb);
         let mut stmt = db.prepare("select a from arrow(?, ?)")?;
         let rb = stmt.query_arrow(param)?.next().expect("no record batch");
-
+    
         let output_any_array = rb.column(0);
-        match (output_any_array.data_type(), expected_output_array.data_type()) {
-            // TODO: DuckDB doesnt return timestamp_tz properly yet, so we just check that the units are the same
-            (DataType::Timestamp(unit_a, _), DataType::Timestamp(unit_b, _)) => assert_eq!(unit_a, unit_b),
-            (a, b) => assert_eq!(a, b),
-        }
-
-        let maybe_output_array = output_any_array.as_primitive_opt::<T2>();
-
-        match maybe_output_array {
+        assert!(output_any_array.data_type().equals_datatype(expected_output_array.data_type()));
+    
+        match output_any_array.as_list_opt::<T>() {
             Some(output_array) => {
-                // Check that the output array is the same as the input array
                 assert_eq!(output_array.len(), expected_output_array.len());
                 for i in 0..output_array.len() {
                     assert_eq!(output_array.is_valid(i), expected_output_array.is_valid(i));
                     if output_array.is_valid(i) {
-                        assert_eq!(output_array.value(i), expected_output_array.value(i));
+                        assert!(expected_output_array.value(i).eq(&output_array.value(i)));
                     }
                 }
             }
-            None => {
-                panic!("Output array is not a PrimitiveArray {:?}", rb.column(0).data_type());
-            }
+            None => panic!("Expected GenericListArray"),
         }
-
+    
         Ok(())
     }
 
-
     #[test]
     fn test_array_roundtrip() -> Result<(), Box<dyn Error>> {
-
-        let list_array = ListArray::new(
+        check_generic_array_roundtrip(ListArray::new(
             Arc::new(Field::new("item", DataType::Utf8, true)),
             OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 4, 5])), 
             Arc::new(StringArray::from(vec![Some("foo"), Some("baz"), Some("bar"), Some("foo"), Some("baz")])), None
-        );
-        check_generic_array_roundtrip(list_array)?;
+        ))?;
 
         Ok(())
     }

--- a/src/vtab/arrow.rs
+++ b/src/vtab/arrow.rs
@@ -422,17 +422,20 @@ fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
     match value_array.data_type() {
         dt if dt.is_primitive() => {
             primitive_array_to_vector(value_array.as_ref(), &mut child)?;
-            for i in 0..array.len() {
-                let offset = array.value_offsets()[i];
-                let length = array.value_length(i);
-                out.set_entry(i, offset.as_(), length.as_());
-            }
+        }
+        DataType::Utf8 => {
+            string_array_to_vector(as_string_array(value_array.as_ref()), &mut child);
         }
         _ => {
             return Err("Nested list is not supported yet.".into());
         }
     }
 
+    for i in 0..array.len() {
+        let offset = array.value_offsets()[i];
+        let length = array.value_length(i);
+        out.set_entry(i, offset.as_(), length.as_());
+    }
     Ok(())
 }
 
@@ -452,10 +455,19 @@ fn fixed_size_list_array_to_vector(
             }
             out.set_len(value_array.len());
         }
+        DataType::Utf8 => {
+            string_array_to_vector(as_string_array(value_array.as_ref()), &mut child);
+        }
         _ => {
             return Err("Nested list is not supported yet.".into());
         }
     }
+    for i in 0..array.len() {
+        let offset = array.value_offset(i);
+        let length = array.value_length();
+        out.set_entry(i, offset as usize, length as usize);
+    }
+    out.set_len(value_array.len());
 
     Ok(())
 }

--- a/src/vtab/arrow.rs
+++ b/src/vtab/arrow.rs
@@ -561,7 +561,7 @@ mod test {
             TimestampSecondArray,
         },
         buffer::{OffsetBuffer, ScalarBuffer},
-        datatypes::{i256, ArrowNativeType, ArrowPrimitiveType, DataType, Field, Fields, Schema},
+        datatypes::{i256, ArrowPrimitiveType, DataType, Field, Fields, Schema},
         record_batch::RecordBatch,
     };
     use std::{error::Error, sync::Arc};


### PR DESCRIPTION
## Changes
- Currently only primitive nested types are supported
- Add support for `ListArray` with nested `UTF8` type 

### Illustrative Example
```rust
let mut stmt = db.prepare(format!(r#"CREATE TABLE "{name}" AS SELECT * FROM arrow(?, ?);"#).as_str()).unwrap();

// [["foo", "baz"], ["bar", "foo"], ["baz"]]
let list_array: ArrayRef = Arc::new(ListArray::new(
    Arc::new(Field::new("item", DataType::Utf8, true)),
    OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 4, 5])), 
    Arc::new(StringArray::from(vec![Some("foo"), Some("baz"), Some("bar"), Some("foo"), Some("baz")])), None)
);

let b: Result<RecordBatch, arrow::error::ArrowError> = RecordBatch::try_from_iter(vec![("my_col", list_array)]); 
stmt.execute(arrow_recordbatch_to_query_params(
    RecordBatch::try_from_iter(vec![("col_name", list_array)])?)
);
```
