### PR TITLE
Add Utf8View & BinaryView to supported Arrow vtab types

### DIFF
--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -1405,9 +1405,9 @@ mod test {
             .expect("Expected StringArray");
 
         assert_eq!(output_array.len(), 3);
-        assert_eq!(output_array.is_valid(0), true);
-        assert_eq!(output_array.is_valid(1), false);
-        assert_eq!(output_array.is_valid(2), true);
+        assert!(output_array.is_valid(0));
+        assert!(!output_array.is_valid(1));
+        assert!(output_array.is_valid(2));
         assert_eq!(output_array.value(0), "foo");
         assert_eq!(output_array.value(2), "baz");
 
@@ -1434,9 +1434,9 @@ mod test {
             .expect("Expected BinaryArray");
 
         assert_eq!(output_array.len(), 3);
-        assert_eq!(output_array.is_valid(0), true);
-        assert_eq!(output_array.is_valid(1), false);
-        assert_eq!(output_array.is_valid(2), true);
+        assert!(output_array.is_valid(0));
+        assert!(!output_array.is_valid(1));
+        assert!(output_array.is_valid(2));
         assert_eq!(output_array.value(0), b"hello");
         assert_eq!(output_array.value(2), b"!");
 


### PR DESCRIPTION
Adds support for Arrow's Utf8View (StringView) and BinaryView types in the Arrow vtab component. These types are now returned by DataFusion (see https://datafusion.apache.org/blog/2024/09/13/string-view-german-style-strings-part-1/).