### PR TITLE
Set the default min version when min_duckdb_version is not specified

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -10,6 +10,8 @@ use darling::{ast::NestedMeta, Error, FromMeta};
 
 use std::env;
 
+const DEFAULT_DUCKDB_VERSION: &str = "v1.2.0";
+
 /// For parsing the arguments to the duckdb_entrypoint_c_api macro
 #[derive(Debug, FromMeta)]
 struct CEntryPointMacroArgs {
@@ -40,9 +42,10 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
     };
 
     // Set the minimum duckdb version (dev by default)
-    let minimum_duckdb_version = match args.min_duckdb_version {
-        Some(i) => i,
-        None => env::var("DUCKDB_EXTENSION_MIN_DUCKDB_VERSION").expect("Please either set env var DUCKDB_EXTENSION_MIN_DUCKDB_VERSION or pass it as an argument to the proc macro").to_string()
+    let minimum_duckdb_version = match (args.min_duckdb_version, env::var("DUCKDB_EXTENSION_MIN_DUCKDB_VERSION")) {
+        (Some(i), _) => i,
+        (None, Ok(i)) => i.to_string(),
+        _ => DEFAULT_DUCKDB_VERSION.to_string(),
     };
 
     let extension_name = match args.ext_name {


### PR DESCRIPTION
This is another part of an attempt to fix https://github.com/duckdb/extension-template-rs/issues/15.

The idea is the same; set a reasonable default value if no envvar is specified in order to avoid rust-analyzer crash. However, I don't come up with what value is the "reasonable default value." Probably, it can be the same as the version of libduckdb-sys, but I couldn't find nice way to acquire the value programmatically.

I also believe the value provided by extension-ci-tools, "v0.0.1", is not quite right for Rust case. As it uses the C extension API, which was officially introduced in DuckDB v1.2.0, maybe this should be "v1.2.0" unless the C extension API introduces some breaking change...?

https://github.com/duckdb/extension-ci-tools/blob/00e6af068429bf776a54f67cb1cd1ff5370a8dd7/makefiles/c_api_extensions/base.Makefile#L39-L42