### PR TITLE
fix: libduckdb-sys build fails on Windows

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -152,6 +152,7 @@ mod build_bundled {
 
         cfg.cpp(true)
             .flag_if_supported("-std=c++11")
+            .flag_if_supported("/utf-8")
             .flag_if_supported("/bigobj")
             .warnings(false)
             .flag_if_supported("-w");


### PR DESCRIPTION
Fix libduckdb-sys build failure on Windows related to #268 (possibly also related to #482 and #413).

Added a line to libduckdb-sys/build.rs to specify the encoding when compiling C code.