### PR TITLE
Update `github.com/wangfenjin/duckdb-rs` to `github.com/duckdb/duckdb-rs`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ cd ~/github/duckdb-rs/crates/libduckdb-sys
 cargo test --features bundled
 ```
 
-Currently in [github actions](https://github.com/wangfenjin/duckdb-rs/actions), we always use the bundled file for testing. So if you change the header in duckdb-cpp repo, you need to make the PR merged and updated the [bundled-file](https://github.com/wangfenjin/duckdb-rs/tree/main/crates/libduckdb-sys/duckdb).
+Currently in [github actions](https://github.com/duckdb/duckdb-rs/actions), we always use the bundled file for testing. So if you change the header in duckdb-cpp repo, you need to make the PR merged and updated the [bundled-file](https://github.com/duckdb/duckdb-rs/tree/main/crates/libduckdb-sys/duckdb).
 You can generated the amalgamated file by:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # duckdb-rs
 
 [![Downloads](https://img.shields.io/crates/d/duckdb)](https://img.shields.io/crates/d/duckdb)
-[![Build Status](https://github.com/wangfenjin/duckdb-rs/workflows/CI/badge.svg)](https://github.com/wangfenjin/duckdb-rs/actions)
+[![Build Status](https://github.com/duckdb/duckdb-rs/workflows/CI/badge.svg)](https://github.com/duckdb/duckdb-rs/actions)
 [![dependency status](https://deps.rs/repo/github/wangfenjin/duckdb-rs/status.svg)](https://deps.rs/repo/github/wangfenjin/duckdb-rs)
 [![codecov](https://codecov.io/gh/wangfenjin/duckdb-rs/branch/main/graph/badge.svg?token=0xV88q8KU0)](https://codecov.io/gh/wangfenjin/duckdb-rs)
 [![Latest Version](https://img.shields.io/crates/v/duckdb.svg)](https://crates.io/crates/duckdb)
@@ -15,7 +15,7 @@ forked from rusqlite as duckdb also tries to expose a sqlite3 compatible API.
 use duckdb::{params, Connection, Result};
 
 // In your project, we need to keep the arrow version same as the version used in duckdb.
-// Refer to https://github.com/wangfenjin/duckdb-rs/issues/92
+// Refer to https://github.com/duckdb/duckdb-rs/issues/92
 // You can either:
 use duckdb::arrow::record_batch::RecordBatch;
 // Or in your Cargo.toml, use * as the version; features can be toggled according to your needs
@@ -85,7 +85,7 @@ declarations for DuckDB's C API. By default, `libduckdb-sys` attempts to find a 
 
 You can adjust this behavior in a number of ways:
 
-* If you use the `bundled` feature, `libduckdb-sys` will use the
+- If you use the `bundled` feature, `libduckdb-sys` will use the
   [cc](https://crates.io/crates/cc) crate to compile DuckDB from source and
   link against that. This source is embedded in the `libduckdb-sys` crate and
   as we are still in development, we will update it regularly. After we are more stable,
@@ -97,7 +97,7 @@ You can adjust this behavior in a number of ways:
   ```
 
   `Cargo.toml` will be updated.
-  
+
   ```toml
   [dependencies]
   # Assume that version DuckDB version 0.9.2 is used.
@@ -109,7 +109,6 @@ You can adjust this behavior in a number of ways:
   and [vcpkg](https://github.com/mcgoo/vcpkg-rs) have some additional configuration
   options. The default when using vcpkg is to dynamically link,
   which must be enabled by setting `VCPKGRS_DYNAMIC=1` environment variable before build.
-
 
 ### Binding generation
 

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -220,7 +220,7 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalTypeHandle,
         | DataType::FixedSizeBinary(_) => Ok(LogicalTypeHandle::from(to_duckdb_type_id(data_type)?)),
         dtype if dtype.is_primitive() => Ok(LogicalTypeHandle::from(to_duckdb_type_id(data_type)?)),
         _ => Err(format!(
-            "Unsupported data type: {data_type}, please file an issue https://github.com/wangfenjin/duckdb-rs"
+            "Unsupported data type: {data_type}, please file an issue https://github.com/duckdb/duckdb-rs"
         )
         .into()),
     }
@@ -636,7 +636,7 @@ pub fn write_arrow_array_to_vector(
         }
         dt => {
             return Err(format!(
-                "column with data_type {} is not supported yet, please file an issue https://github.com/wangfenjin/duckdb-rs",
+                "column with data_type {} is not supported yet, please file an issue https://github.com/duckdb/duckdb-rs",
                 dt
             )
             .into());
@@ -1071,7 +1071,7 @@ fn struct_array_to_vector(array: &StructArray, out: &mut StructVector) -> Result
             }
             _ => {
                 unimplemented!(
-                    "Unsupported data type: {}, please file an issue https://github.com/wangfenjin/duckdb-rs",
+                    "Unsupported data type: {}, please file an issue https://github.com/duckdb/duckdb-rs",
                     column.data_type()
                 );
             }


### PR DESCRIPTION
Previously, users were directed to the old repo using this code:

```rs
"Unsupported data type: {}, please file an issue https://github.com/wangfenjin/duckdb-rs",
```