### PR TITLE
Avoid unnecessary copy and allocation in FlatVector::insert

### DIFF
--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -137,10 +137,7 @@ impl Inserter<CString> for FlatVector {
 
 impl Inserter<&str> for FlatVector {
     fn insert(&self, index: usize, value: &str) {
-        let cstr = CString::new(value.as_bytes()).unwrap();
-        unsafe {
-            duckdb_vector_assign_string_element(self.ptr, index as u64, cstr.as_ptr());
-        }
+        self.insert(index, value.as_bytes());
     }
 }
 


### PR DESCRIPTION
Currently, the `&str` overload of `insert` calls [CString::new](https://doc.rust-lang.org/beta/std/ffi/struct.CString.html#method.new). This function copies the input and appends a trailing null terminator. However, the DuckDB function `duckdb_vector_assign_string_element_len`, which is used by the `&[u8]` overload of insert, does not require a null terminator, so if we use this overload we can avoid the copy and heap allocation into a CString. I observed a measurable performance improvement from this change on my workload. Since this change has no intended side effects, it seemed to me that no additional test was necessary, but please let me know if you disagree.