### PR TITLE
Remove broken release changelog/action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      # cargo publish
       - name: publish crates
         uses: katyo/publish-crates@v2
         with:
@@ -22,17 +21,5 @@ jobs:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           ignore-unpublished-changes: true
 
-      # create release
-      - name: "Build Changelog"
-        id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Release
-        uses: actions/create-release@v1
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{steps.build_changelog.outputs.changelog}}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# NOTE: After running this action, manually create a new release via https://github.com/duckdb/duckdb-rs/releases/new
+# TODO: Automate the entire release process


### PR DESCRIPTION
The changelog generated by this action has (always?) been empty. Remove it for now in favor of creating releases manually, which has the benefit of auto-generated release notes.