### PR TITLE
Upgrade arrow-rs to 53

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,4 @@ unicase = "2.6.0"
 url = "2.1"
 uuid = "1.0"
 vcpkg = "0.2"
-arrow = { version = "52", default-features = false }
+arrow = { version = "53", default-features = false }


### PR DESCRIPTION
Upgrade arrow-rs to the latest version.

It would be great to have this merged before the next crate version is published for `v1.1.0` (bumped in #381)