### PR TITLE
fix: don't write files outside of `OUT_DIR`

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -167,9 +167,6 @@ mod build_bundled {
         }
         cfg.compile(lib_name);
 
-        // Remove the extracted files after building.
-        std::fs::remove_dir_all(format!("{out_dir}/{lib_name}")).expect("Could not delete extracted files");
-
         println!("cargo:lib_dir={out_dir}");
     }
 }

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -97,7 +97,7 @@ mod build_bundled {
         #[cfg(feature = "buildtime_bindgen")]
         {
             use super::{bindings, HeaderLocation};
-            let header = HeaderLocation::FromPath(format!("{}/src/include/duckdb.h", lib_name));
+            let header = HeaderLocation::FromPath(format!("{out_dir}/{lib_name}/src/include/duckdb.h"));
             bindings::write_to_out_dir(header, out_path);
         }
         #[cfg(not(feature = "buildtime_bindgen"))]
@@ -132,7 +132,7 @@ mod build_bundled {
 
         // Since the manifest controls the set of files, we require it to be changed to know whether
         // to rebuild the project
-        println!("cargo:rerun-if-changed={}/manifest.json", lib_name);
+        println!("cargo:rerun-if-changed={out_dir}/{lib_name}/manifest.json");
         // Make sure to rebuild the project if tar file changed
         println!("cargo:rerun-if-changed=duckdb.tar.gz");
 


### PR DESCRIPTION
The cargo docs state that `build.rs` scripts should not write files outside of the `OUT_DIR`.

> In general, build scripts should not modify any files outside of OUT_DIR. It may seem fine on the first blush, but it does cause problems when you use such crate as a dependency, because there’s an implicit invariant that sources in .cargo/registry should be immutable. cargo won’t allow such scripts when packaging.

Taken from [here](https://doc.rust-lang.org/cargo/reference/build-script-examples.html#code-generation).

Some build environments like [Nix](https://nixos.org/) use this information to provide a sandbox environment for `build.rs` scripts to run. These sandbox environments fail the build if the script tries to modify files that are not in the `OUT_DIR`.

The modification being done in this crate is the extraction of the DuckDB source archive. Currently, the archive is being extracted in the root directory of the `libduckdb-sys` crate. This causes the build to fail in sandbox environments.

In this PR, I have modified the `build.rs` script for `libduckdb-sys` to extract the DuckDB archive in the `OUT_DIR`. I have also added some code to delete all the extracted source files from the `OUT_DIR` after the compilation is completed because they will no longer needed.  