### PR TITLE
Fix CI

### DIFF
--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -32,6 +32,7 @@ extensions-full = ["json", "parquet", "vtab-full"]
 buildtime_bindgen = ["libduckdb-sys/buildtime_bindgen"]
 modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars"]
 polars = ["dep:polars"]
+time = []
 
 [dependencies]
 libduckdb-sys = { workspace = true }

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -32,7 +32,9 @@ extensions-full = ["json", "parquet", "vtab-full"]
 buildtime_bindgen = ["libduckdb-sys/buildtime_bindgen"]
 modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars"]
 polars = ["dep:polars"]
-time = []
+# FIXME: These were added to make clippy happy: these features appear unused and should perhaps be removed
+column_decltype = []
+extra_check = []
 
 [dependencies]
 libduckdb-sys = { workspace = true }

--- a/crates/duckdb/src/column.rs
+++ b/crates/duckdb/src/column.rs
@@ -146,7 +146,7 @@ impl Statement<'_> {
     #[cfg(feature = "column_decltype")]
     pub fn columns(&self) -> Vec<Column> {
         let n = self.column_count();
-        let mut cols = Vec::with_capacity(n as usize);
+        let mut cols = Vec::with_capacity(n);
         for i in 0..n {
             let name = self.column_name_unwrap(i);
             let slice = self.stmt.column_decltype(i);


### PR DESCRIPTION
@Mytherin I think this solves the CI issues, likely something changed upstream making clippy more strict. 

I've removed the `time` feature completely. It doesn't appear to be used anywhere and seems like a leftover from copying rusqlite stuff. Also remove the large comment which is just copied from rusqlite and is just confusing overall: `DuckDB uses a [dynamic type system](https://www.sqlite.org/datatype3.html)` 

I just wanted to restore CI here quickly, but i think we should look into more thoroughly trimming dead features/code from the package. I feel there's a lot of stuff that is not really used and could potentially be removed to make the package easier to understand.