### PR TITLE
Fix test  to trigger append error

### DIFF
--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -288,20 +288,23 @@ mod test {
 
     #[test]
     fn test_appender_error() -> Result<(), crate::Error> {
+        use crate::params;
         let conn = Connection::open_in_memory()?;
         conn.execute(
             r"CREATE TABLE foo (
             foobar TEXT,
+            foobar_int INT,
             foobar_split TEXT[] AS (split(trim(foobar), ','))
             );",
             [],
         )?;
         let mut appender = conn.appender("foo")?;
-        match appender.append_row(["foo"]) {
+        match appender.append_row(params!["foo"]) {
             Err(crate::Error::DuckDBFailure(.., Some(msg))) => {
                 assert_eq!(msg, "Call to EndRow before all columns have been appended to!")
             }
-            _ => panic!("expected error"),
+            Err(err) => panic!("unexpected error: {:?}", err),
+            Ok(_) => panic!("expected an error but got Ok"),
         }
         Ok(())
     }


### PR DESCRIPTION
This PR fixes the `test_appender_error` test, which was failing due to changes in DuckDB’s handling of virtual generated columns. DuckDB treats `foobar_split` as a virtual generated column, meaning its value is computed at query time and cannot be inserted into. Previously, the test assumed appending to the `foobar` column alone would trigger an error, but DuckDB allowed the insertion, causing the test to fail. By adding `foobar_int`, the test now correctly validates that appending an incomplete row still fails as expected.