### PR TITLE
Add prepared_schema() to get Arrow schema without executing statement

### DIFF
--- a/crates/duckdb/src/inner_connection.rs
+++ b/crates/duckdb/src/inner_connection.rs
@@ -6,6 +6,11 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use arrow::{
+    datatypes::{Schema, SchemaRef},
+    ffi::FFI_ArrowSchema,
+};
+
 use super::{ffi, Appender, Config, Connection, Result};
 use crate::{
     error::{
@@ -225,6 +230,78 @@ impl InnerConnection {
         self.interrupt.clone()
     }
 
+    /// Extracts the Arrow schema from a prepared statement without executing it.
+    pub fn prepared_schema(&self, stmt: ffi::duckdb_prepared_statement) -> Result<Option<SchemaRef>> {
+        let ncols = unsafe { ffi::duckdb_prepared_statement_column_count(stmt) as usize };
+        if ncols == 0 {
+            return Ok(None);
+        }
+
+        let mut names: Vec<CString> = Vec::with_capacity(ncols);
+        let mut logical_types = LogicalTypesGuard::with_capacity(ncols);
+
+        for i in 0..ncols {
+            let name_ptr = unsafe { ffi::duckdb_prepared_statement_column_name(stmt, i as ffi::idx_t) };
+            if name_ptr.is_null() {
+                return Err(Error::DuckDBFailure(
+                    ffi::Error::new(ffi::DuckDBError),
+                    Some(format!("Failed to get column name for column {i}")),
+                ));
+            }
+            let name = unsafe { CStr::from_ptr(name_ptr).to_owned() };
+            unsafe { ffi::duckdb_free(name_ptr as *mut c_void) };
+            names.push(name);
+
+            let logical_type = unsafe { ffi::duckdb_prepared_statement_column_logical_type(stmt, i as ffi::idx_t) };
+            if logical_type.is_null() {
+                return Err(Error::DuckDBFailure(
+                    ffi::Error::new(ffi::DuckDBError),
+                    Some(format!("Failed to get logical type for column {i}")),
+                ));
+            }
+            logical_types.push(logical_type);
+        }
+
+        let mut arrow_options = ArrowOptionsGuard::from_connection(self.con)?;
+        let name_ptrs: Vec<*const i8> = names.iter().map(|n| n.as_ptr()).collect();
+        let mut arrow_schema = FFI_ArrowSchema::empty();
+
+        let error_data = unsafe {
+            ffi::duckdb_to_arrow_schema(
+                arrow_options.as_mut_ptr(),
+                logical_types.as_mut_ptr(),
+                name_ptrs.as_ptr() as *mut *const i8,
+                ncols as ffi::idx_t,
+                &mut arrow_schema as *mut FFI_ArrowSchema as *mut ffi::ArrowSchema,
+            )
+        };
+
+        if !error_data.is_null() {
+            let error_msg = unsafe {
+                CStr::from_ptr(ffi::duckdb_error_data_message(error_data))
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            unsafe {
+                let mut error_data = error_data;
+                ffi::duckdb_destroy_error_data(&mut error_data);
+            }
+            return Err(Error::DuckDBFailure(
+                ffi::Error::new(ffi::DuckDBError),
+                Some(format!("Failed to convert to Arrow schema: {error_msg}")),
+            ));
+        }
+
+        let schema = Schema::try_from(&arrow_schema).map_err(|e| {
+            Error::DuckDBFailure(
+                ffi::Error::new(ffi::DuckDBError),
+                Some(format!("Failed to convert FFI Arrow schema: {e}")),
+            )
+        })?;
+
+        Ok(Some(Arc::new(schema)))
+    }
+
     #[inline]
     pub fn is_autocommit(&self) -> bool {
         true
@@ -236,6 +313,58 @@ struct ExtractedStatementsGuard(ffi::duckdb_extracted_statements);
 impl Drop for ExtractedStatementsGuard {
     fn drop(&mut self) {
         unsafe { ffi::duckdb_destroy_extracted(&mut self.0) }
+    }
+}
+
+/// RAII guard for a collection of DuckDB logical types.
+struct LogicalTypesGuard(Vec<ffi::duckdb_logical_type>);
+
+impl LogicalTypesGuard {
+    fn with_capacity(cap: usize) -> Self {
+        Self(Vec::with_capacity(cap))
+    }
+
+    fn push(&mut self, lt: ffi::duckdb_logical_type) {
+        self.0.push(lt);
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut ffi::duckdb_logical_type {
+        self.0.as_mut_ptr()
+    }
+}
+
+impl Drop for LogicalTypesGuard {
+    fn drop(&mut self) {
+        for lt in &mut self.0 {
+            unsafe { ffi::duckdb_destroy_logical_type(lt) }
+        }
+    }
+}
+
+/// RAII guard for DuckDB arrow options.
+struct ArrowOptionsGuard(ffi::duckdb_arrow_options);
+
+impl ArrowOptionsGuard {
+    fn from_connection(con: ffi::duckdb_connection) -> Result<Self> {
+        let mut opts: ffi::duckdb_arrow_options = ptr::null_mut();
+        unsafe { ffi::duckdb_connection_get_arrow_options(con, &mut opts) };
+        if opts.is_null() {
+            return Err(Error::DuckDBFailure(
+                ffi::Error::new(ffi::DuckDBError),
+                Some("Failed to get arrow options from connection".to_string()),
+            ));
+        }
+        Ok(Self(opts))
+    }
+
+    fn as_mut_ptr(&mut self) -> ffi::duckdb_arrow_options {
+        self.0
+    }
+}
+
+impl Drop for ArrowOptionsGuard {
+    fn drop(&mut self) {
+        unsafe { ffi::duckdb_destroy_arrow_options(&mut self.0) }
     }
 }
 

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -653,6 +653,15 @@ impl Connection {
         self.db.borrow().is_autocommit()
     }
 
+    /// Extracts the Arrow schema from a prepared statement without executing it.
+    #[inline]
+    pub(crate) fn prepared_schema(
+        &self,
+        stmt: ffi::duckdb_prepared_statement,
+    ) -> Result<Option<arrow::datatypes::SchemaRef>> {
+        self.db.borrow().prepared_schema(stmt)
+    }
+
     /// Creates a new connection to the already-opened database.
     pub fn try_clone(&self) -> Result<Self> {
         let inner = self.db.borrow().try_clone()?;


### PR DESCRIPTION
# Summary
Adds a new `prepared_schema()` method that extracts the Arrow Schema from a prepared statement without executing it.

When using `stream_arrow()` for streaming query results, the caller must provide the schema upfront. 
Currently, the only way to obtain the schema is to execute the query first, which forces a pattern like:
```rust
// Current workaround: prepare and execute twice 
let mut stmt1 = conn.prepare(sql)?;
stmt1.execute([])?; 
let schema = stmt1.schema();
drop(stmt1); 

let mut stmt2 = conn.prepare(sql)?;  // Second preparation        
let stream = stmt2.stream_arrow([], schema)?;
```                                                                                                                                
                                                                                                                                                                                
This doubles the preparation cost (parsing, planning, optimization) for every streaming query.
With `prepared_schema()`, the schema can be obtained directly from the prepared statement:                                                                                                                                                                                                                                                           
```rust
// New: single preparation                                                                                                                                                            
let mut stmt = conn.prepare(sql)?;                                                                                                                                                    
let schema = stmt.prepared_schema()?.unwrap();                                                                                                                                        
let stream = stmt.stream_arrow([], schema)?;           
```