### PR TITLE
Make DuckString's constructor public

### DIFF
--- a/crates/duckdb/src/types/string.rs
+++ b/crates/duckdb/src/types/string.rs
@@ -6,8 +6,9 @@ pub struct DuckString<'a> {
 }
 
 impl<'a> DuckString<'a> {
+    /// Creates a DuckString from the underlying duck string type
     #[allow(dead_code)]
-    pub(crate) fn new(ptr: &'a mut duckdb_string_t) -> Self {
+    pub fn new(ptr: &'a mut duckdb_string_t) -> Self {
         DuckString { ptr }
     }
 }


### PR DESCRIPTION
When trying to build a scalar function extension in Rust, pulling VARCHARs from the `invoke` function is quite difficult, as there isn't an easy way to convert duck_string_t into a Rust string. @yutannihilation describes it well here https://github.com/duckdb/duckdb-rs/issues/484. 

This PR just removes the `(crate)` in front of the DuckString constructor. 