### PR TITLE
fix: pin duckdb and libduckdb-sys versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ license = "MIT"
 categories = ["database"]
 
 [workspace.dependencies]
-duckdb = { version = "1.2.0", path = "crates/duckdb" }
-libduckdb-sys = { version = "1.2.0", path = "crates/libduckdb-sys" }
+duckdb = { version = "=1.2.0", path = "crates/duckdb" }
+libduckdb-sys = { version = "=1.2.0", path = "crates/libduckdb-sys" }
 duckdb-loadable-macros = { version = "0.1.4", path = "crates/duckdb-loadable-macros" }
 autocfg = "1.0"
 bindgen = { version = "0.71.1", default-features = false }


### PR DESCRIPTION
**Context** :
- Rust considers a package version to be compatible if their leftmost greater-than-zero version is the same. This means 1.2.0 is compatible with 1.1.1. This is not "wrong" and complies well with "semver". However, minor releases of duckdb usually contains breaking changes  (see changelogs at https://r.duckdb.org/news/index.html) and 1.2.0 might break 1.1.1
- Recent changes to libduckdb-sys breaks build process on ubuntu for duckdb-rs https://github.com/duckdb/duckdb-rs/issues/436. Since there was no version lock for libduckdb-sys, there are cases that even when locking duckdb-rs in downstream repos, libduckdb-sys is still upgraded to the newer and mismatched version. 

**Proposed changes**:
- Strictly lock version of libduckdbsys and duckdb by using [Comparision Requirement](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#comparison-requirements). While tilde requirement can be used as well, I am not too sure if that is suitable given that every version bump in this repo usually couples duckdb-rs and libduckdb-sys

**Note**:
- This should be backported to version `1.1.1` as `1.1.2` to safeguard maintainers from accidentally being bumped to 1.2.0