### PR TITLE
chore: Let Inserter accept &String and &Vec<u8>

### DIFF
--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -146,10 +146,7 @@ impl Inserter<&str> for FlatVector {
 
 impl Inserter<&String> for FlatVector {
     fn insert(&self, index: usize, value: &String) {
-        let cstr = CString::new(value.as_bytes()).unwrap();
-        unsafe {
-            duckdb_vector_assign_string_element(self.ptr, index as u64, cstr.as_ptr());
-        }
+        self.insert(index, value.as_str());
     }
 }
 
@@ -170,16 +167,7 @@ impl Inserter<&[u8]> for FlatVector {
 
 impl Inserter<&Vec<u8>> for FlatVector {
     fn insert(&self, index: usize, value: &Vec<u8>) {
-        let value_size = value.len();
-        unsafe {
-            // This function also works for binary data. https://duckdb.org/docs/api/c/api#duckdb_vector_assign_string_element_len
-            duckdb_vector_assign_string_element_len(
-                self.ptr,
-                index as u64,
-                value.as_ptr() as *const ::std::os::raw::c_char,
-                value_size as u64,
-            );
-        }
+        self.insert(index, value.as_slice());
     }
 }
 


### PR DESCRIPTION
Currently, this doesn't work because the trait requires it to be `&str`, not `&String`. Just using `.as_str()` fixes the problem, but it's nice if `insert()` accept it as it is.

```rust
let value: String = some_function();
flat_vector.insert(index, &value);
```

I thought `impl<T: AsRef<str>> Inserter<T> for FlatVector {` works, but it's not allowed by the compiler. So, I added impls for `&String` and `&Vec<u8>` individually.

```
error[E0119]: conflicting implementations of trait `vector::Inserter<CString>` for type `vector::FlatVector`
   --> crates\duckdb\src\core\vector.rs:138:1
    |
130 | impl Inserter<CString> for FlatVector {
    | ------------------------------------- first implementation here
...
138 | impl<T: AsRef<str>> Inserter<T> for FlatVector {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `vector::FlatVector`
    |
    = note: upstream crates may add a new impl of trait `std::convert::AsRef<str>` for type `std::ffi::CString` in future versions

```