### PR TITLE
Ensure we all use the same Rust version during development

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          components: 'rustfmt, clippy'
 
       # cargo publish
       - name: publish crates

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -28,9 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           target: ${{ matrix.target }}
-          components: 'rustfmt, clippy'
 
       # download libduckdb
       - uses: robinraju/release-downloader@v1.4
@@ -112,7 +110,6 @@ jobs:
             index-${{ runner.os }}-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
           target: x86_64-pc-windows-msvc
 
       - run: cargo install cargo-examples

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,7 +1,0 @@
-max_width = 120
-imports_granularity = "Crate"
-reorder_imports = true
-fn_call_width = 72
-# indent_style = "Block"
-# tab_spaces = 2
-# group_imports="StdExternalCrate"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.87"
+components = ["rustfmt", "clippy"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 120
+edition = "2021"


### PR DESCRIPTION
This adds a toolchain file, which is also [automatically used by CI](https://github.com/actions-rust-lang/setup-rust-toolchain?tab=readme-ov-file#inputs).

Additionally, I took the opportunity to clean up rustfmt's settings (no visible changes, `cargo fmt` is a no-op).