### PR TITLE
Deploy the API doc to GitHub Pages

### DIFF
--- a/.github/workflows/extension-docs.yml
+++ b/.github/workflows/extension-docs.yml
@@ -44,16 +44,13 @@ jobs:
           # cf. https://github.com/actions/deploy-pages/issues/188#issuecomment-1597651901
           rm -f ./target/doc/.lock
 
-          mkdir _docs
-          mv ./target/doc ./_docs/extension-api
-
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './_docs/'
+          path: './target/doc'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/extension-docs.yml
+++ b/.github/workflows/extension-docs.yml
@@ -1,0 +1,60 @@
+name: Document for extension API
+
+on:
+  push:
+    branches: main
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Build API Reference
+        run: cargo doc --no-deps --features loadable-extension
+        env:
+          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+
+      - name: Tweak
+        run: |
+          # As of v1.0.9, upload-pages-artifact action rejects files with incorrect permissions.
+          # In Rust doc's case, .lock is such a file.
+          #
+          # cf. https://github.com/actions/deploy-pages/issues/188#issuecomment-1597651901
+          rm -f ./target/doc/.lock
+
+          mkdir _docs
+          mv ./target/doc ./_docs/extension-api
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './_docs/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/extension-docs.yml
+++ b/.github/workflows/extension-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Build API Reference
-        run: cargo doc --no-deps --features vtab-loadable,loadable-extension
+        run: cargo doc --no-deps --features vscalar,vtab-loadable,loadable-extension
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 

--- a/.github/workflows/extension-docs.yml
+++ b/.github/workflows/extension-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Build API Reference
-        run: cargo doc --no-deps --features vscalar,vtab-loadable,loadable-extension
+        run: cargo doc --no-deps --features vscalar-arrow,vtab-arrow,vtab-loadable,loadable-extension
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 

--- a/.github/workflows/extension-docs.yml
+++ b/.github/workflows/extension-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Build API Reference
-        run: cargo doc --no-deps --features vscalar-arrow,vtab-arrow,vtab-loadable,loadable-extension
+        run: cargo doc --no-deps --features vscalar,vscalar-arrow,vtab-loadable,vtab-arrow,loadable-extension
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 

--- a/.github/workflows/extension-docs.yml
+++ b/.github/workflows/extension-docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Build API Reference
-        run: cargo doc --no-deps --features loadable-extension
+        run: cargo doc --no-deps --features vtab-loadable,loadable-extension
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 


### PR DESCRIPTION
Usual APIs can be found on the documents on docs.rs. However, optional items like `VScalar` and `VTab` are not found, while we need such things to write an extension. Does it make sense to build the doc with the necessary feature flags and deploy it to GitHub Pages?

Example:
https://yutannihilation.github.io/duckdb-rs/?search=VTab