### PR TITLE
Update Rust to v1.88.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87"
+channel = "1.88"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/