### PR TITLE
Minor fixes

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -42,12 +42,12 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
     // Set the minimum duckdb version (dev by default)
     let minimum_duckdb_version = match args.min_duckdb_version {
         Some(i) => i,
-        None => env::var("DUCKDB_EXTENSION_MIN_DUCKDB_VERSION").unwrap().to_string()
+        None => env::var("DUCKDB_EXTENSION_MIN_DUCKDB_VERSION").expect("Please either set env var DUCKDB_EXTENSION_MIN_DUCKDB_VERSION or pass it as an argument to the proc macro").to_string()
     };
 
     let extension_name = match args.ext_name {
         Some(i) => i,
-        None => env::var("DUCKDB_EXTENSION_NAME").unwrap().to_string()
+        None => env::var("DUCKDB_EXTENSION_NAME").expect("Please either set env var DUCKDB_EXTENSION_MIN_DUCKDB_VERSION or pass it as an argument to the proc macro").to_string()
     };
 
     let ast = parse_macro_input!(item as syn::Item);

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -20,7 +20,7 @@ mod excel;
 pub use function::{BindInfo, FunctionInfo, InitInfo, TableFunction};
 pub use value::Value;
 
-use crate::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
+use crate::core::{DataChunkHandle, LogicalTypeHandle};
 use ffi::{duckdb_bind_info, duckdb_data_chunk, duckdb_function_info, duckdb_init_info};
 
 use ffi::duckdb_malloc;


### PR DESCRIPTION
Some minor tweaks for the rust extension template:
- extension name and version can now also be passed through env variables: since we need them in the build system for the extension metadata this ensure there's only 1 definition
- also remove an unused import to avoid warnings