### PR TITLE
feat: set duckdb api to rust and add custom_user_agent config

### DIFF
--- a/crates/duckdb/src/config.rs
+++ b/crates/duckdb/src/config.rs
@@ -222,7 +222,6 @@ mod test {
         assert!(iter.next().unwrap().is_none());
         assert_eq!(iter.next(), None);
 
-
         let user_agent: Result<String> = db.query_row("PRAGMA USER_AGENT", [], |row| row.get(0));
         let user_agent = user_agent.unwrap();
         assert!(&user_agent.ends_with("rust test_user_agent"));

--- a/crates/duckdb/src/config.rs
+++ b/crates/duckdb/src/config.rs
@@ -65,6 +65,12 @@ impl Config {
         Ok(self)
     }
 
+    /// Metadata from DuckDB callers
+    pub fn custom_user_agent(mut self, custom_user_agent: &str) -> Result<Config> {
+        self.set("custom_user_agent", custom_user_agent)?;
+        Ok(self)
+    }
+
     /// The order type used when none is specified ([ASC] or DESC)
     pub fn default_order(mut self, order: DefaultOrder) -> Result<Config> {
         self.set("default_order", &order.to_string())?;
@@ -190,6 +196,7 @@ mod test {
             .enable_object_cache(false)?
             .enable_autoload_extension(true)?
             .allow_unsigned_extensions()?
+            .custom_user_agent("test_user_agent")?
             .max_memory("2GB")?
             .threads(4)?
             .with("preserve_insertion_order", "true")?;
@@ -214,6 +221,11 @@ mod test {
         assert_eq!(iter.next().unwrap().as_ref().unwrap(), "a");
         assert!(iter.next().unwrap().is_none());
         assert_eq!(iter.next(), None);
+
+
+        let user_agent: Result<String> = db.query_row("PRAGMA USER_AGENT", [], |row| row.get(0));
+        let user_agent = user_agent.unwrap();
+        assert!(&user_agent.ends_with("rust test_user_agent"));
 
         Ok(())
     }

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -295,6 +295,7 @@ impl Connection {
         }
 
         let c_path = path_to_cstring(path.as_ref())?;
+        let config = config.with("duckdb_api", "rust").unwrap();
         InnerConnection::open_with_flags(&c_path, config).map(|db| Connection {
             db: RefCell::new(db),
             cache: StatementCache::with_capacity(STATEMENT_CACHE_DEFAULT_CAPACITY),


### PR DESCRIPTION
- this is so we can distinguish rust from capi.
- caller can configure the custom_user_agent duckdb config.