### PR TITLE
duckdb/Cargo.toml: teach docs.rs about vtab

### DIFF
--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -85,7 +85,7 @@ pretty_assertions = { workspace = true }
 
 
 [package.metadata.docs.rs]
-features = []
+features = ["vtab", "vtab-arrow"]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
This adds back changes from #295 that were accidentally removed by #285 due to merge skew. It also adds the arrow support because that's a public API.

Fixes #444

Context: https://discord.com/channels/909674491309850675/922563050173792297/1339645035766874175