### PR TITLE
Fix Rust 1.85 clippy error

### DIFF
--- a/crates/duckdb/src/r2d2.rs
+++ b/crates/duckdb/src/r2d2.rs
@@ -115,7 +115,7 @@ impl r2d2::ManageConnection for DuckdbConnectionManager {
     }
 
     fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        conn.execute_batch("").map_err(Into::into)
+        conn.execute_batch("")
     }
 
     fn has_broken(&self, _: &mut Self::Connection) -> bool {


### PR DESCRIPTION
Fixes the following error when running clippy under Rust 1.85 (since 2025-02-17)

```rust
cargo clippy --all-targets --workspace --all-features -- -D warnings -A clippy::redundant-closure

error: useless conversion to the same type: `error::Error`
   --> crates/duckdb/src/r2d2.rs:118:31
    |
118 |           conn.execute_batch("").map_err(Into::into)
    |  _______________________________-^^^^^^^^^^^^^^^^^^^
119 | |     }
    | |____- help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
note: the lint level is defined here
   --> crates/duckdb/src/r2d2.rs:1:9
    |
1   | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(clippy::useless_conversion)]` implied by `#[deny(warnings)]`

error: could not compile `duckdb` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `duckdb` (lib test) due to 1 previous error
```