### PR TITLE
Remove stale copyright years from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,6 @@ Join our [Discord](https://discord.gg/tcvwpjfnZx) to chat with the community in 
 
 ## License
 
-Copyright 2021-2025 Stichting DuckDB Foundation
+Copyright (c) Stichting DuckDB Foundation
 
 Licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
Copyright notices do not need years. One less thing to worry about.

Follow-up to https://github.com/duckdb/duckdb-rs/pull/672