### PR TITLE
fix(loadable-macros): eliminate .unwrap() panic paths in generated extern "C" entry point

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -71,15 +71,18 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
                 /// Internal Entrypoint for error handling
                 pub unsafe fn #c_entrypoint_internal(info: ::duckdb::ffi::duckdb_extension_info, access: *const ::duckdb::ffi::duckdb_extension_access) -> ::std::result::Result<bool, Box<dyn ::std::error::Error>> {
                     unsafe {
-                        let have_api_struct = ::duckdb::ffi::duckdb_rs_extension_api_init(info, access, #minimum_duckdb_version).unwrap();
+                        let have_api_struct = ::duckdb::ffi::duckdb_rs_extension_api_init(info, access, #minimum_duckdb_version)
+                            .map_err(|e| -> ::std::boxed::Box<dyn ::std::error::Error> { e.into() })?;
 
                         if !have_api_struct {
                             // initialization failed to return an api struct, likely due to an API version mismatch, we can simply return here
                             return Ok(false);
                         }
 
-                        // TODO: handle error here?
-                        let db: ::duckdb::ffi::duckdb_database = *(*access).get_database.unwrap()(info);
+                        let get_database = (*access)
+                            .get_database
+                            .ok_or("get_database function pointer is null in duckdb_extension_access")?;
+                        let db: ::duckdb::ffi::duckdb_database = *get_database(info);
                         let connection = ::duckdb::Connection::open_from_raw(db.cast())?;
 
                         #prefixed_original_function(connection)?;
@@ -96,22 +99,24 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
                     unsafe {
                         let init_result = #c_entrypoint_internal(info, access);
 
-                        if let Err(x) = init_result {
-                            let error_c_string = ::std::ffi::CString::new(x.to_string());
-
-                            match error_c_string {
-                                Ok(e) => {
-                                    (*access).set_error.unwrap()(info, e.as_ptr());
-                                },
-                                Err(_e) => {
-                                    let error_alloc_failure = c"An error occured but the extension failed to allocate memory for an error string";
-                                    (*access).set_error.unwrap()(info, error_alloc_failure.as_ptr());
+                        match init_result {
+                            ::std::result::Result::Ok(v) => v,
+                            ::std::result::Result::Err(x) => {
+                                if let ::std::option::Option::Some(set_error_fn) = (*access).set_error {
+                                    let error_c_string = ::std::ffi::CString::new(x.to_string());
+                                    match error_c_string {
+                                        Ok(e) => {
+                                            set_error_fn(info, e.as_ptr());
+                                        },
+                                        Err(_e) => {
+                                            let error_alloc_failure = c"An error occured but the extension failed to allocate memory for an error string";
+                                            set_error_fn(info, error_alloc_failure.as_ptr());
+                                        }
+                                    }
                                 }
+                                false
                             }
-                            return false;
                         }
-
-                        init_result.unwrap()
                     }
                 }
 


### PR DESCRIPTION
## Problem

The `duckdb_entrypoint_c_api` macro generates code with three `.unwrap()` call sites that can panic inside or on the call stack below an `extern "C"` function:

| Site | Location |
|---|---|
| `duckdb_rs_extension_api_init(...).unwrap()` | `_internal` helper, called from `extern "C"` |
| `(*access).get_database.unwrap()` | same |
| `(*access).set_error.unwrap()` | directly inside `extern "C"` |

Per the [Rust Reference](https://doc.rust-lang.org/reference/items/functions.html#extern-function-qualifier):

> Unwinding into Rust from foreign code or unwinding out of Rust into foreign
> code is **undefined behavior**.

With the default `panic = "unwind"` strategy — which most users of this macro
will have, since `panic = "abort"` is neither required nor documented — any of
these reaching `None` causes UB at the FFI boundary.

## Discovery

This was identified while developing [duckdb-behavioral](https://github.com/tomtom215/duckdb-behavioral), a Rust
DuckDB community extension. Debugging extension load failures led to rewriting
the entry point by hand, at which point `if let Some(...)` and `.ok_or()?`
were used throughout as natural safe alternatives. This PR takes that pattern
upstream to the macro so all users of `duckdb_entrypoint_c_api` get the same
protection automatically.

## Fix

- Replace `duckdb_rs_extension_api_init(...).unwrap()` with
  `.map_err(|e| -> Box<dyn Error> { e.into() })?` so API init errors
  propagate through the `Result` return of `_internal`.
- Replace `get_database.unwrap()` with `.ok_or("...")?` for the same reason.
- Replace the `set_error.unwrap()` sites and trailing `init_result.unwrap()`
  with a `match` that calls `set_error` only when the function pointer is
  `Some`, eliminating all panic paths at the `extern "C"` boundary.

Fully-qualified `::std::result::Result` and `::std::option::Option` paths are
used to match the style already in the generated code and avoid namespace
collisions in user crates.

## Testing

```bash
cargo test -p duckdb-loadable-macros
cargo clippy -p duckdb-loadable-macros --all-targets
cargo fmt --package duckdb-loadable-macros -- --check
```

The generated code is not directly unit-testable, but the fix compiles cleanly
and eliminates every `.unwrap()` path that could reach the FFI boundary.
