### PR TITLE
Fix a bunch of problems reported by Clippy

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.'cfg(all())']
+rustflags = [
+    "-Dclippy::all",
+    "-Dnonstandard-style",
+    "-Drust-2018-idioms",
+]

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -59,8 +59,7 @@ jobs:
           DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
           LD_LIBRARY_PATH: ${{ github.workspace }}/libduckdb
         run: |
-          cargo clippy --all-targets --workspace --all-features -- -D warnings -A clippy::redundant-closure
-    
+          cargo clippy --all-targets --workspace --all-features -- -D warnings
 
       # For windows
       - name: Windows extract duckdb

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DUCKDB_INCLUDE_DIR = /Users/wangfenjin/duckdb
 
 all:
 	cargo test --features buildtime_bindgen --features modern-full -- --nocapture
-	cargo clippy --all-targets --workspace --features buildtime_bindgen --features modern-full -- -D warnings -A clippy::redundant-closure
+	cargo clippy --all-targets --workspace --features buildtime_bindgen --features modern-full -- -D warnings
 
 test:
 	cargo test --features bundled --features modern-full -- --nocapture

--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -58,10 +58,10 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
 
     match ast {
         Item::Fn(func) => {
-            let c_entrypoint = Ident::new(format!("{}_init_c_api", extension_name).as_str(), Span::call_site());
+            let c_entrypoint = Ident::new(format!("{extension_name}_init_c_api").as_str(), Span::call_site());
             let prefixed_original_function = func.sig.ident.clone();
             let c_entrypoint_internal = Ident::new(
-                format!("{}_init_c_api_internal", extension_name).as_str(),
+                format!("{extension_name}_init_c_api_internal").as_str(),
                 Span::call_site(),
             );
 
@@ -132,7 +132,7 @@ pub fn duckdb_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
             );
 
             let original_funcname = func.sig.ident.to_string();
-            func.sig.ident = Ident::new(format!("_{}", original_funcname).as_str(), func.sig.ident.span());
+            func.sig.ident = Ident::new(format!("_{original_funcname}").as_str(), func.sig.ident.span());
 
             let prefixed_original_function = func.sig.ident.clone();
 

--- a/crates/duckdb/examples/appender.rs
+++ b/crates/duckdb/examples/appender.rs
@@ -1,5 +1,3 @@
-extern crate duckdb;
-
 use duckdb::{params, Connection, DropBehavior, Result};
 
 fn main() -> Result<()> {

--- a/crates/duckdb/examples/basic.rs
+++ b/crates/duckdb/examples/basic.rs
@@ -1,7 +1,5 @@
 // Basic example copy from README
 
-extern crate duckdb;
-
 use duckdb::{
     arrow::{record_batch::RecordBatch, util::pretty::print_batches},
     params, Connection, Result,

--- a/crates/duckdb/examples/hello-ext-capi/main.rs
+++ b/crates/duckdb/examples/hello-ext-capi/main.rs
@@ -1,7 +1,3 @@
-extern crate duckdb;
-extern crate duckdb_loadable_macros;
-extern crate libduckdb_sys;
-
 use duckdb::{
     core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId},
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},

--- a/crates/duckdb/examples/hello-ext/main.rs
+++ b/crates/duckdb/examples/hello-ext/main.rs
@@ -1,9 +1,5 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
-extern crate duckdb;
-extern crate duckdb_loadable_macros;
-extern crate libduckdb_sys;
-
 use duckdb::{
     core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId},
     vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab},

--- a/crates/duckdb/examples/parquet.rs
+++ b/crates/duckdb/examples/parquet.rs
@@ -1,4 +1,3 @@
-extern crate duckdb;
 use duckdb::{
     arrow::{record_batch::RecordBatch, util::pretty::print_batches},
     Connection, Result,

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -303,7 +303,7 @@ mod test {
             Err(crate::Error::DuckDBFailure(.., Some(msg))) => {
                 assert_eq!(msg, "Call to EndRow before all columns have been appended to!")
             }
-            Err(err) => panic!("unexpected error: {:?}", err),
+            Err(err) => panic!("unexpected error: {err:?}"),
             Ok(_) => panic!("expected an error but got Ok"),
         }
         Ok(())

--- a/crates/duckdb/src/column.rs
+++ b/crates/duckdb/src/column.rs
@@ -144,7 +144,7 @@ impl Statement<'_> {
     /// sure that current statement has already been stepped once before
     /// calling this method.
     #[cfg(feature = "column_decltype")]
-    pub fn columns(&self) -> Vec<Column> {
+    pub fn columns(&self) -> Vec<Column<'_>> {
         let n = self.column_count();
         let mut cols = Vec::with_capacity(n);
         for i in 0..n {

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -207,7 +207,7 @@ pub enum DatabaseName<'a> {
 
 #[allow(clippy::needless_lifetimes)]
 impl<'a> fmt::Display for DatabaseName<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DatabaseName::Main => write!(f, "main"),
             DatabaseName::Temp => write!(f, "temp"),

--- a/crates/duckdb/src/r2d2.rs
+++ b/crates/duckdb/src/r2d2.rs
@@ -125,7 +125,6 @@ impl r2d2::ManageConnection for DuckdbConnectionManager {
 
 #[cfg(test)]
 mod test {
-    extern crate r2d2;
     use super::*;
     use crate::types::Value;
     use std::{sync::mpsc, thread};

--- a/crates/duckdb/src/r2d2.rs
+++ b/crates/duckdb/src/r2d2.rs
@@ -8,37 +8,31 @@
 //! ## Example
 //!
 //! ```rust,no_run
-//! extern crate r2d2;
-//! extern crate duckdb;
-//!
-//!
 //! use std::thread;
 //! use duckdb::{DuckdbConnectionManager, params};
+//! use r2d2;
 //!
+//! let manager = DuckdbConnectionManager::file("file.db").unwrap();
+//! let pool = r2d2::Pool::new(manager).unwrap();
+//! pool.get()
+//!     .unwrap()
+//!     .execute("CREATE TABLE IF NOT EXISTS foo (bar INTEGER)", params![])
+//!     .unwrap();
 //!
-//! fn main() {
-//!     let manager = DuckdbConnectionManager::file("file.db").unwrap();
-//!     let pool = r2d2::Pool::new(manager).unwrap();
-//!     pool.get()
-//!         .unwrap()
-//!         .execute("CREATE TABLE IF NOT EXISTS foo (bar INTEGER)", params![])
-//!         .unwrap();
-//!
-//!     (0..10)
-//!         .map(|i| {
-//!             let pool = pool.clone();
-//!             thread::spawn(move || {
-//!                 let conn = pool.get().unwrap();
-//!                 conn.execute("INSERT INTO foo (bar) VALUES (?)", &[&i])
-//!                     .unwrap();
-//!             })
+//! (0..10)
+//!     .map(|i| {
+//!         let pool = pool.clone();
+//!         thread::spawn(move || {
+//!             let conn = pool.get().unwrap();
+//!             conn.execute("INSERT INTO foo (bar) VALUES (?)", &[&i])
+//!                 .unwrap();
 //!         })
-//!         .collect::<Vec<_>>()
-//!         .into_iter()
-//!         .map(thread::JoinHandle::join)
-//!         .collect::<Result<_, _>>()
-//!         .unwrap()
-//! }
+//!     })
+//!     .collect::<Vec<_>>()
+//!     .into_iter()
+//!     .map(thread::JoinHandle::join)
+//!     .collect::<Result<_, _>>()
+//!     .unwrap()
 //! ```
 use crate::{Config, Connection, Error, Result};
 use std::{

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -183,7 +183,7 @@ impl RawStatement {
                 // Therefore, we return None when encountering this error.
                 match err {
                     polars::error::PolarsError::ComputeError(_) => return None,
-                    _ => panic!("Failed to import arrow2 Array from C: {}", err),
+                    _ => panic!("Failed to import arrow2 Array from C: {err}"),
                 }
             }
 

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -343,7 +343,7 @@ impl<'stmt> Row<'stmt> {
         Self::value_ref_internal(row, col, column)
     }
 
-    pub(crate) fn value_ref_internal(row: usize, col: usize, column: &ArrayRef) -> ValueRef {
+    pub(crate) fn value_ref_internal(row: usize, col: usize, column: &ArrayRef) -> ValueRef<'_> {
         if column.is_null(row) {
             return ValueRef::Null;
         }

--- a/crates/duckdb/src/test_all_types.rs
+++ b/crates/duckdb/src/test_all_types.rs
@@ -30,7 +30,7 @@ fn test_with_database(database: &Connection) -> crate::Result<()> {
         "SELECT * EXCLUDE ({}) FROM test_all_types()",
         excluded
             .iter()
-            .map(|s| format!("'{}'", s))
+            .map(|s| format!("'{s}'"))
             .collect::<Vec<String>>()
             .join(",")
     ))?;

--- a/crates/duckdb/src/test_all_types.rs
+++ b/crates/duckdb/src/test_all_types.rs
@@ -51,7 +51,7 @@ fn test_with_database(database: &Connection) -> crate::Result<()> {
     Ok(())
 }
 
-fn test_single(idx: &mut i32, column: String, value: ValueRef) {
+fn test_single(idx: &mut i32, column: String, value: ValueRef<'_>) {
     match column.as_str() {
         "bool" => match idx {
             0 => assert_eq!(value, ValueRef::Boolean(false)),

--- a/crates/duckdb/src/types/from_sql.rs
+++ b/crates/duckdb/src/types/from_sql.rs
@@ -1,7 +1,8 @@
-extern crate cast;
+use std::{error::Error, fmt};
+
+use cast;
 
 use super::{TimeUnit, Value, ValueRef};
-use std::{error::Error, fmt};
 
 /// Enum listing possible errors from [`FromSql`] trait.
 #[derive(Debug)]

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -232,10 +232,10 @@ mod test {
     fn test_cow_str() {
         use std::borrow::Cow;
         let s = "str";
-        let cow: Cow<str> = Cow::Borrowed(s);
+        let cow: Cow<'_, str> = Cow::Borrowed(s);
         let r = cow.to_sql();
         assert!(r.is_ok());
-        let cow: Cow<str> = Cow::Owned::<str>(String::from(s));
+        let cow: Cow<'_, str> = Cow::Owned(String::from(s));
         let r = cow.to_sql();
         assert!(r.is_ok());
         // Ensure this compiles.

--- a/crates/duckdb/src/vscalar/mod.rs
+++ b/crates/duckdb/src/vscalar/mod.rs
@@ -182,7 +182,7 @@ mod test {
         ) -> Result<(), Box<dyn std::error::Error>> {
             let mut msg = input.flat_vector(0).as_slice_with_len::<duckdb_string_t>(input.len())[0];
             let string = DuckString::new(&mut msg).as_str();
-            Err(format!("Error: {}", string).into())
+            Err(format!("Error: {string}").into())
         }
 
         fn signatures() -> Vec<ScalarFunctionSignature> {

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -161,7 +161,7 @@ pub fn to_duckdb_type_id(data_type: &DataType) -> Result<LogicalTypeId, Box<dyn 
         DataType::Decimal256(_, _) => Double,
         DataType::Map(_, _) => Map,
         _ => {
-            return Err(format!("Unsupported data type: {:?}", data_type).into());
+            return Err(format!("Unsupported data type: {data_type:?}").into());
         }
     };
     Ok(type_id)
@@ -636,8 +636,7 @@ pub fn write_arrow_array_to_vector(
         }
         dt => {
             return Err(format!(
-                "column with data_type {} is not supported yet, please file an issue https://github.com/duckdb/duckdb-rs",
-                dt
+                "column with data_type {dt} is not supported yet, please file an issue https://github.com/duckdb/duckdb-rs"
             )
             .into());
         }
@@ -858,7 +857,7 @@ fn decimal_array_to_vector(array: &Decimal128Array, out: &mut FlatVector, width:
             }
         }
         // This should never happen, arrow only supports 1-38 decimal digits
-        _ => panic!("Invalid decimal width: {}", width),
+        _ => panic!("Invalid decimal width: {width}"),
     }
 
     // Set nulls
@@ -1995,7 +1994,7 @@ mod test {
         check_map_array_roundtrip(map_array)?;
 
         // Test 2 - large MapArray of 4000 elements to test buffers capacity adjustment
-        let keys: Vec<String> = (0..4000).map(|i| format!("key-{}", i)).collect();
+        let keys: Vec<String> = (0..4000).map(|i| format!("key-{i}")).collect();
         let values_data = UInt32Array::from(
             (0..4000)
                 .map(|i| if i % 5 == 0 { None } else { Some(i as u32) })

--- a/crates/duckdb/src/vtab/excel.rs
+++ b/crates/duckdb/src/vtab/excel.rs
@@ -35,7 +35,7 @@ impl VTab for ExcelVTab {
         let mut workbook = open_workbook_auto(path)?;
         let range = workbook
             .worksheet_range(&sheet)
-            .unwrap_or_else(|| panic!("Can't find sheet: {} ?", sheet))?;
+            .unwrap_or_else(|| panic!("Can't find sheet: {sheet} ?"))?;
         let _column_count = range.get_size().1;
         let mut rows = range.rows();
         let header = rows.next().unwrap();
@@ -62,7 +62,7 @@ impl VTab for ExcelVTab {
                         bind.add_result_column(
                             header[idx]
                                 .get_string()
-                                .unwrap_or_else(|| panic!("idx {} header empty?", idx)),
+                                .unwrap_or_else(|| panic!("idx {idx} header empty?")),
                             LogicalTypeHandle::from(LogicalTypeId::Varchar),
                         );
                     }
@@ -70,7 +70,7 @@ impl VTab for ExcelVTab {
                         bind.add_result_column(
                             header[idx]
                                 .get_string()
-                                .unwrap_or_else(|| panic!("idx {} header empty?", idx)),
+                                .unwrap_or_else(|| panic!("idx {idx} header empty?")),
                             LogicalTypeHandle::from(LogicalTypeId::Double),
                         );
                     }
@@ -78,7 +78,7 @@ impl VTab for ExcelVTab {
                         bind.add_result_column(
                             header[idx]
                                 .get_string()
-                                .unwrap_or_else(|| panic!("idx {} header empty?", idx)),
+                                .unwrap_or_else(|| panic!("idx {idx} header empty?")),
                             LogicalTypeHandle::from(LogicalTypeId::Bigint),
                         );
                     }
@@ -86,7 +86,7 @@ impl VTab for ExcelVTab {
                         bind.add_result_column(
                             header[idx]
                                 .get_string()
-                                .unwrap_or_else(|| panic!("idx {} header empty?", idx)),
+                                .unwrap_or_else(|| panic!("idx {idx} header empty?")),
                             LogicalTypeHandle::from(LogicalTypeId::Boolean),
                         );
                     }
@@ -94,7 +94,7 @@ impl VTab for ExcelVTab {
                         bind.add_result_column(
                             header[idx]
                                 .get_string()
-                                .unwrap_or_else(|| panic!("idx {} header empty?", idx)),
+                                .unwrap_or_else(|| panic!("idx {idx} header empty?")),
                             LogicalTypeHandle::from(LogicalTypeId::Date),
                         );
                     }

--- a/crates/duckdb/src/vtab/function.rs
+++ b/crates/duckdb/src/vtab/function.rs
@@ -74,7 +74,7 @@ impl BindInfo {
         unsafe {
             let ptr = duckdb_bind_get_parameter(self.ptr, param_index);
             if ptr.is_null() {
-                panic!("{} is out of range for function definition", param_index);
+                panic!("{param_index} is out of range for function definition");
             } else {
                 Value::from(ptr)
             }

--- a/crates/duckdb/src/vtab/value.rs
+++ b/crates/duckdb/src/vtab/value.rs
@@ -33,7 +33,7 @@ impl Value {
 }
 
 impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let c_string = unsafe { CString::from_raw(duckdb_get_varchar(self.ptr)) };
         write!(f, "{}", c_string.to_str().unwrap())
     }


### PR DESCRIPTION
I noticed the following warning in CI, which is only reported by Rust nightly:

```
[Address Sanitizer: crates/duckdb/src/row.rs#L346](https://github.com/duckdb/duckdb-rs/pull/516/files#annotation_35818535305)
lifetime flowing from input to output with different syntax can be confusing
```

One thing led to another, and I fixed a bunch of clippy warnings as a result. 😎

`cargo build` and `cargo clippy` now work fine using both Rust stable and nightly.
