### PR TITLE
Speed up CI by canceling in-progress runs

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -7,6 +7,11 @@ on:
     branches: [main]
 env:
   RUST_BACKTRACE: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test ${{ matrix.target }}


### PR DESCRIPTION
Prevents redundant CI runs when new commits are pushed to the same branch, while ensuring main branch builds always complete.

This is how it's already done elsewhere in DuckDB land, e.g. [here](https://github.com/duckdb/extension-template/blob/f85fea84e263ec539bf44da45fb6b2a864fddb64/.github/workflows/ExtensionTemplate.yml).