### PR TITLE
Mark no_mangle attribute as unsafe

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -142,7 +142,7 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// # Safety
                 ///
                 /// Will be called by duckdb
-                #[no_mangle]
+                #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn #c_entrypoint(db: *mut c_void) {
                     unsafe {
                         let connection = Connection::open_from_raw(db.cast()).expect("can't open db connection");
@@ -153,7 +153,7 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 /// # Safety
                 ///
                 /// Predefined function, don't need to change unless you are sure
-                #[no_mangle]
+                #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn #c_entrypoint_version() -> *const c_char {
                     unsafe {
                         ffi::duckdb_library_version()


### PR DESCRIPTION
As per https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html