### PR TITLE
Remove redundant flush and close calls in Appender Drop

### DIFF
--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -161,9 +161,7 @@ impl Appender<'_> {
 impl Drop for Appender<'_> {
     fn drop(&mut self) {
         if !self.app.is_null() {
-            let _ = self.flush(); // can't safely handle failures here
             unsafe {
-                ffi::duckdb_appender_close(self.app);
                 ffi::duckdb_appender_destroy(&mut self.app);
             }
         }


### PR DESCRIPTION
`duckdb_appender_destroy` already handles flushing and closing internally, making explicit calls unnecessary and potentially unsafe for partial rows.

The C API documentation confirms this behavior:

```c
/*!
Closes the appender by flushing all intermediate states to the table and destroying it. By destroying it, this function
de-allocates all memory associated with the appender. If flushing the data triggers a constraint violation,
then all data is invalidated, and this function returns DuckDBError. Due to the destruction of the appender, it is no
longer possible to obtain the specific error message with duckdb_appender_error. Therefore, call duckdb_appender_close
before destroying the appender, if you need insights into the specific error.

* @param appender The appender to flush, close and destroy.
* @return `DuckDBSuccess` on success or `DuckDBError` on failure.
*/
DUCKDB_C_API duckdb_state duckdb_appender_destroy(duckdb_appender *appender);
```