### PR TITLE
Add ICU extension to the list of statically linked extensions

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -126,6 +126,7 @@ mod build_bundled {
         let mut cfg = cc::Build::new();
 
         add_extension(&mut cfg, &manifest, "core_functions", &mut cpp_files, &mut include_dirs);
+        add_extension(&mut cfg, &manifest, "icu", &mut cpp_files, &mut include_dirs);
 
         #[cfg(feature = "parquet")]
         add_extension(&mut cfg, &manifest, "parquet", &mut cpp_files, &mut include_dirs);

--- a/crates/libduckdb-sys/update_sources.py
+++ b/crates/libduckdb-sys/update_sources.py
@@ -16,7 +16,7 @@ SRC_DIR = os.path.join(SCRIPT_DIR, "src")
 
 # List of extensions' sources to grab. Technically, these sources will be compiled
 # but not included in the final build unless they're explicitly enabled.
-EXTENSIONS = ["core_functions", "parquet", "json"]
+EXTENSIONS = ["core_functions", "parquet", "json", "icu"]
 
 # Clear the duckdb directory
 try:


### PR DESCRIPTION
## 🗣 Description

Query `select now() - interval '1'` works via duckdb CLI, but fails via `duckdb-rs` without manually installing/loading ICU extension. In order to match the behavior of CLI, we can make it statically linked.

## 🔨 Related Issues

https://github.com/duckdb/duckdb-rs/issues/591
