### PR TITLE
fix bindgen issue with WASM builds

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -467,6 +467,7 @@ mod bindings {
             .header(header.clone())
             .allowlist_item(r#"(\w*duckdb\w*)"#)
             .allowlist_type("idx_t")
+            .layout_tests(false) // causes problems on WASM builds
             .clang_arg("-DDUCKDB_EXTENSION_API_VERSION_UNSTABLE")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .generate()


### PR DESCRIPTION
Without this fix, the generated bindgen code causes problems in wasm like:

```
error[E0080]: evaluation of constant value failed
   --> /Users/sam/Development/extension-template-rs/target/wasm32-unknown-emscripten/release/build/libduckdb-sys-9ac58d9f4f249afb/out/bindgen.rs:633:46
    |
633 |     ["Size of _duckdb_extracted_statements"][::std::mem::size_of::<_duckdb_extracted_statements>() - 8usize];
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `4_usize - 8_usize`, which would overflow

error[E0080]: evaluation of constant value failed
   --> /Users/sam/Development/extension-template-rs/target/wasm32-unknown-emscripten/release/build/libduckdb-sys-9ac58d9f4f249afb/out/bindgen.rs:648:40
    |
648 |     ["Size of _duckdb_pending_result"][::std::mem::size_of::<_duckdb_pending_result>() - 8usize];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `4_usize - 8_usize`, which would overflow
```