### PR TITLE
Safety fixes and docs for vtab

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -133,8 +133,10 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// Will be called by duckdb
                 #[no_mangle]
                 pub unsafe extern "C" fn #c_entrypoint(db: *mut c_void) {
-                    let connection = Connection::open_from_raw(db.cast()).expect("can't open db connection");
-                    #prefixed_original_function(connection).expect("init failed");
+                    unsafe {
+                        let connection = Connection::open_from_raw(db.cast()).expect("can't open db connection");
+                        #prefixed_original_function(connection).expect("init failed");
+                    }
                 }
 
                 /// # Safety
@@ -142,7 +144,9 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// Predefined function, don't need to change unless you are sure
                 #[no_mangle]
                 pub unsafe extern "C" fn #c_entrypoint_version() -> *const c_char {
-                    ffi::duckdb_library_version()
+                    unsafe {
+                        ffi::duckdb_library_version()
+                    }
                 }
 
 

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -12,6 +12,7 @@ use libduckdb_sys as ffi;
 use std::{
     error::Error,
     ffi::{c_char, c_void, CString},
+    ptr,
 };
 
 #[repr(C)]
@@ -47,14 +48,19 @@ impl VTab for HelloVTab {
         bind.add_result_column("column0", LogicalTypeHandle::from(LogicalTypeId::Varchar));
         let param = bind.get_parameter(0).to_string();
         unsafe {
-            (*data).name = CString::new(param).unwrap().into_raw();
+            ptr::write(
+                data,
+                HelloBindData {
+                    name: CString::new(param).unwrap().into_raw(),
+                },
+            );
         }
         Ok(())
     }
 
     unsafe fn init(_: &InitInfo, data: *mut HelloInitData) -> Result<(), Box<dyn std::error::Error>> {
         unsafe {
-            (*data).done = false;
+            ptr::write(data, HelloInitData { done: false });
         }
         Ok(())
     }

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -17,23 +17,12 @@ use std::{
     ptr,
 };
 
-#[repr(C)]
 struct HelloBindData {
-    name: *mut c_char,
+    name: String,
 }
 
-impl Free for HelloBindData {
-    fn free(&mut self) {
-        unsafe {
-            if self.name.is_null() {
-                return;
-            }
-            drop(CString::from_raw(self.name));
-        }
-    }
-}
+impl Free for HelloBindData {}
 
-#[repr(C)]
 struct HelloInitData {
     done: bool,
 }
@@ -48,14 +37,9 @@ impl VTab for HelloVTab {
 
     unsafe fn bind(bind: &BindInfo, data: *mut HelloBindData) -> Result<(), Box<dyn std::error::Error>> {
         bind.add_result_column("column0", LogicalTypeHandle::from(LogicalTypeId::Varchar));
-        let param = bind.get_parameter(0).to_string();
+        let name = bind.get_parameter(0).to_string();
         unsafe {
-            ptr::write(
-                data,
-                HelloBindData {
-                    name: CString::new(param).unwrap().into_raw(),
-                },
-            );
+            ptr::write(data, HelloBindData { name });
         }
         Ok(())
     }
@@ -76,10 +60,7 @@ impl VTab for HelloVTab {
         } else {
             init_info.done = true;
             let vector = output.flat_vector(0);
-            let name = unsafe { CString::from_raw((*bind_info).name) };
-            let result = CString::new(format!("Hello {}", name.to_str()?))?;
-            // Can't consume the CString
-            bind_info.name = CString::into_raw(name);
+            let result = CString::new(format!("Hello {}", bind_info.name))?;
             vector.insert(0, result);
             output.set_len(1);
         }

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -20,7 +20,7 @@ mod excel;
 pub use function::{BindInfo, FunctionInfo, InitInfo, TableFunction};
 pub use value::Value;
 
-use crate::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
+use crate::core::{DataChunkHandle, LogicalTypeHandle};
 use ffi::{duckdb_bind_info, duckdb_data_chunk, duckdb_function_info, duckdb_init_info};
 
 use ffi::duckdb_malloc;
@@ -194,6 +194,7 @@ impl InnerConnection {
 mod test {
     use super::*;
     use crate::core::Inserter;
+    use crate::core::LogicalTypeId;
     use std::{
         error::Error,
         ffi::{c_char, CString},

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -65,27 +65,22 @@ pub trait VTab: Sized {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it dereferences raw pointers (`data`) and manipulates the memory directly.
-    /// The caller must ensure that:
-    ///
-    /// - The `data` pointer is valid and points to a properly initialized `BindData` instance.
-    /// - The lifetime of `data` must outlive the execution of `bind` to avoid dangling pointers, especially since
-    ///   `bind` does not take ownership of `data`.
-    /// - Concurrent access to `data` (if applicable) must be properly synchronized.
-    /// - The `bind` object must be valid and correctly initialized.
+    /// `data` points to an *uninitialized* block of memory large enough to hold a `Self::BindData` value.
+    /// The implementation should initialize this memory with the appropriate data for the table function,
+    /// without reading the existing memory,
+    /// typically using [`std::ptr::write`] or similar.
     unsafe fn bind(bind: &BindInfo, data: *mut Self::BindData) -> Result<(), Box<dyn std::error::Error>>;
+
     /// Initialize the table function
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it performs raw pointer dereferencing on the `data` argument.
-    /// The caller is responsible for ensuring that:
-    ///
-    /// - The `data` pointer is non-null and points to a valid `InitData` instance.
-    /// - There is no data race when accessing `data`, meaning if `data` is accessed from multiple threads,
-    ///   proper synchronization is required.
-    /// - The lifetime of `data` extends beyond the scope of this call to avoid use-after-free errors.
+    /// `data` points to an *uninitialized* block of memory large enough to hold a `Self::InitData` value.
+    /// The implementation should initialize this memory with the appropriate data for the table function,
+    /// without reading the existing memory,
+    /// typically using [`std::ptr::write`] or similar.
     unsafe fn init(init: &InitInfo, data: *mut Self::InitData) -> Result<(), Box<dyn std::error::Error>>;
+
     /// The actual function
     ///
     /// # Safety


### PR DESCRIPTION
The vtab methods are called with pointers to uninitialized blocks of memory:

* The docs previously seemed to falsely indicate that these blocks were actually initialized: clarify the docs.

* It's UB to read uninitialzed memory, and better to write it with ptr::write. In particular, less trivial code that follows the example can corrupt memory if it uses the patterns shown in the example.

* Use unsafe blocks inside unsafe fns in the example, because this will be a warning in Rust 2024. In particular, do this to avoid a warning from the duckdb_entrypoint macro.

* The Rust types used in the examples don't need layout compatibility with C, and can simply be Rust structs using native strings.

Improves #414