### PR TITLE
Support Arrow type `LargeUtf8`.

### DIFF
--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -122,7 +122,7 @@ impl From<::std::ffi::NulError> for Error {
     }
 }
 
-const UNKNOWN_COLUMN: usize = std::usize::MAX;
+const UNKNOWN_COLUMN: usize = usize::MAX;
 
 /// The conversion isn't precise, but it's convenient to have it
 /// to allow use of `get_raw(…).as_…()?` in callbacks that take `Error`.

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -261,10 +261,7 @@ impl fmt::Display for Type {
 mod test {
     use super::Value;
     use crate::{params, Connection, Error, Result, Statement};
-    use std::{
-        f64::EPSILON,
-        os::raw::{c_double, c_int},
-    };
+    use std::os::raw::{c_double, c_int};
 
     fn checked_memory_handle() -> Result<Connection> {
         let db = Connection::open_in_memory()?;
@@ -385,7 +382,7 @@ mod test {
         assert_eq!(vec![1, 2], row.get::<_, Vec<u8>>(0)?);
         assert_eq!("text", row.get::<_, String>(1)?);
         assert_eq!(1, row.get::<_, c_int>(2)?);
-        assert!((1.5 - row.get::<_, c_double>(3)?).abs() < EPSILON);
+        assert!((1.5 - row.get::<_, c_double>(3)?).abs() < f64::EPSILON);
         assert_eq!(row.get::<_, Option<c_int>>(4)?, None);
         assert_eq!(row.get::<_, Option<c_double>>(4)?, None);
         assert_eq!(row.get::<_, Option<String>>(4)?, None);
@@ -453,7 +450,7 @@ mod test {
         assert_eq!(Value::Text(String::from("text")), row.get::<_, Value>(1)?);
         assert_eq!(Value::Int(1), row.get::<_, Value>(2)?);
         match row.get::<_, Value>(3)? {
-            Value::Float(val) => assert!((1.5 - val).abs() < EPSILON as f32),
+            Value::Float(val) => assert!((1.5 - val).abs() < f32::EPSILON),
             x => panic!("Invalid Value {x:?}"),
         }
         assert_eq!(Value::Null, row.get::<_, Value>(4)?);

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -873,14 +873,8 @@ mod test {
 
     #[test]
     fn test_utf8_roundtrip() -> Result<(), Box<dyn Error>> {
-        check_rust_primitive_array_roundtrip(
-            StringArray::from(vec![Some("foo"), None, Some("bar")]),
-            StringArray::from(vec![Some("foo"), None, Some("bar")]),
-        )?;
-        check_rust_primitive_array_roundtrip(
-            LargeStringArray::from(vec![Some("foo"), None, Some("bar")]),
-            LargeStringArray::from(vec![Some("foo"), None, Some("bar")]),
-        )?;
+        check_generic_array_roundtrip(StringArray::from(vec![Some("foo"), None, Some("bar")]))?;
+        check_generic_array_roundtrip(LargeStringArray::from(vec![Some("foo"), None, Some("bar")]))?;
         Ok(())
     }
 

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -622,11 +622,11 @@ mod test {
         array::{
             Array, ArrayRef, AsArray, BinaryArray, Date32Array, Date64Array, Decimal128Array, Decimal256Array,
             FixedSizeListArray, GenericByteArray, GenericListArray, Int32Array, LargeStringArray, ListArray,
-            OffsetSizeTrait, PrimitiveArray, StringArray, Time32SecondArray, Time64MicrosecondArray,
+            OffsetSizeTrait, PrimitiveArray, StringArray, StructArray, Time32SecondArray, Time64MicrosecondArray,
             TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
         },
         buffer::{OffsetBuffer, ScalarBuffer},
-        datatypes::{i256, ArrowPrimitiveType, ByteArrayType, DataType, Field, Schema},
+        datatypes::{i256, ArrowPrimitiveType, ByteArrayType, DataType, Field, Fields, Schema},
         record_batch::RecordBatch,
     };
     use std::{error::Error, sync::Arc};

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -6,7 +6,9 @@ use std::ptr::null_mut;
 
 use crate::vtab::vector::Inserter;
 use arrow::array::{
-    as_boolean_array, as_generic_binary_array, as_large_list_array, as_list_array, as_primitive_array, as_string_array, as_struct_array, Array, ArrayData, AsArray, BinaryArray, BooleanArray, Decimal128Array, FixedSizeListArray, GenericListArray, GenericStringArray, LargeStringArray, OffsetSizeTrait, PrimitiveArray, StructArray
+    as_boolean_array, as_generic_binary_array, as_large_list_array, as_list_array, as_primitive_array, as_string_array,
+    as_struct_array, Array, ArrayData, AsArray, BinaryArray, BooleanArray, Decimal128Array, FixedSizeListArray,
+    GenericListArray, GenericStringArray, LargeStringArray, OffsetSizeTrait, PrimitiveArray, StructArray,
 };
 
 use arrow::{
@@ -226,11 +228,14 @@ pub fn record_batch_to_duckdb_data_chunk(
             }
             DataType::Utf8 => {
                 string_array_to_vector(as_string_array(col.as_ref()), &mut chunk.flat_vector(i));
-            },
+            }
             DataType::LargeUtf8 => {
                 string_array_to_vector(
-                    col.as_ref().as_any().downcast_ref::<LargeStringArray>()  .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to LargeStringArray"))?,
-                    &mut chunk.flat_vector(i)
+                    col.as_ref()
+                        .as_any()
+                        .downcast_ref::<LargeStringArray>()
+                        .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to LargeStringArray"))?,
+                    &mut chunk.flat_vector(i),
                 );
             }
             DataType::Binary => {
@@ -615,7 +620,10 @@ mod test {
     use crate::{Connection, Result};
     use arrow::{
         array::{
-            Array, ArrayRef, AsArray, BinaryArray, Date32Array, Date64Array, Decimal128Array, Decimal256Array, FixedSizeListArray, GenericListArray, Int32Array, LargeStringArray, ListArray, OffsetSizeTrait, PrimitiveArray, StringArray, StructArray, Time32SecondArray, Time64MicrosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray
+            Array, ArrayRef, AsArray, BinaryArray, Date32Array, Date64Array, Decimal128Array, Decimal256Array,
+            FixedSizeListArray, GenericListArray, Int32Array, LargeStringArray, ListArray, OffsetSizeTrait,
+            PrimitiveArray, StringArray, StructArray, Time32SecondArray, Time64MicrosecondArray,
+            TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
         },
         buffer::{OffsetBuffer, ScalarBuffer},
         datatypes::{i256, ArrowPrimitiveType, DataType, Field, Fields, Schema},
@@ -863,12 +871,16 @@ mod test {
         Ok(())
     }
 
-
-
     #[test]
     fn test_utf8_roundtrip() -> Result<(), Box<dyn Error>> {
-        check_rust_primitive_array_roundtrip(StringArray::from(vec![Some("foo"), None, Some("bar")]), StringArray::from(vec![Some("foo"), None, Some("bar")]))?;
-        check_rust_primitive_array_roundtrip(LargeStringArray::from(vec![Some("foo"), None, Some("bar")]), LargeStringArray::from(vec![Some("foo"), None, Some("bar")]))?;
+        check_rust_primitive_array_roundtrip(
+            StringArray::from(vec![Some("foo"), None, Some("bar")]),
+            StringArray::from(vec![Some("foo"), None, Some("bar")]),
+        )?;
+        check_rust_primitive_array_roundtrip(
+            LargeStringArray::from(vec![Some("foo"), None, Some("bar")]),
+            LargeStringArray::from(vec![Some("foo"), None, Some("bar")]),
+        )?;
         Ok(())
     }
 


### PR DESCRIPTION
## Changes
 - Support `LargeUTF8` arrow type.
 - Abstract `string_array_to_vector` to `GenericStringArray`