### PR TITLE
A temporary fix for compile error with chrono v0.4.40

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = "1.3"
 calamine = "0.22.0"
 cast = "0.3"
 cc = "1.0"
-chrono = "0.4.22"
+chrono = "=0.4.39" # TODO: Fix this when new version of arrow-rs is released
 csv = "1.1"
 doc-comment = "0.3"
 fallible-iterator = "0.3"


### PR DESCRIPTION
Due to an unfortunate collision, arrow-rs currently doesn't compile without pinning the version of chrono to before v0.4.40. It's already fixed in the dev version of arrow-rs, but it takes some time to be released on crates.io. So, this pull request adds a temporary fix by specifying the version. After the new version of arrow-rs is released, this tweak can be removed (but probably the versions should be bumped to the latest to make sure the appropriate versions are chosen).

c.f. https://github.com/apache/arrow-rs/issues/7196