### PR TITLE
Do not pass both stdlib flags.

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           rust-version: stable${{ matrix.host }}
           targets: ${{ matrix.target }}
-          components: 'rustfmt, clippy'
+          components: 'rustfmt,clippy'
 
       # download libduckdb
       - uses: robinraju/release-downloader@v1.4

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -152,8 +152,6 @@ mod build_bundled {
 
         cfg.cpp(true)
             .flag_if_supported("-std=c++11")
-            .flag_if_supported("-stdlib=libc++")
-            .flag_if_supported("-stdlib=libstdc++")
             .flag_if_supported("/bigobj")
             .warnings(false)
             .flag_if_supported("-w");


### PR DESCRIPTION
We use [sccache](https://github.com/mozilla/sccache) in our CI and we encountered errors where the C++ stdlib includes were not found.

<details>
<summary>Error sample</summary>

```
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/case_insensitive_map.hpp:11:
  cargo:warning=/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/unordered_map.hpp:11:10: fatal error: 'unordered_map' file not found
  cargo:warning=   11 | #include <unordered_map>
  cargo:warning=      |          ^~~~~~~~~~~~~~~
  cargo:warning=1 error generated.

  exit status: 1
  cargo:warning=ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET "sccache" "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-darwin" "-mmacosx-version-min=15.2" "-I" "duckdb" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/common" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/dec" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/hyperloglog" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/enc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/yyjson/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/lz4" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fast_float" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/zstd/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/re2" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fmt/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fsst" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fastpforlib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/httplib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/miniz" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/parquet" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/skiplist" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/library" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/json/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/snappy" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/thrift" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/parquet/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler/details" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/concurrentqueue" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/tdigest" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/pcg" "-std=c++11" "-stdlib=libc++" "-stdlib=libstdc++" "-w" "-DDUCKDB_EXTENSION_JSON_LINKED=1" "-DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=1" "-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1" "-o" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/867fff77d999175c-ub_src_function_scalar.o" "-c" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/ub_src_function_scalar.cpp" with args "c++" did not execute successfully (status code exit status: 1).running: env -u IPHONEOS_DEPLOYMENT_TARGET "sccache" "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-darwin" "-mmacosx-version-min=15.2" "-I" "duckdb" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/common" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/dec" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/hyperloglog" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/enc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/yyjson/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/lz4" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fast_float" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/zstd/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/re2" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fmt/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fsst" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fastpforlib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/httplib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/miniz" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/parquet" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/skiplist" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/library" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/json/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/snappy" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/thrift" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/parquet/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler/details" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/concurrentqueue" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/tdigest" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/pcg" "-std=c++11" "-stdlib=libc++" "-stdlib=libstdc++" "-w" "-DDUCKDB_EXTENSION_JSON_LINKED=1" "-DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=1" "-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1" "-o" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/867fff77d999175c-ub_src_main.o" "-c" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/ub_src_main.cpp"
  running: env -u IPHONEOS_DEPLOYMENT_TARGET "sccache" "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-darwin" "-mmacosx-version-min=15.2" "-I" "duckdb" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/common" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/dec" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/hyperloglog" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/enc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/yyjson/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/lz4" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fast_float" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/zstd/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/re2" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fmt/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fsst" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fastpforlib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/httplib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/miniz" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/parquet" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/skiplist" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/library" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/json/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/snappy" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/thrift" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/parquet/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler/details" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/concurrentqueue" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/tdigest" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/pcg" "-std=c++11" "-stdlib=libc++" "-stdlib=libstdc++" "-w" "-DDUCKDB_EXTENSION_JSON_LINKED=1" "-DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=1" "-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1" "-o" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/867fff77d999175c-ub_src_common_exception.o" "-c" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/ub_src_common_exception.cpp"
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/ub_src_common_exception.cpp:1:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/common/exception/binder_exception.cpp:1:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/exception/binder_exception.hpp:11:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/exception.hpp:12:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/exception_format_value.hpp:11:
  cargo:warning=/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/string.hpp:11:10: fatal error: 'sstream' file not found
  cargo:warning=   11 | #include <sstream>
  cargo:warning=      |          ^~~~~~~~~
  cargo:warning=1 error generated.

  exit status: 0
  exit status: 1
  cargo:warning=ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET "sccache" "c++" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-darwin" "-mmacosx-version-min=15.2" "-I" "duckdb" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/common" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/dec" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/hyperloglog" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/enc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/yyjson/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/brotli/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/lz4" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fast_float" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/zstd/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/re2" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fmt/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fsst" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/fastpforlib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/httplib" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/miniz" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/parquet" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/skiplist" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/library" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/json/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/snappy" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/thrift" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/extension/parquet/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/mbedtls" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/utf8proc" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/jaro_winkler/details" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/libpg_query/include" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/concurrentqueue" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/tdigest" "-I" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/third_party/pcg" "-std=c++11" "-stdlib=libc++" "-stdlib=libstdc++" "-w" "-DDUCKDB_EXTENSION_JSON_LINKED=1" "-DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=1" "-DDUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1" "-o" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/867fff77d999175c-ub_src_common_exception.o" "-c" "/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/ub_src_common_exception.cpp" with args "c++" did not execute successfully (status code exit status: 1).cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/ub_src_main.cpp:1:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/main/appender.cpp:1:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/main/appender.hpp:11:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/types/data_chunk.hpp:11:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/allocator.hpp:12:
  cargo:warning=In file included from /Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/helper.hpp:11:
  cargo:warning=/Users/distiller/project/mixer/target/aarch64-apple-darwin/release/build/libduckdb-sys-eb69c526d57bcd77/out/duckdb/src/include/duckdb/common/constants.hpp:11:10: fatal error: 'memory' file not found
  cargo:warning=   11 | #include <memory>
  cargo:warning=      |          ^~~~~~~~
  cargo:warning=1 error generated.

  exit status: 1
```

</details>

Digging deeper, it turns out that both `libc++` and `libstdc++` were being passed to the compiler: `"-std=c++11" "-stdlib=libc++" "-stdlib=libstdc++"`.

According to [`cc`s docs](https://docs.rs/cc/latest/src/cc/lib.rs.html#746-750), just setting `.cpp(true)` automatically passes the expected `-stdlib` flags to the compiler.

This PR removes the two, seemingly redundant, flags. With this, we are able to use `sccache` again.