### PR TITLE
upgrade arrow-rs to 55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
     "crates/duckdb",
     "crates/libduckdb-sys",
-    "crates/duckdb-loadable-macros"
+    "crates/duckdb-loadable-macros",
 ]
 
 [workspace.package]
@@ -36,7 +36,6 @@ fallible-streaming-iterator = "0.1"
 flate2 = "1.0"
 hashlink = "0.9"
 lazy_static = "1.4"
-memchr = "2.3"
 num = { version = "0.4", default-features = false }
 num-integer = "0.1.46"
 pkg-config = "0.3.24"
@@ -63,4 +62,4 @@ unicase = "2.6.0"
 url = "2.1"
 uuid = "1.0"
 vcpkg = "0.2"
-arrow = { version = "54.2.1", default-features = false }
+arrow = { version = "55", default-features = false }

--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -143,7 +143,7 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 ///
                 /// Will be called by duckdb
                 #[no_mangle]
-                pub unsafe extern "C" fn #c_entrypoint(db: *mut c_void) {
+                pub unsafe extern "C" fn #c_entrypoint(db: *mut std::ffi::c_void) {
                     unsafe {
                         let connection = Connection::open_from_raw(db.cast()).expect("can't open db connection");
                         #prefixed_original_function(connection).expect("init failed");
@@ -154,7 +154,7 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 ///
                 /// Predefined function, don't need to change unless you are sure
                 #[no_mangle]
-                pub unsafe extern "C" fn #c_entrypoint_version() -> *const c_char {
+                pub unsafe extern "C" fn #c_entrypoint_version() -> *const std::ffi::c_char {
                     unsafe {
                         ffi::duckdb_library_version()
                     }

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -51,7 +51,6 @@ lazy_static = { workspace = true, optional = true }
 byteorder = { workspace = true, features = ["i128"], optional = true }
 fallible-iterator = { workspace = true }
 fallible-streaming-iterator = { workspace = true }
-memchr = { workspace = true }
 uuid = { workspace = true, optional = true }
 smallvec = { workspace = true }
 cast = { workspace = true, features = ["std"] }
@@ -82,7 +81,6 @@ pretty_assertions = { workspace = true }
 # [[bench]]
 # name = "data_types"
 # harness = false
-
 
 [package.metadata.docs.rs]
 features = ["vtab", "vtab-arrow"]

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -13,7 +13,7 @@ use duckdb_loadable_macros::duckdb_entrypoint;
 use libduckdb_sys as ffi;
 use std::{
     error::Error,
-    ffi::{c_char, c_void, CString},
+    ffi::CString,
     sync::atomic::{AtomicBool, Ordering},
 };
 

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -169,11 +169,10 @@ impl InnerConnection {
 mod test {
     use super::*;
     use crate::core::{Inserter, LogicalTypeId};
-    use std::sync::atomic::AtomicBool;
-    use std::sync::atomic::Ordering;
     use std::{
         error::Error,
-        ffi::{c_char, CString},
+        ffi::CString,
+        sync::atomic::{AtomicBool, Ordering},
     };
 
     struct HelloBindData {


### PR DESCRIPTION
also did a couple of clippy/fmt driven cleanups + removed an unused dependency.
Also fixed a minor issue where `duckdb_entrypoint` macro required external imports, so this seems like a nicer cleanup but I wouldn't mind splitting it into a separate PR.