### PR TITLE
Publish docs for more features

### DIFF
--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -69,7 +69,7 @@ tempfile = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [package.metadata.docs.rs]
-features = ["vtab", "vtab-arrow"]
+features = ["vtab-full", "modern-full", "vscalar", "vscalar-arrow"]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
This fixes the fact that https://docs.rs/duckdb/latest/duckdb/ doesn't include documentation for `register_scalar_function`, among other things.

(Normally, we could simply set `all-features = true`, but that might not work well with `bundled`)