### PR TITLE
Fix memory leak in Value Display implementation

### DIFF
--- a/crates/duckdb/src/vtab/value.rs
+++ b/crates/duckdb/src/vtab/value.rs
@@ -1,5 +1,5 @@
-use crate::ffi::{duckdb_destroy_value, duckdb_get_int64, duckdb_get_varchar, duckdb_value};
-use std::{ffi::CString, fmt};
+use crate::ffi::{duckdb_destroy_value, duckdb_free, duckdb_get_int64, duckdb_get_varchar, duckdb_value};
+use std::{ffi::CStr, fmt, os::raw::c_void};
 
 /// The Value object holds a single arbitrary value of any type that can be
 /// stored in the database.
@@ -34,7 +34,27 @@ impl Value {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let c_string = unsafe { CString::from_raw(duckdb_get_varchar(self.ptr)) };
-        write!(f, "{}", c_string.to_str().unwrap())
+        unsafe {
+            let varchar = duckdb_get_varchar(self.ptr);
+            let c_str = CStr::from_ptr(varchar);
+            let res = write!(f, "{}", c_str.to_string_lossy());
+            duckdb_free(varchar as *mut c_void);
+            res
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi::duckdb_create_varchar;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_value_to_string() {
+        let c_str = CString::new("some value").unwrap();
+        let duckdb_val = unsafe { duckdb_create_varchar(c_str.as_ptr()) };
+        let val = Value::from(duckdb_val);
+        assert_eq!(val.to_string(), "some value");
     }
 }


### PR DESCRIPTION
The original code used `CString::from_raw()`, which takes ownership of the C string but never frees the underlying memory allocated by DuckDB. Worse, assuming ownership of memory that belonged to DuckDB's memory allocator can lead to undefined behavior.

Fixes #197 