### PR TITLE
Fix silent streaming error handling

### DIFF
--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -1,6 +1,8 @@
+use std::iter::FusedIterator;
+
 use super::{
-    arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
     Result, Statement,
+    arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
 };
 
 /// A handle for the resulting RecordBatch of a query.
@@ -65,12 +67,16 @@ impl<'stmt> Iterator for ArrowStream<'stmt> {
         let stmt = self.stmt?;
         match stmt.stream_step(self.get_schema()) {
             Ok(Some(array)) => Some(Ok(RecordBatch::from(&array))),
-            Ok(None) => None,
+            Ok(None) => {
+                self.stmt = None;
+                None
+            }
             Err(e) => {
-                // Clear the statement to prevent further iteration after error
                 self.stmt = None;
                 Some(Err(e))
             }
         }
     }
 }
+
+impl<'stmt> FusedIterator for ArrowStream<'stmt> {}

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -1,6 +1,6 @@
 use super::{
-    Statement,
     arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
+    Result, Statement,
 };
 
 /// A handle for the resulting RecordBatch of a query.
@@ -59,9 +59,18 @@ impl<'stmt> ArrowStream<'stmt> {
 
 #[allow(clippy::needless_lifetimes)]
 impl<'stmt> Iterator for ArrowStream<'stmt> {
-    type Item = RecordBatch;
+    type Item = Result<RecordBatch>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(RecordBatch::from(&self.stmt?.stream_step(self.get_schema())?))
+        let stmt = self.stmt?;
+        match stmt.stream_step(self.get_schema()) {
+            Ok(Some(array)) => Some(Ok(RecordBatch::from(&array))),
+            Ok(None) => None,
+            Err(e) => {
+                // Clear the statement to prevent further iteration after error
+                self.stmt = None;
+                Some(Err(e))
+            }
+        }
     }
 }

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -1512,10 +1512,9 @@ mod test {
         let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int64, true)]));
         let mut stmt = db.prepare("SELECT i FROM range(1000000000) t(i)")?;
 
-        let stream = stmt.stream_arrow([], schema)?;
+        let mut stream = stmt.stream_arrow([], schema)?;
 
         let mut ok_batches = 0usize;
-        let mut stream = stream;
 
         // Fetch at least one batch to ensure the stream has started.
         let first = stream.next().expect("Expected at least one batch from stream");
@@ -1531,10 +1530,7 @@ mod test {
             Err(e) => {
                 assert!(ok_batches > 0, "Expected at least one batch before error");
                 let msg = format!("{e}");
-                assert!(
-                    msg == "INTERRUPT Error: Interrupted!",
-                    "Expected interrupt error, got: {msg}"
-                );
+                assert!(msg.contains("INTERRUPT"), "Expected interrupt error, got: {msg}");
                 Ok(())
             }
         }
@@ -1553,15 +1549,18 @@ mod test {
         let schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Int32, true)]));
 
         let mut stmt = db.prepare("SELECT value FROM test_data")?;
-        let stream = stmt.stream_arrow([], schema)?;
+        let mut stream = stmt.stream_arrow([], schema)?;
 
         // Collect results - all should be successful
-        let results: Result<Vec<_>> = stream.collect();
+        let results: Result<Vec<_>> = stream.by_ref().collect();
         let batches = results?;
 
         // Verify we got all 100 rows
         let total_rows: usize = batches.iter().map(|rb| rb.num_rows()).sum();
         assert_eq!(total_rows, 100);
+
+        // Verify the iterator is fused: exhausted stream yields None
+        assert!(stream.next().is_none());
 
         Ok(())
     }

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -680,12 +680,12 @@ doc_comment::doctest!("../../../README.md");
 
 #[cfg(test)]
 mod test {
-    use crate::types::Value;
-
     use super::*;
-    use std::{error::Error as StdError, fmt};
+    use crate::types::Value;
+    use std::{error::Error as StdError, fmt, sync::Arc};
 
-    use arrow::{array::Int32Array, datatypes::DataType, record_batch::RecordBatch};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::{array::Int32Array, record_batch::RecordBatch};
     use fallible_iterator::FallibleIterator;
 
     // this function is never called, but is still type checked; in
@@ -1472,9 +1472,6 @@ mod test {
 
     #[test]
     fn test_stream_arrow_with_call() -> Result<()> {
-        use arrow::datatypes::{DataType, Field, Schema};
-        use std::sync::Arc;
-
         let db = checked_memory_handle();
 
         db.execute_batch(
@@ -1490,7 +1487,7 @@ mod test {
         ]));
 
         let mut stmt = db.prepare("CALL test_func()")?;
-        let rbs: Vec<RecordBatch> = stmt.stream_arrow([], schema)?.collect();
+        let rbs: Vec<RecordBatch> = stmt.stream_arrow([], schema)?.collect::<Result<Vec<_>>>()?;
 
         // Verify we got results
         assert!(!rbs.is_empty(), "Expected at least one record batch");
@@ -1499,6 +1496,72 @@ mod test {
 
         let id_column = rbs[0].column(0).as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(id_column.value(0), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_stream_arrow_error_during_streaming() -> Result<()> {
+        let db = checked_memory_handle();
+
+        // We want to specifically test the case where streaming starts successfully,
+        // then an error occurs during a later fetch. A deterministic way to trigger
+        // this is to interrupt the connection mid-stream.
+        let db_interrupt = db.interrupt_handle();
+
+        let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int64, true)]));
+        let mut stmt = db.prepare("SELECT i FROM range(1000000000) t(i)")?;
+
+        let stream = stmt.stream_arrow([], schema)?;
+
+        let mut ok_batches = 0usize;
+        let mut stream = stream;
+
+        // Fetch at least one batch to ensure the stream has started.
+        let first = stream.next().expect("Expected at least one batch from stream");
+        assert!(first.is_ok(), "Expected first batch to be Ok, got: {first:?}");
+        ok_batches += 1;
+
+        // Interrupt the connection, then the next fetch should return an error (not end-of-stream).
+        db_interrupt.interrupt();
+
+        let second = stream.next().expect("Expected an error after interrupt");
+        match second {
+            Ok(_rb) => panic!("Expected streaming error after interrupt, got Ok batch"),
+            Err(e) => {
+                assert!(ok_batches > 0, "Expected at least one batch before error");
+                let msg = format!("{e}");
+                assert!(
+                    msg == "INTERRUPT Error: Interrupted!",
+                    "Expected interrupt error, got: {msg}"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn test_stream_arrow_successful_completion() -> Result<()> {
+        let db = checked_memory_handle();
+
+        // Create a table with valid data
+        db.execute_batch(
+            "CREATE TABLE test_data(value INTEGER);
+             INSERT INTO test_data SELECT i FROM range(100) AS t(i);",
+        )?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Int32, true)]));
+
+        let mut stmt = db.prepare("SELECT value FROM test_data")?;
+        let stream = stmt.stream_arrow([], schema)?;
+
+        // Collect results - all should be successful
+        let results: Result<Vec<_>> = stream.collect();
+        let batches = results?;
+
+        // Verify we got all 100 rows
+        let total_rows: usize = batches.iter().map(|rb| rb.num_rows()).sum();
+        assert_eq!(total_rows, 100);
 
         Ok(())
     }

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -162,7 +162,8 @@ impl RawStatement {
 
                 let schema = FFI_ArrowSchema::try_from(schema.deref())
                     .map_err(|e| Error::DuckDBFailure(ffi::Error::new(ffi::DuckDBError), Some(e.to_string())))?;
-                let array_data = from_ffi(arrays, &schema).expect("ok");
+                let array_data = from_ffi(arrays, &schema)
+                    .map_err(|e| Error::DuckDBFailure(ffi::Error::new(ffi::DuckDBError), Some(e.to_string())))?;
                 let struct_array = StructArray::from(array_data);
                 return Ok(Some(struct_array));
             }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -129,7 +129,7 @@ impl Statement<'_> {
     /// # use arrow::record_batch::RecordBatch;
     /// # use arrow::datatypes::SchemaRef;
     /// fn get_arrow_data(conn: &Connection, schema: SchemaRef) -> Result<Vec<RecordBatch>> {
-    ///     Ok(conn.prepare("SELECT * FROM test")?.stream_arrow([], schema)?.collect())
+    ///     conn.prepare("SELECT * FROM test")?.stream_arrow([], schema)?.collect()
     /// }
     /// ```
     ///
@@ -400,7 +400,7 @@ impl Statement<'_> {
 
     /// Get next batch records in arrow-rs in a streaming way
     #[inline]
-    pub fn stream_step(&self, schema: SchemaRef) -> Option<StructArray> {
+    pub fn stream_step(&self, schema: SchemaRef) -> Result<Option<StructArray>> {
         self.stmt.streaming_step(schema)
     }
 


### PR DESCRIPTION
When `duckdb_stream_fetch_chunk` returns null, it could indicate either end-of-stream or an error, but the code previously returned `None` in both cases, silently swallowing errors. This PR checks `duckdb_result_error` to distinguish between the two and returns `Result<Option<...>>` so callers can handle streaming failures.