### PR TITLE
Fix MSRV CI: disable cargo bin caching

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -104,6 +104,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-bin: false
       - uses: taiki-e/install-action@cargo-binstall
       - run: cargo binstall --no-confirm cargo-msrv
       - run: cargo msrv verify --path crates/duckdb


### PR DESCRIPTION
`Swatinem/rust-cache` cleans cargo-msrv from `~/.cargo/bin` before saving but keeps stale `.crates.toml` metadata. On restore, `binstall` sees "already installed" and skips, but the binary is gone.

CI failure: https://github.com/duckdb/duckdb-rs/actions/runs/22623246023/job/65592256148

Follow-up to #687 