### PR TITLE
bump loadable macros version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["database"]
 [workspace.dependencies]
 duckdb = { version = "1.1.1", path = "crates/duckdb" }
 libduckdb-sys = { version = "1.1.1", path = "crates/libduckdb-sys" }
-duckdb-loadable-macros = { version = "0.1.2", path = "crates/duckdb-loadable-macros" }
+duckdb-loadable-macros = { version = "0.1.3", path = "crates/duckdb-loadable-macros" }
 autocfg = "1.0"
 bindgen = { version = "0.69", default-features = false }
 byteorder = "1.3"

--- a/crates/duckdb-loadable-macros/Cargo.toml
+++ b/crates/duckdb-loadable-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duckdb-loadable-macros"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Follow up of https://github.com/duckdb/duckdb-rs/pull/381.

Adress Sanitizer job was throwing error: 
```
[Address Sanitizer](https://github.com/duckdb/duckdb-rs/actions/runs/11234182797/job/31230038060#step:5:233)
It seems package 'duckdb-loadable-macros' modified since '0.1.2' so new version should be published
```

I've bumped the version to `v0.1.3`