### PR TITLE
Enable `stream_arrow()` to work with CALL statements

### DIFF
--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -1381,6 +1381,39 @@ mod test {
     }
 
     #[test]
+    fn test_stream_arrow_with_call() -> Result<()> {
+        use arrow::datatypes::{DataType, Field, Schema};
+        use std::sync::Arc;
+
+        let db = checked_memory_handle();
+
+        db.execute_batch(
+            "CREATE TABLE test_data(id INTEGER, name VARCHAR);
+             INSERT INTO test_data VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie');",
+        )?;
+
+        db.execute_batch("CREATE MACRO test_func() AS TABLE SELECT * FROM test_data;")?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+
+        let mut stmt = db.prepare("CALL test_func()")?;
+        let rbs: Vec<RecordBatch> = stmt.stream_arrow([], schema)?.collect();
+
+        // Verify we got results
+        assert!(!rbs.is_empty(), "Expected at least one record batch");
+        let total_rows: usize = rbs.iter().map(|rb| rb.num_rows()).sum();
+        assert_eq!(total_rows, 3);
+
+        let id_column = rbs[0].column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(id_column.value(0), 1);
+
+        Ok(())
+    }
+
+    #[test]
     fn round_trip_interval() -> Result<()> {
         let db = checked_memory_handle();
         db.execute_batch("CREATE TABLE foo (t INTERVAL);")?;


### PR DESCRIPTION
## Problem

When using `stream_arrow()` with CALL statements (e.g., `CALL my_function()`), no results were returned, while `query_arrow()` worked correctly. This affected table functions and macros invoked via CALL syntax.

## Root Cause

DuckDB's C API distinguishes between truly streaming results and materialized results:
- Some statements (like CALL) return **materialized results** even when `duckdb_execute_prepared_streaming()` is called
- The existing code always used `duckdb_stream_fetch_chunk()`, which explicitly rejects non-streaming results by returning `nullptr`
- This caused `stream_arrow()` to return no results for CALL statements, even though the data was present and fetchable

## Solution

This PR implements a fallback mechanism that:
1. Checks if the result is truly streaming using `duckdb_result_is_streaming()` after execution
2. Uses `duckdb_stream_fetch_chunk()` for truly streaming results (optimal performance)
3. Falls back to `duckdb_fetch_chunk()` for materialized results (handles CALL statements)

### Changes

- **`raw_statement.rs`**: 
  - Added `is_streaming: bool` field to track result type
  - Modified `execute_streaming()` to check `duckdb_result_is_streaming()`
  - Updated `streaming_step()` to use appropriate fetch function based on result type
  - Updated `reset_result()` to reset the streaming flag

- **`lib.rs`**:
  - Added `test_stream_arrow_with_call()` to verify CALL statements work with `stream_arrow()`

## Testing

- Added a new tests validating the new behavior. This test indeed doesn't pass on `main`.