### PR TITLE
Clean up ignored tests

### DIFF
--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -208,10 +208,8 @@ mod test {
         Ok(())
     }
 
-    // Waiting https://github.com/duckdb/duckdb/pull/3405
     #[cfg(feature = "uuid")]
     #[test]
-    #[ignore = "not supported for now"]
     fn test_append_uuid() -> Result<()> {
         use uuid::Uuid;
 

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -980,14 +980,13 @@ mod test {
     }
 
     #[test]
-    #[ignore = "not supported"]
-    fn test_statement_debugging() -> Result<()> {
+    #[should_panic(expected = "not supported")]
+    fn test_statement_debugging() {
         let db = checked_memory_handle();
         let query = "SELECT 12345";
-        let stmt = db.prepare(query)?;
+        let stmt = db.prepare(query).unwrap();
 
         assert!(format!("{stmt:?}").contains(query));
-        Ok(())
     }
 
     #[test]

--- a/crates/duckdb/src/pragma.rs
+++ b/crates/duckdb/src/pragma.rs
@@ -292,15 +292,13 @@ mod test {
     }
 
     #[test]
-    #[ignore = "not supported"]
     fn pragma_query_with_schema() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        let mut version = "".to_string();
-        db.pragma_query(Some(DatabaseName::Main), "version", |row| {
-            version = row.get(0)?;
-            Ok(())
-        })?;
-        assert!(!version.is_empty());
+        let res = db.pragma_query(Some(DatabaseName::Main), "version", |_| Ok(()));
+        assert_eq!(
+            res.unwrap_err().to_string().lines().next().unwrap(),
+            "Parser Error: syntax error at or near \".\""
+        );
         Ok(())
     }
 
@@ -324,12 +322,10 @@ mod test {
     }
 
     #[test]
-    #[ignore = "don't support query pragma"]
     fn test_pragma_update_and_check() -> Result<()> {
         let db = Connection::open_in_memory()?;
-        let journal_mode: String =
-            db.pragma_update_and_check(None, "explain_output", &"OPTIMIZED_ONLY", |row| row.get(0))?;
-        assert_eq!("OPTIMIZED_ONLY", &journal_mode);
+        let res = db.pragma_update_and_check(None, "explain_output", &"OPTIMIZED_ONLY", |_| Ok(()));
+        assert_eq!(res.unwrap_err(), crate::Error::QueryReturnedNoRows);
         Ok(())
     }
 
@@ -353,12 +349,5 @@ mod test {
         let mut sql = Sql::new();
         sql.push_string_literal("value'; --");
         assert_eq!("'value''; --'", sql.as_str());
-    }
-
-    #[test]
-    #[ignore]
-    fn test_locking_mode() -> Result<()> {
-        let db = Connection::open_in_memory()?;
-        db.pragma_update(None, "locking_mode", &"exclusive")
     }
 }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -980,7 +980,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_bind_parameters() -> Result<()> {
         let db = Connection::open_in_memory()?;
         // dynamic slice:
@@ -995,8 +994,8 @@ mod test {
         })?;
         db.query_row("SELECT ?1, ?2, ?3", params_from_iter(data), |row| row.get::<_, u8>(0))?;
 
-        use std::collections::BTreeSet;
-        let data: BTreeSet<String> = ["one", "two", "three"].iter().map(|s| (*s).to_string()).collect();
+        let data: std::collections::BTreeSet<String> =
+            ["one", "two", "three"].iter().map(|s| (*s).to_string()).collect();
         db.query_row("SELECT ?1, ?2, ?3", params_from_iter(&data), |row| {
             row.get::<_, String>(0)
         })?;
@@ -1035,22 +1034,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
-    fn test_utf16_conversion() -> Result<()> {
-        let db = Connection::open_in_memory()?;
-        db.pragma_update(None, "encoding", &"UTF-16le")?;
-        let encoding: String = db.pragma_query_value(None, "encoding", |row| row.get(0))?;
-        assert_eq!("UTF-16le", encoding);
-        db.execute_batch("CREATE TABLE foo(x TEXT)")?;
-        let expected = "テスト";
-        db.execute("INSERT INTO foo(x) VALUES (?)", [&expected])?;
-        let actual: String = db.query_row("SELECT x FROM foo", [], |row| row.get(0))?;
-        assert_eq!(expected, actual);
-        Ok(())
-    }
-
-    #[test]
-    #[ignore]
     fn test_nul_byte() -> Result<()> {
         let db = Connection::open_in_memory()?;
         let expected = "a\x00b";

--- a/crates/duckdb/src/types/chrono.rs
+++ b/crates/duckdb/src/types/chrono.rs
@@ -174,7 +174,7 @@ impl ToSql for Duration {
 #[cfg(test)]
 mod test {
     use crate::{
-        types::{FromSql, ToSql, ToSqlOutput, ValueRef},
+        types::{FromSql, FromSqlError, ToSql, ToSqlOutput, ValueRef},
         Connection, Result,
     };
     use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta, TimeZone, Utc};
@@ -349,9 +349,15 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_lenient_parse_timezone() {
-        assert!(DateTime::<Utc>::column_result(ValueRef::Text(b"1970-01-01T00:00:00Z")).is_ok());
-        assert!(DateTime::<Utc>::column_result(ValueRef::Text(b"1970-01-01T00:00:00+00")).is_ok());
+        // Not supported
+        assert!(matches!(
+            DateTime::<Utc>::column_result(ValueRef::Text(b"1970-01-01T00:00:00Z")),
+            Err(FromSqlError::Other(_))
+        ));
+        assert!(matches!(
+            DateTime::<Utc>::column_result(ValueRef::Text(b"1970-01-01T00:00:00+00")),
+            Err(FromSqlError::Other(_))
+        ));
     }
 }


### PR DESCRIPTION
- Remove `#[ignore]` from tests that can now pass
- Update failing tests to use `#[should_panic]` with expected messages
- Fix test implementations to show DuckDB behavior
- Remove useless tests copied from rusqlite