### PR TITLE
Remove mut from raw_query

### DIFF
--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -448,7 +448,7 @@ impl Statement<'_> {
     /// Note that if the SQL does not return results, [`Statement::raw_execute`]
     /// should be used instead.
     #[inline]
-    pub fn raw_query(&mut self) -> Rows<'_> {
+    pub fn raw_query(&self) -> Rows<'_> {
         Rows::new(self)
     }
 


### PR DESCRIPTION
The `&mut` reference was not required here, this solved a use case for us where we wanted to query while the statement was immutably borrowed.