### PR TITLE
streaming arrow data support

### DIFF
--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -3,7 +3,7 @@ use super::{
     Statement,
 };
 
-/// An handle for the resulting RecordBatch of a query.
+/// A handle for the resulting RecordBatch of a query.
 #[must_use = "Arrow is lazy and will do nothing unless consumed"]
 pub struct Arrow<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
@@ -27,5 +27,36 @@ impl<'stmt> Iterator for Arrow<'stmt> {
 
     fn next(&mut self) -> Option<Self::Item> {
         Some(RecordBatch::from(&self.stmt?.step()?))
+    }
+}
+
+/// A handle for the resulting RecordBatch of a query in streaming
+#[must_use = "Arrow stream is lazy and will not fetch data unless consumed"]
+pub struct ArrowStream<'stmt> {
+    pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
+    pub(crate) schema: SchemaRef,
+}
+
+impl<'stmt> ArrowStream<'stmt> {
+    #[inline]
+    pub(crate) fn new(stmt: &'stmt Statement<'stmt>, schema: SchemaRef) -> ArrowStream<'stmt> {
+        ArrowStream {
+            stmt: Some(stmt),
+            schema,
+        }
+    }
+
+    /// return arrow schema
+    #[inline]
+    pub fn get_schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl<'stmt> Iterator for ArrowStream<'stmt> {
+    type Item = RecordBatch;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(RecordBatch::from(&self.stmt?.stream_step(self.get_schema())?))
     }
 }

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -73,7 +73,7 @@ pub use crate::r2d2::DuckdbConnectionManager;
 pub use crate::{
     appender::Appender,
     appender_params::{appender_params_from_iter, AppenderParams, AppenderParamsFromIter},
-    arrow_batch::Arrow,
+    arrow_batch::{Arrow, ArrowStream},
     cache::CachedStatement,
     column::Column,
     config::{AccessMode, Config, DefaultNullOrder, DefaultOrder},

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -6,7 +6,7 @@ use super::{ffi, AndThenRows, Connection, Error, MappedRows, Params, RawStatemen
 #[cfg(feature = "polars")]
 use crate::{arrow2, polars_dataframe::Polars};
 use crate::{
-    arrow_batch::Arrow,
+    arrow_batch::{Arrow, ArrowStream},
     error::result_from_duckdb_prepare,
     types::{TimeUnit, ToSql, ToSqlOutput},
 };
@@ -107,6 +107,30 @@ impl Statement<'_> {
     pub fn query_arrow<P: Params>(&mut self, params: P) -> Result<Arrow<'_>> {
         self.execute(params)?;
         Ok(Arrow::new(self))
+    }
+
+    /// Execute the prepared statement, returning a handle to the resulting
+    /// vector of arrow RecordBatch in streaming way
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// # use duckdb::{Result, Connection};
+    /// # use arrow::record_batch::RecordBatch;
+    /// # use arrow::datatypes::SchemaRef
+    /// fn get_arrow_data(conn: &Connection, schema: SchemaRef) -> Result<Vec<RecordBatch>> {
+    ///     Ok(conn.prepare("SELECT * FROM test")?.stream_arrow([], schema)?.collect())
+    /// }
+    /// ```
+    ///
+    /// # Failure
+    ///
+    /// Will return `Err` if binding parameters fails.
+    #[inline]
+    pub fn stream_arrow<P: Params>(&mut self, params: P, schema: SchemaRef) -> Result<ArrowStream<'_>> {
+        params.__bind_in(self)?;
+        self.stmt.execute_streaming()?;
+        Ok(ArrowStream::new(self, schema))
     }
 
     /// Execute the prepared statement, returning a handle to the resulting
@@ -335,6 +359,12 @@ impl Statement<'_> {
     #[inline]
     pub fn step(&self) -> Option<StructArray> {
         self.stmt.step()
+    }
+
+    /// Get next batch records in arrow-rs in a streaming way
+    #[inline]
+    pub fn stream_step(&self, schema: SchemaRef) -> Option<StructArray> {
+        self.stmt.streaming_step(schema)
     }
 
     #[cfg(feature = "polars")]

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -117,7 +117,7 @@ impl Statement<'_> {
     /// ```rust,no_run
     /// # use duckdb::{Result, Connection};
     /// # use arrow::record_batch::RecordBatch;
-    /// # use arrow::datatypes::SchemaRef
+    /// # use arrow::datatypes::SchemaRef;
     /// fn get_arrow_data(conn: &Connection, schema: SchemaRef) -> Result<Vec<RecordBatch>> {
     ///     Ok(conn.prepare("SELECT * FROM test")?.stream_arrow([], schema)?.collect())
     /// }


### PR DESCRIPTION
This PR adds a new `execute_streaming` method in Statement and a `ArrowStream` struct to support streaming arrow data rather than fetching all in one call.

This has a caveat that require a SchemaRef to be passed into the `ArrowStream` struct as I couldn't find a way to get the schema without fetching entire batches.

Please point out if anyone knows

This fixes #171 