### PR TITLE
Consolidate loadable extension features

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -78,18 +78,18 @@ jobs:
 
       - name: Run cargo-test
         if: matrix.os == 'windows-latest'
-        run: cargo test --features "modern-full vtab-full vtab-loadable"
+        run: cargo test --features "modern-full vtab-full"
         env:
           DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
           DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb
 
       - name: Build loadable extension
         if: matrix.os == 'ubuntu-latest'
-        run: cargo build --example hello-ext --features="vtab-loadable loadable-extension"
+        run: cargo build --example hello-ext --features="loadable-extension"
 
       - name: Build loadable extension (windows)
         if: matrix.os == 'windows-latest'
-        run: cargo build --example hello-ext --features="vtab-loadable loadable-extension"
+        run: cargo build --example hello-ext --features="loadable-extension"
         env:
           DUCKDB_LIB_DIR: ${{ github.workspace }}/libduckdb
           DUCKDB_INCLUDE_DIR: ${{ github.workspace }}/libduckdb

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ The `duckdb` crate provides a number of Cargo features that can be enabled to ad
 - `vtab` - Base support for creating custom table functions and virtual tables.
 - `vtab-arrow` - Apache Arrow integration for virtual tables. Enables conversion between Arrow RecordBatch and DuckDB data chunks.
 - `vtab-excel` - Read Excel (.xlsx) files directly in SQL queries with automatic schema detection.
-- `vtab-loadable` - Support for creating loadable DuckDB extensions. Includes procedural macros for extension development.
 - `vscalar` - Create custom scalar functions that operate on individual values or rows.
 - `vscalar-arrow` - Arrow-optimized scalar functions for vectorized operations.
 
@@ -116,7 +115,7 @@ The `duckdb` crate provides a number of Cargo features that can be enabled to ad
 
 - `bundled` - Uses a bundled version of DuckDB's source code and compiles it during build. This is the simplest way to get started and avoids needing DuckDB system libraries.
 - `buildtime_bindgen` - Use bindgen at build time to generate fresh bindings instead of using pre-generated ones.
-- `loadable-extension` - _Experimental_ support for building extensions that can be dynamically loaded into DuckDB.
+- `loadable-extension` - _Experimental_ support for creating loadable DuckDB extensions. Includes procedural macros for extension development.
 
 ## Installation
 

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -24,7 +24,8 @@ parquet = ["libduckdb-sys/parquet", "bundled"]
 vscalar = ["vtab-arrow"]
 vscalar-arrow = []
 vtab = []
-vtab-loadable = ["vtab", "duckdb-loadable-macros"]
+# Deprecated: use loadable-extension instead
+vtab-loadable = ["loadable-extension"]
 vtab-excel = ["vtab", "calamine"]
 vtab-arrow = ["vtab", "num"]
 appender-arrow = ["vtab-arrow"]
@@ -34,7 +35,7 @@ buildtime_bindgen = ["libduckdb-sys/buildtime_bindgen"]
 modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars"]
 polars = ["dep:polars", "dep:polars-arrow"]
 # Warning: experimental feature
-loadable-extension = ["libduckdb-sys/loadable-extension"]
+loadable-extension = ["vtab", "duckdb-loadable-macros", "libduckdb-sys/loadable-extension"]
 
 [dependencies]
 arrow = { workspace = true, features = ["prettyprint", "ffi"] }
@@ -79,4 +80,4 @@ all-features = false
 [[example]]
 name = "hello-ext"
 crate-type = ["cdylib"]
-required-features = ["vtab-loadable", "loadable-extension"]
+required-features = ["loadable-extension"]

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -91,7 +91,7 @@ pub use polars_dataframe::Polars;
 
 // re-export dependencies to minimise version maintenance for crate users
 pub use arrow;
-#[cfg(feature = "vtab-loadable")]
+#[cfg(feature = "loadable-extension")]
 pub use duckdb_loadable_macros::duckdb_entrypoint_c_api;
 #[cfg(feature = "polars")]
 pub use polars;


### PR DESCRIPTION
Having two separate features was confusing:
- `vtab-loadable` - macros only
- `loadable-extension` - linking changes only

Users needed both for working extensions. Using `vtab-loadable` alone produced non-functional extensions (DuckDB linked statically into cdylib → two DuckDB instances when loaded → broken).

Before:

```rust
duckdb = { features = ["vtab-loadable", "loadable-extension"] }
```

After:

```rust
duckdb = { features = ["loadable-extension"] }
```

`vtab-loadable` is preserved as a deprecated alias pointing to `loadable-extension`. Existing `Cargo.toml` files continue to work.

---

What does this mean for https://github.com/duckdb/extension-template-rs?

After the next release, we can change
```toml
[dependencies]
duckdb = { version = "=1.4.3", features = ["vtab-loadable"] }
duckdb-loadable-macros = "=0.1.13"
libduckdb-sys = { version = "=1.4.3", features = ["loadable-extension"] }
```
to
```toml
duckdb = { version = "=1.4.4", features = ["loadable-extension"] }
```
(though the old way will still work)