### PR TITLE
performance(statement): introduce a lazy cache for column name to index

### DIFF
--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CStr, ops::Deref, ptr, rc::Rc, sync::Arc};
+use std::{cell::OnceCell, collections::HashMap, ffi::CStr, ops::Deref, ptr, rc::Rc, sync::Arc};
 
 use arrow::{
     array::StructArray,
@@ -24,6 +24,7 @@ pub struct RawStatement {
     result: Option<ffi::duckdb_arrow>,
     duckdb_result: Option<ffi::duckdb_result>,
     schema: Option<SchemaRef>,
+    column_name_cache: OnceCell<HashMap<Box<str>, usize>>,
     // Tracks whether the duckdb_result is truly streaming or materialized.
     // This is needed because some statements (like CALL) return materialized
     // results even when execute_streaming is called.
@@ -48,6 +49,7 @@ impl RawStatement {
             ptr: stmt,
             result: None,
             schema: None,
+            column_name_cache: OnceCell::new(),
             duckdb_result: None,
             is_streaming: false,
             statement_cache_key: None,
@@ -247,6 +249,23 @@ impl RawStatement {
         Some(self.schema.as_ref().unwrap().field(idx).name())
     }
 
+    #[inline]
+    pub fn column_index(&self, name: &str) -> Option<usize> {
+        let cache = self.column_name_cache.get_or_init(|| self.build_column_name_cache());
+        cache.get(&*name.to_ascii_lowercase()).copied()
+    }
+
+    fn build_column_name_cache(&self) -> HashMap<Box<str>, usize> {
+        let schema = self.schema.as_ref().expect("The statement was not executed yet");
+        let mut cache = HashMap::with_capacity(schema.fields().len());
+        for (index, field) in schema.fields().iter().enumerate() {
+            cache
+                .entry(field.name().to_ascii_lowercase().into_boxed_str())
+                .or_insert(index);
+        }
+        cache
+    }
+
     #[allow(dead_code)]
     unsafe fn print_result(&self, mut result: ffi::duckdb_result) {
         use ffi::{duckdb_column_count, duckdb_column_name, duckdb_row_count};
@@ -319,6 +338,7 @@ impl RawStatement {
     #[inline]
     pub fn reset_result(&mut self) {
         self.schema = None;
+        self.column_name_cache = OnceCell::new();
         self.is_streaming = false;
         if self.result.is_some() {
             unsafe {


### PR DESCRIPTION
# Summary
Introduce a lazy cache for the column name to index.
Lazily evaluated, small, and immutable cache.
Uses `HashMap` for lookup instead of linear search.

# Performance
Local benchmark with 100K rows × 32 cols: `~2x` faster for name-based access.