### PR TITLE
Add unit test for table function and remote parquet source

### DIFF
--- a/crates/duckdb/src/extension.rs
+++ b/crates/duckdb/src/extension.rs
@@ -31,4 +31,18 @@ mod test {
         );
         Ok(())
     }
+
+    #[test]
+    fn test_extension_remote_parquet() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        assert_eq!(
+            9i64,
+            db.query_row::<i64, _, _>(
+                r#"SELECT count(*) FROM read_parquet('https://duckdb.org/data/prices.parquet');"#,
+                [],
+                |r| r.get(0)
+            )?
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
Add unit test to cover 
  - https://github.com/duckdb/duckdb-rs/issues/467

**cargo test --features "extensions-full" --tests test_extension_remote_parquet**

```
⚡ cargo test --features "extensions-full" --tests test_extension_remote_parquet
   Compiling duckdb v1.2.1 .../duckdb-rs/crates/duckdb)
warning: unused import: `c_char`
   --> crates/duckdb/src/vtab/mod.rs:176:15
    |
176 |         ffi::{c_char, CString},
    |               ^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: `duckdb` (lib test) generated 1 warning (run `cargo fix --lib -p duckdb --tests` to apply 1 suggestion)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.66s
     Running unittests src/lib.rs (target/debug/deps/duckdb-568781b06bad4d97)

running 1 test
error: test failed, to rerun pass `-p duckdb --lib`

Caused by:
  process didn't exit successfully: `.../duckdb-rs/target/debug/deps/duckdb-568781b06bad4d97 test_extension_remote_parquet` (signal: 11, SIGSEGV: invalid memory reference)
```