### PR TITLE
Fix Parquet example to run from workspace root

### DIFF
--- a/crates/duckdb/examples/parquet.rs
+++ b/crates/duckdb/examples/parquet.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use duckdb::{
     arrow::{record_batch::RecordBatch, util::pretty::print_batches},
     Connection, Result,
@@ -5,11 +7,17 @@ use duckdb::{
 
 fn main() -> Result<()> {
     let db = Connection::open_in_memory()?;
+
     db.execute_batch("INSTALL parquet; LOAD parquet;")?;
+
+    let parquet_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/int32_decimal.parquet");
+
     let rbs: Vec<RecordBatch> = db
-        .prepare("SELECT * FROM read_parquet('./examples/int32_decimal.parquet');")?
-        .query_arrow([])?
+        .prepare("SELECT * FROM read_parquet(?)")?
+        .query_arrow([parquet_path.to_string_lossy()])?
         .collect();
+
     assert!(print_batches(&rbs).is_ok());
+
     Ok(())
 }


### PR DESCRIPTION
With the change, all examples can be executed from `crates/duckdb` _and_  from the repo root.

```
cargo run --example basic --features bundled
cargo run --example appender --features bundled
cargo run --example parquet --features bundled
```
