### PR TITLE
Remove pointer indirection during init

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -78,7 +78,7 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
                     }
 
                     // TODO: handle error here?
-                    let db: ::libduckdb_sys::duckdb_database = *(*access).get_database.unwrap()(info);
+                    let db: ::libduckdb_sys::duckdb_database = (*access).get_database.unwrap()(info);
                     let connection = ::duckdb::Connection::open_from_raw(db.cast())?;
 
                     #prefixed_original_function(connection)?;


### PR DESCRIPTION
This PR removes the pointer indirection in
`duckdb_extension_access.get_database`. It is expected that the definition of `duckdb_extension_access` will be updated automatically after `duckdb.h` is updated (not sure if manual changes are needed there).

Engine PR: duckdb/duckdb#19529