### PR TITLE
Use the crate name if ext_name is not specified

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -45,9 +45,10 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
         None => env::var("DUCKDB_EXTENSION_MIN_DUCKDB_VERSION").expect("Please either set env var DUCKDB_EXTENSION_MIN_DUCKDB_VERSION or pass it as an argument to the proc macro").to_string()
     };
 
-    let extension_name = match args.ext_name {
-        Some(i) => i,
-        None => env::var("DUCKDB_EXTENSION_NAME").expect("Please either set env var DUCKDB_EXTENSION_MIN_DUCKDB_VERSION or pass it as an argument to the proc macro").to_string()
+    let extension_name = match (args.ext_name, env::var("DUCKDB_EXTENSION_NAME")) {
+        (Some(i), _) => i,
+        (None, Ok(i)) => i.to_string(),
+        _ => env::var("CARGO_PKG_NAME").unwrap().to_string(),
     };
 
     let ast = parse_macro_input!(item as syn::Item);


### PR DESCRIPTION
This is part of an attempt to fix https://github.com/duckdb/extension-template-rs/issues/15.

Currently, `#[duckdb_entrypoint_c_api()]` assumes these envvars are provided by `duckdb/extension-ci-tools`. However, this is inconvenient to develop it locally. So, this pull request puts a reasonable default value; I think it's reasonable to assume the extension name is the same as the crate name.