### PR TITLE
Implement binding for list types

### DIFF
--- a/crates/duckdb/src/core/logical_type.rs
+++ b/crates/duckdb/src/core/logical_type.rs
@@ -168,6 +168,7 @@ impl Debug for LogicalTypeHandle {
                 }
                 write!(f, ">")
             }
+            LogicalTypeId::List => write!(f, "List<{:?}>", self.child(0)),
             _ => write!(f, "{:?}", id),
         }
     }
@@ -340,6 +341,7 @@ impl LogicalTypeHandle {
     pub fn child(&self, idx: usize) -> Self {
         let c_logical_type = unsafe {
             match self.id() {
+                LogicalTypeId::List => duckdb_list_type_child_type(self.ptr),
                 LogicalTypeId::Struct => duckdb_struct_type_child_type(self.ptr, idx as u64),
                 LogicalTypeId::Union => duckdb_union_type_member_type(self.ptr, idx as u64),
                 LogicalTypeId::Array => duckdb_array_type_child_type(self.ptr),

--- a/crates/duckdb/src/core/mod.rs
+++ b/crates/duckdb/src/core/mod.rs
@@ -1,7 +1,9 @@
 mod data_chunk;
 mod logical_type;
+mod value;
 mod vector;
 
 pub use data_chunk::DataChunkHandle;
 pub use logical_type::{LogicalTypeHandle, LogicalTypeId};
+pub use value::ValueHandle;
 pub use vector::*;

--- a/crates/duckdb/src/core/value.rs
+++ b/crates/duckdb/src/core/value.rs
@@ -1,0 +1,62 @@
+use crate::{
+    ffi::*,
+    types::{ListType, ValueRef},
+};
+
+/// A wrapper around a DuckDB value handle.
+#[derive(Debug)]
+#[repr(C)]
+pub struct ValueHandle {
+    pub(crate) ptr: duckdb_value,
+    // Do not add members so that array of this type can be used in FFI.
+}
+
+impl Drop for ValueHandle {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                duckdb_destroy_value(&mut self.ptr);
+            }
+        }
+        self.ptr = std::ptr::null_mut();
+    }
+}
+
+impl<'a> From<ValueRef<'a>> for ValueHandle {
+    fn from(value_ref: ValueRef<'a>) -> Self {
+        let ptr = match value_ref {
+            ValueRef::Null => unsafe { duckdb_create_null_value() },
+            ValueRef::Boolean(v) => unsafe { duckdb_create_bool(v) },
+            ValueRef::TinyInt(v) => unsafe { duckdb_create_int8(v) },
+            ValueRef::SmallInt(v) => unsafe { duckdb_create_int16(v) },
+            ValueRef::Int(v) => unsafe { duckdb_create_int32(v) },
+            ValueRef::BigInt(v) => unsafe { duckdb_create_int64(v) },
+            ValueRef::HugeInt(v) => {
+                let lower = v.cast_unsigned() as u64;
+                let upper = (v >> 64) as i64;
+                unsafe { duckdb_create_hugeint(duckdb_hugeint { lower, upper }) }
+            }
+            ValueRef::UTinyInt(v) => unsafe { duckdb_create_uint8(v) },
+            ValueRef::USmallInt(v) => unsafe { duckdb_create_uint16(v) },
+            ValueRef::UInt(v) => unsafe { duckdb_create_uint32(v) },
+            ValueRef::UBigInt(v) => unsafe { duckdb_create_uint64(v) },
+            ValueRef::Float(v) => unsafe { duckdb_create_float(v) },
+            ValueRef::Double(v) => unsafe { duckdb_create_double(v) },
+            ValueRef::Text(v) => unsafe { duckdb_create_varchar_length(v.as_ptr() as *const i8, v.len() as u64) },
+            ValueRef::Blob(v) => unsafe { duckdb_create_blob(v.as_ptr() as *const u8, v.len() as u64) },
+            ValueRef::Timestamp(..)
+            | ValueRef::List(..)
+            | ValueRef::Date32(..)
+            | ValueRef::Time64(..)
+            | ValueRef::Interval { .. }
+            | ValueRef::Decimal(..)
+            | ValueRef::Enum(..)
+            | ValueRef::Struct(..)
+            | ValueRef::Array(..)
+            | ValueRef::Map(..)
+            | ValueRef::Union(..) => unimplemented!("Not implemented for {:?}", value_ref),
+        };
+        assert!(!ptr.is_null(), "Failed to create DuckDB value for {:?}", value_ref);
+        Self { ptr }
+    }
+}

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -621,12 +621,12 @@ impl<'stmt> Row<'stmt> {
             DataType::LargeList(..) => {
                 let arr = column.as_any().downcast_ref::<array::LargeListArray>().unwrap();
 
-                ValueRef::List(ListType::Large(arr), row)
+                ValueRef::List(ListType::Large(arr, row))
             }
             DataType::List(..) => {
                 let arr = column.as_any().downcast_ref::<ListArray>().unwrap();
 
-                ValueRef::List(ListType::Regular(arr), row)
+                ValueRef::List(ListType::Regular(arr, row))
             }
             DataType::Dictionary(key_type, ..) => {
                 let column = column.as_any();

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -361,4 +361,54 @@ mod test {
         assert_eq!(found_label, "target");
         Ok(())
     }
+
+    #[test]
+    fn test_list() -> crate::Result<()> {
+        use crate::{
+            params,
+            types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, Value, ValueRef},
+            Connection,
+        };
+
+        #[derive(Debug, PartialEq, Eq)]
+        struct MyList(Vec<i32>);
+
+        impl ToSql for MyList {
+            fn to_sql(&self) -> crate::Result<ToSqlOutput<'_>> {
+                Ok(ToSqlOutput::Owned(Value::List(
+                    self.0.iter().map(|&x| Value::Int(x)).collect(),
+                )))
+            }
+        }
+
+        impl FromSql for MyList {
+            fn column_result(value_ref: ValueRef<'_>) -> FromSqlResult<Self> {
+                match value_ref.to_owned() {
+                    Value::List(values) => values
+                        .into_iter()
+                        .map(|v| {
+                            if let Value::Int(i) = v {
+                                Ok(i)
+                            } else {
+                                Err(FromSqlError::InvalidType)
+                            }
+                        })
+                        .collect::<Result<Vec<i32>, _>>()
+                        .map(MyList),
+                    _ => return FromSqlResult::Err(FromSqlError::InvalidType),
+                }
+            }
+        }
+
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE foo (numbers INT[]);")?;
+
+        let list = MyList(vec![1, 2, 3, 4, 5]);
+        db.execute("INSERT INTO foo (numbers) VALUES (?)", params![&list])?;
+
+        let found_numbers: MyList = db.prepare("SELECT numbers FROM foo")?.query_one([], |r| r.get(0))?;
+        assert_eq!(found_numbers, MyList(vec![1, 2, 3, 4, 5]));
+
+        Ok(())
+    }
 }

--- a/crates/duckdb/src/types/value.rs
+++ b/crates/duckdb/src/types/value.rs
@@ -1,3 +1,5 @@
+use crate::types::{value_ref::ListType, ValueRef};
+
 use super::{Null, OrderedMap, TimeUnit, Type};
 use rust_decimal::prelude::*;
 
@@ -238,7 +240,8 @@ impl Value {
             Self::Date32(_) => Type::Date32,
             Self::Time64(..) => Type::Time64,
             Self::Interval { .. } => Type::Interval,
-            Self::Union(..) | Self::Struct(..) | Self::List(..) | Self::Array(..) | Self::Map(..) => todo!(),
+            Self::List(ref arr) => ValueRef::List(ListType::Native(arr)).data_type(),
+            Self::Union(..) | Self::Struct(..) | Self::Array(..) | Self::Map(..) => todo!(),
             Self::Enum(..) => Type::Enum,
         }
     }


### PR DESCRIPTION
This PR enables implementing `ToSql` for types that represent lists. Below example starts working:

```rust
#[derive(Debug, PartialEq, Eq)]
struct MyList(Vec<i32>);

impl ToSql for MyList {
    fn to_sql(&self) -> crate::Result<ToSqlOutput<'_>> {
        Ok(ToSqlOutput::Owned(Value::List(
            self.0.iter().map(|&x| Value::Int(x)).collect(),
        )))
    }
}

let db = Connection::open_in_memory()?;
db.execute_batch("CREATE TABLE foo (numbers INT[]);")?;

let list = MyList(vec![1, 2, 3, 4, 5]);
db.execute("INSERT INTO foo (numbers) VALUES (?)", params![&list])?;
```

This code works by inferring inner data type of a list from the first element of the list.

This means below code doesn't work since this method doesn't work for empty lists unfortunately:

```rust
let list = MyList(vec![]);

// This should panic because the list is empty and DuckDB cannot determine the type of the list.
_ = db.execute("INSERT INTO foo (numbers) VALUES (?)", params![&list]);
```

There are also a breaking change in `ValueRef::List` so that conversion from `Value::List` is possible. Without this change, `ValueRef::List` assumes referee is backed by an Arrow array, while `Value::List` is backed by `Vec<Value>`, preventing a conversion.