### PR TITLE
Allow to write extension using a single crate dependency

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -69,8 +69,8 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
                 /// # Safety
                 ///
                 /// Internal Entrypoint for error handling
-                pub unsafe fn #c_entrypoint_internal(info: ::libduckdb_sys::duckdb_extension_info, access: *const ::libduckdb_sys::duckdb_extension_access) -> ::std::result::Result<bool, Box<dyn ::std::error::Error>> {
-                    let have_api_struct = ::libduckdb_sys::duckdb_rs_extension_api_init(info, access, #minimum_duckdb_version).unwrap();
+                pub unsafe fn #c_entrypoint_internal(info: ::duckdb::ffi::duckdb_extension_info, access: *const ::duckdb::ffi::duckdb_extension_access) -> ::std::result::Result<bool, Box<dyn ::std::error::Error>> {
+                    let have_api_struct = ::duckdb::ffi::duckdb_rs_extension_api_init(info, access, #minimum_duckdb_version).unwrap();
 
                     if !have_api_struct {
                         // initialization failed to return an api struct, likely due to an API version mismatch, we can simply return here
@@ -78,7 +78,7 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
                     }
 
                     // TODO: handle error here?
-                    let db: ::libduckdb_sys::duckdb_database = *(*access).get_database.unwrap()(info);
+                    let db: ::duckdb::ffi::duckdb_database = *(*access).get_database.unwrap()(info);
                     let connection = ::duckdb::Connection::open_from_raw(db.cast())?;
 
                     #prefixed_original_function(connection)?;
@@ -90,7 +90,7 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
                 ///
                 /// Entrypoint that will be called by DuckDB
                 #[no_mangle]
-                pub unsafe extern "C" fn #c_entrypoint(info: ::libduckdb_sys::duckdb_extension_info, access: *const ::libduckdb_sys::duckdb_extension_access) -> bool {
+                pub unsafe extern "C" fn #c_entrypoint(info: ::duckdb::ffi::duckdb_extension_info, access: *const ::duckdb::ffi::duckdb_extension_access) -> bool {
                     let init_result = #c_entrypoint_internal(info, access);
 
                     if let Err(x) = init_result {


### PR DESCRIPTION
By changing macro to use `::duckdb::ffi::*` instead of `::libduckdb_sys::*`

Extension authors just need:

```toml
[dependencies]
duckdb = { version = "=1.4.4", features = ["loadable-extension"] }
```