### PR TITLE
build(libduckdb-sys): sort C++ source files for deterministic builds

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -146,7 +146,10 @@ mod build_bundled {
         cfg.include(lib_name);
         cfg.includes(include_dirs.iter().map(|dir| format!("{out_dir}/{lib_name}/{dir}")));
 
-        for f in cpp_files.into_iter().map(|file| format!("{out_dir}/{file}")) {
+        // Ensure deterministic builds
+        let mut cpp_files_vec: Vec<String> = cpp_files.into_iter().collect(); 
+        cpp_files_vec.sort();
+        for f in cpp_files_vec.into_iter().map(|file| format!("{out_dir}/{file}")) {
             cfg.file(f);
         }
 

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -147,7 +147,7 @@ mod build_bundled {
         cfg.includes(include_dirs.iter().map(|dir| format!("{out_dir}/{lib_name}/{dir}")));
 
         // Ensure deterministic builds
-        let mut cpp_files_vec: Vec<String> = cpp_files.into_iter().collect(); 
+        let mut cpp_files_vec: Vec<String> = cpp_files.into_iter().collect();
         cpp_files_vec.sort();
         for f in cpp_files_vec.into_iter().map(|file| format!("{out_dir}/{file}")) {
             cfg.file(f);


### PR DESCRIPTION
# Description
## Summary

This PR modifies the build.rs script in the libduckdb-sys crate to ensure deterministic builds by sorting the C++ file paths before including them in the build process.

Closes #582.

## Motivation

Currently, cpp_files is derived from a HashSet, which yields non-deterministic ordering. This causes builds to vary across runs, leading to non-reproducible binaries. The change directly addresses the “Unreproducible binaries due to cpp_files HashSet in build.rs” issue by introducing a structured ordering of file inclusions.

## Implementation Details

Convert the cpp_files iterator into a Vec<String>.

Apply .sort() to that vector to enforce a consistent ordering.

Iterate over the sorted vector to invoke cfg.file(...) on each entry.

# Test Results (Unchanged from Before)

These two tests continue to fail—they were failing prior to this PR and remain unrelated to its intent:

```
failures:

---- test_all_types::test_large_arrow_types stdout ----
Error: DuckDBFailure(Error { code: Unknown, extended_code: 1 }, Some("Binder Error: Column \"varint\" in EXCLUDE list not found in FROM clause"))

---- test_all_types::test_all_types stdout ----
Error: DuckDBFailure(Error { code: Unknown, extended_code: 1 }, Some("Binder Error: Column \"varint\" in EXCLUDE list not found in FROM clause"))

failures:
    test_all_types::test_all_types
    test_all_types::test_large_arrow_types

test result: FAILED. 123 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.88s

error: test failed, to rerun pass `-p duckdb --lib`
```

These errors are caused by a Binder Error—specifically stating that the column "varint" in the  list was not found in the FROM clause—and are unrelated to the sorted C++ files.
