### PR TITLE
Bundle core_functions extension by default

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -125,6 +125,8 @@ mod build_bundled {
 
         let mut cfg = cc::Build::new();
 
+        add_extension(&mut cfg, &manifest, "core_functions", &mut cpp_files, &mut include_dirs);
+
         #[cfg(feature = "parquet")]
         add_extension(&mut cfg, &manifest, "parquet", &mut cpp_files, &mut include_dirs);
 

--- a/crates/libduckdb-sys/update_sources.py
+++ b/crates/libduckdb-sys/update_sources.py
@@ -16,7 +16,7 @@ SRC_DIR = os.path.join(SCRIPT_DIR, "src")
 
 # List of extensions' sources to grab. Technically, these sources will be compiled
 # but not included in the final build unless they're explicitly enabled.
-EXTENSIONS = ["parquet", "json"]
+EXTENSIONS = ["core_functions", "parquet", "json"]
 
 # Clear the duckdb directory
 try:


### PR DESCRIPTION
The `core_functions` extension is currently not included when using the "bundled" feature.

Since it's an essential part of DuckDB and loaded on every build, this PR adds the `core_functions` extension by default, similar to how it's done with other client libraries ([duckdb-node](https://github.com/duckdb/duckdb-node), [duckdb-r](https://github.com/duckdb/duckdb-r), [duckdb-swift](https://github.com/duckdb/duckdb-swift), [duckdb-java](https://github.com/duckdb/duckdb-java), etc.)