### PR TITLE
Update Rust to 1.94

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93"
+channel = "1.94"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/