### PR TITLE
Fix #380, bug in code that reads Enums 

### DIFF
--- a/crates/duckdb/src/test_all_types.rs
+++ b/crates/duckdb/src/test_all_types.rs
@@ -651,7 +651,7 @@ fn test_single(idx: &mut i32, column: String, value: ValueRef) {
         },
         "medium_enum" => match idx {
             0 => assert_eq!(value.to_owned(), Value::Enum("enum_0".to_string())),
-            1 => assert_eq!(value.to_owned(), Value::Enum("enum_1".to_string())),
+            1 => assert_eq!(value.to_owned(), Value::Enum("enum_299".to_string())),
             _ => assert_eq!(value, ValueRef::Null),
         },
         "large_enum" => match idx {


### PR DESCRIPTION
In turning a `ValueRef::Enum` to a `Value`, the code was inappropriately indexing with the row index directly into the dictionary's string array, so iterating any query's results was effectively just listing the Enum variants in order until row index > number of variants and it panicked. Fix by getting the row/col value (the dictionary key) and using that to index into the dictionary's string array.

You can see it in all three branches of the match statement at [value_ref.rs#L245](https://github.com/duckdb/duckdb-rs/blob/1096461ea9d6a9632e5cb079860ea47b2de0257b/crates/duckdb/src/types/value_ref.rs#L245). These call [DictionaryArray.values()](https://github.com/apache/arrow-rs/blob/3674073bba31e082b337cee63726cfeb186a3a0c/arrow-array/src/array/dictionary_array.rs#L366), whose docstring says clearly that it returns the dictionary values.

Note that this code was covered by a test, but the expected value was hardcoded incorrectly to make the previous implementation pass. Proof that the old expected value was incorrect and the new one is correct:
```sql
D SELECT medium_enum FROM test_all_types();
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                 medium_enum                                                                  │
│ enum('enum_0', 'enum_1', 'enum_2', 'enum_3', 'enum_4', 'enum_5', 'enum_6', 'enum_7', 'enum_8', 'enum_9', 'enum_10', 'enum_11', 'enum_12', …  │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ enum_0                                                                                                                                       │
│ enum_299                                                                                                                                     │
│ NULL                                                                                                                                         │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```