### PR TITLE
duckdb_entrypoint_c_api: suppress missing_safety_doc lint

### DIFF
--- a/crates/duckdb-loadable-macros/src/lib.rs
+++ b/crates/duckdb-loadable-macros/src/lib.rs
@@ -123,6 +123,7 @@ pub fn duckdb_entrypoint_c_api(attr: TokenStream, item: TokenStream) -> TokenStr
                     }
                 }
 
+                #[allow(clippy::missing_safety_doc)]
                 #func
             }
             .into()


### PR DESCRIPTION
The duckdb_entrypoint_c_api macro re-emits the user's function unchanged, which triggers `clippy::missing_safety_doc`. Since the macro controls the unsafe boundary, users shouldn't need to document it themselves.