### PR TITLE
Pin nightly Rust to fix ASAN CI job

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -114,15 +114,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Need nightly rust.
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly
-          components: "rust-src"
-      # Install LLVM tools
+          toolchain: nightly-2025-08-15
+          components: rust-src
       - name: Install LLVM
-        run: |
-          sudo apt-get install -y llvm
+        run: sudo apt-get install -y llvm
       - name: Tests with asan
         env:
           RUSTFLAGS: -Zsanitizer=address -C debuginfo=0


### PR DESCRIPTION
Compiler bug in current nightly as seen in multiple PRs:

```
❯ cargo +nightly -Z build-std test --features "serde_json url r2d2 uuid polars extensions-full" --package duckdb
...
thread 'rustc' (24108401) panicked at compiler/rustc_trait_selection/src/traits/select/mod.rs:294:24:
`TraitPredicate(<&'a polars_arrow::array::PrimitiveArray<f32> as std::iter::IntoIterator>, polarity:Positive)` has escaping bound vars, so it cannot be wrapped in a dummy binder.
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: <rustc_trait_selection::traits::select::SelectionContext>::select
   3: rustc_traits::codegen::codegen_select_candidate
      [... omitted 2 frames ...]
   4: rustc_ty_utils::instance::resolve_instance_raw
      [... omitted 2 frames ...]
   5: <rustc_middle::ty::instance::Instance>::try_resolve
   6: <rustc_lint::internal::QueryStability as rustc_lint::passes::LateLintPass>::check_expr
   7: <rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>::with_lint_attrs::<<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass> as rustc_hir::intravisit::Visitor>::visit_expr::{closure#0}::{closure#0}>
   8: rustc_hir::intravisit::walk_block::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
   9: rustc_hir::intravisit::walk_expr::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  10: <rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>::with_lint_attrs::<<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass> as rustc_hir::intravisit::Visitor>::visit_expr::{closure#0}::{closure#0}>
  11: rustc_hir::intravisit::walk_expr::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  12: <rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>::with_lint_attrs::<<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass> as rustc_hir::intravisit::Visitor>::visit_expr::{closure#0}::{closure#0}>
  13: rustc_hir::intravisit::walk_block::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  14: rustc_hir::intravisit::walk_expr::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  15: <rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>::with_lint_attrs::<<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass> as rustc_hir::intravisit::Visitor>::visit_expr::{closure#0}::{closure#0}>
  16: rustc_hir::intravisit::walk_block::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  17: rustc_hir::intravisit::walk_expr::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  18: <rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>::with_lint_attrs::<<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass> as rustc_hir::intravisit::Visitor>::visit_expr::{closure#0}::{closure#0}>
  19: rustc_hir::intravisit::walk_expr::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  20: <rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>::with_lint_attrs::<<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass> as rustc_hir::intravisit::Visitor>::visit_expr::{closure#0}::{closure#0}>
  21: rustc_hir::intravisit::walk_block::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  22: rustc_hir::intravisit::walk_expr::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  23: rustc_hir::intravisit::walk_body::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  24: rustc_hir::intravisit::walk_fn::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  25: <rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>::with_param_env::<<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass> as rustc_hir::intravisit::Visitor>::visit_item::{closure#0}::{closure#0}>
  26: rustc_hir::intravisit::walk_mod::<rustc_lint::late::LateContextAndPass<rustc_lint::late::RuntimeCombinedLateLintPass>>
  27: rustc_lint::lint_mod
      [... omitted 1 frame ...]
  28: rustc_lint::late::check_crate::{closure#1}
  29: rustc_lint::late::check_crate
  30: rustc_interface::passes::analysis::{closure#0}
  31: rustc_interface::passes::analysis
      [... omitted 1 frame ...]
  32: rustc_interface::passes::create_and_enter_global_ctxt::<core::option::Option<rustc_interface::queries::Linker>, rustc_driver_impl::run_compiler::{closure#0}::{closure#2}>
  33: rustc_interface::interface::run_compiler::<(), rustc_driver_impl::run_compiler::{closure#0}>::{closure#1}
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: the compiler unexpectedly panicked. this is a bug.

note: using internal features is not supported and expected to cause internal compiler errors when used incorrectly

note: please attach the file at `/Users/mathias/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/polars-ops-0.49.1/rustc-ice-2025-08-21T08_16_15-72961.txt` to your bug report

note: compiler flags: --crate-type lib -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked -C linker=clang -Z unstable-options -C link-arg=-fuse-ld=lld

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
#0 [codegen_select_candidate] computing candidate for `<&'a polars_arrow::array::primitive::PrimitiveArray<f32> as core::iter::traits::collect::IntoIterator>`
panicked at compiler/rustc_middle/src/ty/instance.rs:458:9:

thread panicked while processing panic. aborting.
error: could not compile `polars-ops` (lib)

Caused by:
  process didn't exit successfully: `/Users/mathias/.rustup/toolchains/nightly-aarch64-apple-darwin/bin/rustc --crate-name polars_ops --edition=2024 /Users/mathias/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/polars-ops-0.49.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=159 --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked '--allow=clippy::collapsible_if' --cfg 'feature="dtype-array"' --cfg 'feature="dtype-categorical"' --cfg 'feature="dtype-date"' --cfg 'feature="dtype-datetime"' --cfg 'feature="dtype-decimal"' --cfg 'feature="dtype-duration"' --cfg 'feature="dtype-i128"' --cfg 'feature="dtype-i16"' --cfg 'feature="dtype-i8"' --cfg 'feature="dtype-struct"' --cfg 'feature="dtype-time"' --cfg 'feature="dtype-u16"' --cfg 'feature="dtype-u8"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("abs", "aho-corasick", "approx_unique", "array_any_all", "array_count", "array_to_struct", "asof_join", "base64", "big_idx", "binary_encoding", "bitwise", "business", "chrono", "chrono-tz", "chunked_ids", "cov", "cross_join", "cum_agg", "cutqcut", "diff", "dsl-schema", "dtype-array", "dtype-categorical", "dtype-date", "dtype-datetime", "dtype-decimal", "dtype-duration", "dtype-i128", "dtype-i16", "dtype-i8", "dtype-struct", "dtype-time", "dtype-u16", "dtype-u8", "ewma", "ewma_by", "extract_groups", "extract_jsonpath", "find_many", "fused", "gather", "hash", "hex", "hist", "iejoin", "index_of", "interpolate", "interpolate_by", "is_between", "is_first_distinct", "is_in", "is_last_distinct", "is_unique", "jsonpath_lib", "list_any_all", "list_count", "list_drop_nulls", "list_filter", "list_gather", "list_sample", "list_sets", "list_to_struct", "log", "merge_sorted", "mode", "moment", "nightly", "object", "pct_change", "peaks", "performant", "pivot", "polars-json", "propagate_nans", "rand", "rand_distr", "random", "rank", "reinterpret", "repeat_by", "replace", "rle", "rolling_window", "rolling_window_by", "round_series", "search_sorted", "semi_anti_join", "serde", "serde_json", "simd", "string_encoding", "string_normalize", "string_pad", "string_reverse", "string_to_integer", "strings", "timezones", "to_dummies", "top_k", "unicode-normalization", "unicode-reverse", "unique_counts"))' -C metadata=e6ffe473b4897402 -C extra-filename=-ed80e22f684903e3 --out-dir /Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps -C linker=clang -L dependency=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps --extern 'noprelude:alloc=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/liballoc-6f84f3785e909f2c.rmeta' --extern argminmax=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libargminmax-293029f22ae44ef6.rmeta --extern bytemuck=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libbytemuck-60612eaf065e8f0e.rmeta --extern 'noprelude:compiler_builtins=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libcompiler_builtins-bfa27bff266e0140.rmeta' --extern 'noprelude:core=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libcore-caa7cf4fff4fa0c3.rmeta' --extern either=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libeither-2f473b247e480042.rmeta --extern hashbrown=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libhashbrown-8726436ff9231a63.rmeta --extern indexmap=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libindexmap-7ae9b6606ac0f804.rmeta --extern libm=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/liblibm-1750075c4cee8d90.rmeta --extern memchr=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libmemchr-af099bc9205bfaa0.rmeta --extern num_traits=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libnum_traits-e7e5b85929bf3b3d.rmeta --extern 'noprelude:panic_unwind=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libpanic_unwind-38e31b615a3d7932.rmeta' --extern arrow=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libpolars_arrow-5de95137ab8263ec.rmeta --extern polars_compute=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libpolars_compute-315b1eb9235c5206.rmeta --extern polars_core=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libpolars_core-7f7d5e97e284003f.rmeta --extern polars_error=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libpolars_error-ebbc29d1fdbfba7c.rmeta --extern polars_schema=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libpolars_schema-e60a478dcab8eb69.rmeta --extern polars_utils=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libpolars_utils-2243abe101157aa8.rmeta --extern 'noprelude:proc_macro=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libproc_macro-74c8bbf8c13121ce.rmeta' --extern rayon=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/librayon-cefd3796931309bf.rmeta --extern regex=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libregex-3ec1425aaddcd179.rmeta --extern regex_syntax=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libregex_syntax-74a76dcb95bf9a10.rmeta --extern 'noprelude:std=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libstd-86a540897f069944.rmeta' --extern strum_macros=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libstrum_macros-0f6955ccdf896fd6.dylib --extern 'noprelude:test=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libtest-5b8bc72e70d2e664.rmeta' -Z unstable-options --cap-lints allow -C link-arg=-fuse-ld=lld '-Dclippy::all' -Dnonstandard-style -Drust-2018-idioms -L native=/Users/mathias/devel/duckdb/duckdb-rs/target/debug/build/psm-14c93355f00ec82a/out --cfg 'feature="nightly"'` (signal: 6, SIGABRT: process abort signal)
```