### PR TITLE
Make `Transaction::new_unchecked` public

### DIFF
--- a/crates/duckdb/src/transaction.rs
+++ b/crates/duckdb/src/transaction.rs
@@ -113,7 +113,7 @@ impl Transaction<'_> {
     /// possible, [`Transaction::new`] should be preferred, as it provides a
     /// compile-time guarantee that transactions are not nested.
     #[inline]
-    fn new_unchecked(conn: &Connection, _: TransactionBehavior) -> Result<Transaction<'_>> {
+    pub fn new_unchecked(conn: &Connection, _: TransactionBehavior) -> Result<Transaction<'_>> {
         // TODO(wangfenjin): not supported
         // let query = match behavior {
         //     TransactionBehavior::Deferred => "BEGIN DEFERRED",


### PR DESCRIPTION
`Transaction::new` references `Transaction::new_unchecked` to circumvent the borrow checker if need be, but isn't marked as public.