### PR TITLE
Update Rust to 1.91

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.90"
+channel = "1.91"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/