### PR TITLE
Make the VTab interface safe

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -133,8 +133,10 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// Will be called by duckdb
                 #[no_mangle]
                 pub unsafe extern "C" fn #c_entrypoint(db: *mut c_void) {
-                    let connection = Connection::open_from_raw(db.cast()).expect("can't open db connection");
-                    #prefixed_original_function(connection).expect("init failed");
+                    unsafe {
+                        let connection = Connection::open_from_raw(db.cast()).expect("can't open db connection");
+                        #prefixed_original_function(connection).expect("init failed");
+                    }
                 }
 
                 /// # Safety
@@ -142,7 +144,9 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// Predefined function, don't need to change unless you are sure
                 #[no_mangle]
                 pub unsafe extern "C" fn #c_entrypoint_version() -> *const c_char {
-                    ffi::duckdb_library_version()
+                    unsafe {
+                        ffi::duckdb_library_version()
+                    }
                 }
 
 

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -12,6 +12,7 @@ use libduckdb_sys as ffi;
 use std::{
     error::Error,
     ffi::{c_char, c_void, CString},
+    ptr,
 };
 
 #[repr(C)]
@@ -47,14 +48,19 @@ impl VTab for HelloVTab {
         bind.add_result_column("column0", LogicalTypeHandle::from(LogicalTypeId::Varchar));
         let param = bind.get_parameter(0).to_string();
         unsafe {
-            (*data).name = CString::new(param).unwrap().into_raw();
+            ptr::write(
+                data,
+                HelloBindData {
+                    name: CString::new(param).unwrap().into_raw(),
+                },
+            );
         }
         Ok(())
     }
 
     unsafe fn init(_: &InitInfo, data: *mut HelloInitData) -> Result<(), Box<dyn std::error::Error>> {
         unsafe {
-            (*data).done = false;
+            ptr::write(data, HelloInitData { done: false });
         }
         Ok(())
     }

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -14,7 +14,6 @@ use libduckdb_sys as ffi;
 use std::{
     error::Error,
     ffi::{c_char, c_void, CString},
-    ptr,
 };
 
 struct HelloBindData {
@@ -35,20 +34,14 @@ impl VTab for HelloVTab {
     type InitData = HelloInitData;
     type BindData = HelloBindData;
 
-    unsafe fn bind(bind: &BindInfo, data: *mut HelloBindData) -> Result<(), Box<dyn std::error::Error>> {
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
         bind.add_result_column("column0", LogicalTypeHandle::from(LogicalTypeId::Varchar));
         let name = bind.get_parameter(0).to_string();
-        unsafe {
-            ptr::write(data, HelloBindData { name });
-        }
-        Ok(())
+        Ok(HelloBindData { name })
     }
 
-    unsafe fn init(_: &InitInfo, data: *mut HelloInitData) -> Result<(), Box<dyn std::error::Error>> {
-        unsafe {
-            ptr::write(data, HelloInitData { done: false });
-        }
-        Ok(())
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(HelloInitData { done: false })
     }
 
     unsafe fn func(func: &FunctionInfo, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -40,9 +40,9 @@ impl VTab for HelloVTab {
         Ok(HelloInitData { done: false })
     }
 
-    unsafe fn func(func: &FunctionInfo, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+    fn func(func: &FunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
         let init_info = unsafe { func.get_init_data::<HelloInitData>().as_mut().unwrap() };
-        let bind_info = unsafe { func.get_bind_data::<HelloBindData>().as_mut().unwrap() };
+        let bind_info = func.get_bind_data();
 
         if init_info.done {
             output.set_len(0);

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -6,7 +6,7 @@ extern crate libduckdb_sys;
 
 use duckdb::{
     core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId},
-    vtab::{BindInfo, Free, FunctionInfo, InitInfo, VTab},
+    vtab::{BindInfo, FunctionInfo, InitInfo, VTab},
     Connection, Result,
 };
 use duckdb_loadable_macros::duckdb_entrypoint;
@@ -20,15 +20,11 @@ struct HelloBindData {
     name: String,
 }
 
-impl Free for HelloBindData {}
-
 struct HelloInitData {
     done: bool,
 }
 
 struct HelloVTab;
-
-impl Free for HelloInitData {}
 
 impl VTab for HelloVTab {
     type InitData = HelloInitData;

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -17,23 +17,12 @@ use std::{
     ptr,
 };
 
-#[repr(C)]
 struct HelloBindData {
-    name: *mut c_char,
+    name: String,
 }
 
-impl Free for HelloBindData {
-    fn free(&mut self) {
-        unsafe {
-            if self.name.is_null() {
-                return;
-            }
-            drop(CString::from_raw(self.name));
-        }
-    }
-}
+impl Free for HelloBindData {}
 
-#[repr(C)]
 struct HelloInitData {
     done: bool,
 }
@@ -48,14 +37,9 @@ impl VTab for HelloVTab {
 
     unsafe fn bind(bind: &BindInfo, data: *mut HelloBindData) -> Result<(), Box<dyn std::error::Error>> {
         bind.add_result_column("column0", LogicalTypeHandle::from(LogicalTypeId::Varchar));
-        let param = bind.get_parameter(0).to_string();
+        let name = bind.get_parameter(0).to_string();
         unsafe {
-            ptr::write(
-                data,
-                HelloBindData {
-                    name: CString::new(param).unwrap().into_raw(),
-                },
-            );
+            ptr::write(data, HelloBindData { name });
         }
         Ok(())
     }
@@ -76,10 +60,7 @@ impl VTab for HelloVTab {
         } else {
             init_info.done = true;
             let vector = output.flat_vector(0);
-            let name = unsafe { CString::from_raw((*bind_info).name) };
-            let result = CString::new(format!("Hello {}", name.to_str()?))?;
-            // Can't consume the CString
-            bind_info.name = CString::into_raw(name);
+            let result = CString::new(format!("Hello {}", bind_info.name))?;
             vector.insert(0, result);
             output.set_len(1);
         }

--- a/crates/duckdb/src/vtab/function.rs
+++ b/crates/duckdb/src/vtab/function.rs
@@ -139,7 +139,9 @@ impl From<duckdb_init_info> for InitInfo {
 impl InitInfo {
     /// # Safety
     pub unsafe fn set_init_data(&self, data: *mut c_void, freeer: Option<unsafe extern "C" fn(*mut c_void)>) {
-        duckdb_init_set_init_data(self.0, data, freeer);
+        unsafe {
+            duckdb_init_set_init_data(self.0, data, freeer);
+        }
     }
 
     /// Returns the column indices of the projected columns at the specified positions.
@@ -189,7 +191,7 @@ impl InitInfo {
     /// * `error`: The error message
     pub fn set_error(&self, error: &str) {
         let c_str = CString::new(error).unwrap();
-        unsafe { duckdb_init_set_error(self.0, c_str.as_ptr() as *const c_char) }
+        unsafe { duckdb_init_set_error(self.0, c_str.as_ptr()) }
     }
 }
 
@@ -310,7 +312,9 @@ impl TableFunction {
     ///
     /// # Safety
     pub unsafe fn set_extra_info(&self, extra_info: *mut c_void, destroy: duckdb_delete_callback_t) {
-        duckdb_table_function_set_extra_info(self.ptr, extra_info, destroy);
+        unsafe {
+            duckdb_table_function_set_extra_info(self.ptr, extra_info, destroy);
+        }
     }
 
     /// Sets the thread-local init function of the table function

--- a/crates/duckdb/src/vtab/function.rs
+++ b/crates/duckdb/src/vtab/function.rs
@@ -9,10 +9,11 @@ use super::{
         duckdb_table_function_set_init, duckdb_table_function_set_local_init, duckdb_table_function_set_name,
         duckdb_table_function_supports_projection_pushdown, idx_t,
     },
-    LogicalTypeHandle, Value,
+    LogicalTypeHandle, VTab, Value,
 };
 use std::{
     ffi::{c_void, CString},
+    marker::PhantomData,
     os::raw::c_char,
 };
 
@@ -334,9 +335,12 @@ use super::ffi::{
 
 /// An interface to store and retrieve data during the function execution stage
 #[derive(Debug)]
-pub struct FunctionInfo(duckdb_function_info);
+pub struct FunctionInfo<V: VTab> {
+    ptr: duckdb_function_info,
+    _vtab: std::marker::PhantomData<V>,
+}
 
-impl FunctionInfo {
+impl<V: VTab> FunctionInfo<V> {
     /// Report that an error has occurred while executing the function.
     ///
     /// # Arguments
@@ -344,44 +348,49 @@ impl FunctionInfo {
     pub fn set_error(&self, error: &str) {
         let c_str = CString::new(error).unwrap();
         unsafe {
-            duckdb_function_set_error(self.0, c_str.as_ptr() as *const c_char);
+            duckdb_function_set_error(self.ptr, c_str.as_ptr());
         }
     }
+
     /// Gets the bind data set by [`BindInfo::set_bind_data`] during the bind.
     ///
     /// Note that the bind data should be considered as read-only.
     /// For tracking state, use the init data instead.
-    ///
-    /// # Arguments
-    /// * `returns`: The bind data object
-    pub fn get_bind_data<T>(&self) -> *mut T {
-        unsafe { duckdb_function_get_bind_data(self.0).cast() }
+    pub fn get_bind_data(&self) -> &V::BindData {
+        unsafe {
+            let bind_data: *const V::BindData = duckdb_function_get_bind_data(self.ptr).cast();
+            bind_data.as_ref().unwrap()
+        }
     }
+
     /// Gets the init data set by [`InitInfo::set_init_data`] during the init.
     ///
     /// # Arguments
     /// * `returns`: The init data object
     pub fn get_init_data<T>(&self) -> *mut T {
-        unsafe { duckdb_function_get_init_data(self.0).cast() }
+        unsafe { duckdb_function_get_init_data(self.ptr).cast() }
     }
     /// Retrieves the extra info of the function as set in [`TableFunction::set_extra_info`]
     ///
     /// # Arguments
     /// * `returns`: The extra info
     pub fn get_extra_info<T>(&self) -> *mut T {
-        unsafe { duckdb_function_get_extra_info(self.0).cast() }
+        unsafe { duckdb_function_get_extra_info(self.ptr).cast() }
     }
     /// Gets the thread-local init data set by [`InitInfo::set_init_data`] during the local_init.
     ///
     /// # Arguments
     /// * `returns`: The init data object
     pub fn get_local_init_data<T>(&self) -> *mut T {
-        unsafe { duckdb_function_get_local_init_data(self.0).cast() }
+        unsafe { duckdb_function_get_local_init_data(self.ptr).cast() }
     }
 }
 
-impl From<duckdb_function_info> for FunctionInfo {
+impl<V: VTab> From<duckdb_function_info> for FunctionInfo<V> {
     fn from(ptr: duckdb_function_info) -> Self {
-        Self(ptr)
+        Self {
+            ptr,
+            _vtab: PhantomData,
+        }
     }
 }

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -20,7 +20,7 @@ mod excel;
 pub use function::{BindInfo, FunctionInfo, InitInfo, TableFunction};
 pub use value::Value;
 
-use crate::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
+use crate::core::{DataChunkHandle, LogicalTypeHandle};
 use ffi::{duckdb_bind_info, duckdb_data_chunk, duckdb_function_info, duckdb_init_info};
 
 use ffi::duckdb_malloc;
@@ -194,6 +194,7 @@ impl InnerConnection {
 mod test {
     use super::*;
     use crate::core::Inserter;
+    use crate::core::LogicalTypeId;
     use std::{
         error::Error,
         ffi::{c_char, CString},

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -39,12 +39,21 @@ unsafe extern "C" fn drop_boxed<T>(v: *mut c_void) {
 /// See to the HelloVTab example for more details
 /// <https://duckdb.org/docs/api/c/table_functions>
 pub trait VTab: Sized {
-    /// The data type of the bind data
-    type InitData: Sized;
-    /// The data type of the init data
-    type BindData: Sized; // TODO: and maybe Send + Sync as this might be called from multiple threads?
+    /// The data type of the init data.
+    ///
+    /// The init data tracks the state of the table function and is global across threads.
+    ///
+    /// The init data is shared across threads so must be `Send + Sync`.
+    type InitData: Sized + Send + Sync;
+
+    /// The data type of the bind data.
+    ///
+    /// The bind data is shared across threads so must be `Send + Sync`.
+    type BindData: Sized + Send + Sync;
 
     /// Bind data to the table function
+    ///
+    /// This function is used for determining the return type of a table producing function and returning bind data
     fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>>;
 
     /// Initialize the table function

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -65,27 +65,22 @@ pub trait VTab: Sized {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it dereferences raw pointers (`data`) and manipulates the memory directly.
-    /// The caller must ensure that:
-    ///
-    /// - The `data` pointer is valid and points to a properly initialized `BindData` instance.
-    /// - The lifetime of `data` must outlive the execution of `bind` to avoid dangling pointers, especially since
-    ///   `bind` does not take ownership of `data`.
-    /// - Concurrent access to `data` (if applicable) must be properly synchronized.
-    /// - The `bind` object must be valid and correctly initialized.
+    /// `data` points to an *uninitialized* block of memory large enough to hold a `Self::BindData` value.
+    /// The implementation should initialize this memory with the appropriate data for the table function,
+    /// without reading the existing memory,
+    /// typically using [`std::ptr::write`] or similar.
     unsafe fn bind(bind: &BindInfo, data: *mut Self::BindData) -> Result<(), Box<dyn std::error::Error>>;
+
     /// Initialize the table function
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it performs raw pointer dereferencing on the `data` argument.
-    /// The caller is responsible for ensuring that:
-    ///
-    /// - The `data` pointer is non-null and points to a valid `InitData` instance.
-    /// - There is no data race when accessing `data`, meaning if `data` is accessed from multiple threads,
-    ///   proper synchronization is required.
-    /// - The lifetime of `data` extends beyond the scope of this call to avoid use-after-free errors.
+    /// `data` points to an *uninitialized* block of memory large enough to hold a `Self::InitData` value.
+    /// The implementation should initialize this memory with the appropriate data for the table function,
+    /// without reading the existing memory,
+    /// typically using [`std::ptr::write`] or similar.
     unsafe fn init(init: &InitInfo, data: *mut Self::InitData) -> Result<(), Box<dyn std::error::Error>>;
+
     /// The actual function
     ///
     /// # Safety

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -34,23 +34,15 @@ unsafe extern "C" fn drop_boxed<T>(v: *mut c_void) {
     drop(unsafe { Box::from_raw(v.cast::<T>()) });
 }
 
-/// Free trait for the bind and init data
-pub trait Free {
-    /// Free the data
-    fn free(&mut self) {}
-}
-
 /// Duckdb table function trait
 ///
 /// See to the HelloVTab example for more details
 /// <https://duckdb.org/docs/api/c/table_functions>
 pub trait VTab: Sized {
     /// The data type of the bind data
-    type InitData: Sized + Free;
+    type InitData: Sized;
     /// The data type of the init data
-    type BindData: Sized + Free; // TODO: and maybe Send + Sync as this might be called from multiple threads?
-
-    // TODO: Get rid of Free, just use Drop?
+    type BindData: Sized; // TODO: and maybe Send + Sync as this might be called from multiple threads?
 
     /// Bind data to the table function
     fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>>;
@@ -186,15 +178,11 @@ mod test {
         name: String,
     }
 
-    impl Free for HelloBindData {}
-
     struct HelloInitData {
         done: bool,
     }
 
     struct HelloVTab;
-
-    impl Free for HelloInitData {}
 
     impl VTab for HelloVTab {
         type InitData = HelloInitData;


### PR DESCRIPTION
With this PR, simple table function extensions no longer need any unsafe code, and so are easier to implement and less likely to crash the process.

This partially solves #414.

I have not yet converted every interface to be safe, but if you like the general approach then I could go on to update everything in `crates/duckdb/src/vtab/function.rs`.

This is an API break for Rust extensions. In my opinion it's worth it because the existing API is easy to misuse and it would be better for callers to use a safe interface. It would not be impossible to preserve the existing unsafe interface, but I think it would leave a fair amount of complexity both in the implementation and in the user-facing API. 

Rather than passing a pointer to a block of uninitialized memory, which can easily lead to UB, the setup functions now just return Rust objects.

The `Free` trait is no longer required, as the Rust type will now just be dropped. If extensions want custom behavior on drop, such as closing a connection, they can do that from `impl Drop`.

It looks like the core DuckDB engine will, in at least some cases, run the table function from multiple threads, so to make that safe I've made the references always shareable. Extensions can use mutexes or atomic types internally as desired.

This builds on and goes further than #415.