### PR TITLE
Tie vector lifetimes to DataChunkHandle

### DIFF
--- a/crates/duckdb/src/core/data_chunk.rs
+++ b/crates/duckdb/src/core/data_chunk.rs
@@ -31,16 +31,14 @@ impl DataChunkHandle {
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid `duckdb_data_chunk` that remains allocated and
-    /// usable for the full lifetime of the returned handle. The caller must
-    /// ensure DuckDB does not destroy the chunk, free any column vectors
-    /// reachable from it, or concurrently mutate the same chunk/vector state
-    /// while this handle or any vectors derived from it are in use.
-    ///
-    /// TODO(#673 follow-up): this handle's `flat_vector` / `list_vector` /
-    /// `array_vector` / `struct_vector` accessors currently take `&self` and
-    /// return writable wrappers, so safe code can obtain two wrappers over
-    /// the same column and produce aliased `&mut [T]` slices.
+    /// `ptr` must be a valid `duckdb_data_chunk` that stays allocated and
+    /// unmutated by other code for the full lifetime of the returned handle
+    /// and any vectors derived from it.
+    //
+    // Known aliasing hole (#673 follow-up): `flat_vector` / `list_vector` /
+    // `array_vector` / `struct_vector` take `&self`, so safe code can get two
+    // writable wrappers over the same column and produce aliased `&mut [T]`
+    // slices.
     #[allow(dead_code)] // used only when `vtab` / `vscalar` features are enabled
     pub(crate) unsafe fn new_unowned(ptr: duckdb_data_chunk) -> Self {
         Self { ptr, owned: false }

--- a/crates/duckdb/src/core/data_chunk.rs
+++ b/crates/duckdb/src/core/data_chunk.rs
@@ -41,23 +41,23 @@ impl DataChunkHandle {
     }
 
     /// Get the vector at the specific column index: `idx`.
-    pub fn flat_vector(&self, idx: usize) -> FlatVector {
-        FlatVector::from(unsafe { duckdb_data_chunk_get_vector(self.ptr, idx as u64) })
+    pub fn flat_vector(&self, idx: usize) -> FlatVector<'_> {
+        unsafe { FlatVector::from_raw(duckdb_data_chunk_get_vector(self.ptr, idx as u64)) }
     }
 
     /// Get a list vector from the column index.
-    pub fn list_vector(&self, idx: usize) -> ListVector {
-        ListVector::from(unsafe { duckdb_data_chunk_get_vector(self.ptr, idx as u64) })
+    pub fn list_vector(&self, idx: usize) -> ListVector<'_> {
+        unsafe { ListVector::from_raw(duckdb_data_chunk_get_vector(self.ptr, idx as u64)) }
     }
 
     /// Get a array vector from the column index.
-    pub fn array_vector(&self, idx: usize) -> ArrayVector {
-        ArrayVector::from(unsafe { duckdb_data_chunk_get_vector(self.ptr, idx as u64) })
+    pub fn array_vector(&self, idx: usize) -> ArrayVector<'_> {
+        unsafe { ArrayVector::from_raw(duckdb_data_chunk_get_vector(self.ptr, idx as u64)) }
     }
 
     /// Get struct vector at the column index: `idx`.
-    pub fn struct_vector(&self, idx: usize) -> StructVector {
-        StructVector::from(unsafe { duckdb_data_chunk_get_vector(self.ptr, idx as u64) })
+    pub fn struct_vector(&self, idx: usize) -> StructVector<'_> {
+        unsafe { StructVector::from_raw(duckdb_data_chunk_get_vector(self.ptr, idx as u64)) }
     }
 
     /// Set the size of the data chunk

--- a/crates/duckdb/src/core/data_chunk.rs
+++ b/crates/duckdb/src/core/data_chunk.rs
@@ -26,7 +26,22 @@ impl Drop for DataChunkHandle {
 }
 
 impl DataChunkHandle {
-    #[allow(dead_code)]
+    /// Wrap a `duckdb_data_chunk` pointer owned elsewhere (e.g. by a DuckDB
+    /// callback frame) without taking ownership.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid `duckdb_data_chunk` that remains allocated and
+    /// usable for the full lifetime of the returned handle. The caller must
+    /// ensure DuckDB does not destroy the chunk, free any column vectors
+    /// reachable from it, or concurrently mutate the same chunk/vector state
+    /// while this handle or any vectors derived from it are in use.
+    ///
+    /// TODO(#673 follow-up): this handle's `flat_vector` / `list_vector` /
+    /// `array_vector` / `struct_vector` accessors currently take `&self` and
+    /// return writable wrappers, so safe code can obtain two wrappers over
+    /// the same column and produce aliased `&mut [T]` slices.
+    #[allow(dead_code)] // used only when `vtab` / `vscalar` features are enabled
     pub(crate) unsafe fn new_unowned(ptr: duckdb_data_chunk) -> Self {
         Self { ptr, owned: false }
     }

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, slice};
+use std::{ffi::CString, marker::PhantomData, slice};
 
 use libduckdb_sys::{
     DuckDbString, duckdb_array_type_array_size, duckdb_array_vector_get_child, duckdb_validity_row_is_valid,
@@ -14,24 +14,37 @@ use crate::ffi::{
     duckdb_vector_get_validity, duckdb_vector_size,
 };
 
-/// A flat vector
-pub struct FlatVector {
+/// A flat vector borrowed from a [`DataChunkHandle`].
+///
+/// The `'a` lifetime ties the vector to the chunk it was obtained from,
+/// preventing the chunk from being dropped while the vector is still alive
+/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+pub struct FlatVector<'a> {
     ptr: duckdb_vector,
     capacity: usize,
+    _phantom: PhantomData<&'a ()>,
 }
 
-impl From<duckdb_vector> for FlatVector {
-    fn from(ptr: duckdb_vector) -> Self {
+impl<'a> FlatVector<'a> {
+    /// Build a `FlatVector` from a raw `duckdb_vector` pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
+    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
             capacity: unsafe { duckdb_vector_size() as usize },
+            _phantom: PhantomData,
         }
     }
-}
 
-impl FlatVector {
     fn with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
-        Self { ptr, capacity }
+        Self {
+            ptr,
+            capacity,
+            _phantom: PhantomData,
+        }
     }
 
     /// Returns the capacity of the vector
@@ -109,7 +122,7 @@ pub trait Inserter<T> {
     fn insert(&self, index: usize, value: T);
 }
 
-impl Inserter<CString> for FlatVector {
+impl Inserter<CString> for FlatVector<'_> {
     fn insert(&self, index: usize, value: CString) {
         unsafe {
             duckdb_vector_assign_string_element(self.ptr, index as u64, value.as_ptr());
@@ -117,19 +130,19 @@ impl Inserter<CString> for FlatVector {
     }
 }
 
-impl Inserter<&str> for FlatVector {
+impl Inserter<&str> for FlatVector<'_> {
     fn insert(&self, index: usize, value: &str) {
         self.insert(index, value.as_bytes());
     }
 }
 
-impl Inserter<&String> for FlatVector {
+impl Inserter<&String> for FlatVector<'_> {
     fn insert(&self, index: usize, value: &String) {
         self.insert(index, value.as_str());
     }
 }
 
-impl Inserter<&[u8]> for FlatVector {
+impl Inserter<&[u8]> for FlatVector<'_> {
     fn insert(&self, index: usize, value: &[u8]) {
         let value_size = value.len();
         unsafe {
@@ -144,27 +157,53 @@ impl Inserter<&[u8]> for FlatVector {
     }
 }
 
-impl Inserter<&Vec<u8>> for FlatVector {
+impl Inserter<&Vec<u8>> for FlatVector<'_> {
     fn insert(&self, index: usize, value: &Vec<u8>) {
         self.insert(index, value.as_slice());
     }
 }
 
-/// A list vector.
-pub struct ListVector {
+/// A list vector borrowed from a [`DataChunkHandle`].
+///
+/// The `'a` lifetime ties the vector to the chunk it was obtained from,
+/// preventing the chunk from being dropped while the vector is still alive
+/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+///
+/// Regression test for the use-after-free in issue #673: a `ListVector`
+/// must not be allowed to outlive its parent `DataChunkHandle`.
+///
+/// ```compile_fail,E0597
+/// use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
+///
+/// let vec;
+/// {
+///     let list_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
+///     let chunk = DataChunkHandle::new(&[list_type]);
+///     chunk.set_len(1);
+///     let mut v = chunk.list_vector(0);
+///     v.set_entry(0, 0, 2);
+///     vec = v;
+/// }
+/// // chunk dropped — borrow checker must reject the next line.
+/// let _ = vec.get_entry(0);
+/// ```
+pub struct ListVector<'a> {
     /// ListVector does not own the vector pointer.
-    entries: FlatVector,
+    entries: FlatVector<'a>,
 }
 
-impl From<duckdb_vector> for ListVector {
-    fn from(ptr: duckdb_vector) -> Self {
+impl<'a> ListVector<'a> {
+    /// Build a `ListVector` from a raw `duckdb_vector` pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
+    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
-            entries: FlatVector::from(ptr),
+            entries: unsafe { FlatVector::from_raw(ptr) },
         }
     }
-}
 
-impl ListVector {
     /// Returns the number of entries in the list vector.
     pub fn len(&self) -> usize {
         unsafe { duckdb_list_vector_get_size(self.entries.ptr) as usize }
@@ -177,25 +216,25 @@ impl ListVector {
 
     /// Returns the child vector.
     // TODO: not ideal interface. Where should we keep capacity.
-    pub fn child(&self, capacity: usize) -> FlatVector {
+    pub fn child(&self, capacity: usize) -> FlatVector<'a> {
         self.reserve(capacity);
         FlatVector::with_capacity(unsafe { duckdb_list_vector_get_child(self.entries.ptr) }, capacity)
     }
 
     /// Take the child as [StructVector].
-    pub fn struct_child(&self, capacity: usize) -> StructVector {
+    pub fn struct_child(&self, capacity: usize) -> StructVector<'a> {
         self.reserve(capacity);
-        StructVector::from(unsafe { duckdb_list_vector_get_child(self.entries.ptr) })
+        unsafe { StructVector::from_raw(duckdb_list_vector_get_child(self.entries.ptr)) }
     }
 
     /// Take the child as [ArrayVector].
-    pub fn array_child(&self) -> ArrayVector {
-        ArrayVector::from(unsafe { duckdb_list_vector_get_child(self.entries.ptr) })
+    pub fn array_child(&self) -> ArrayVector<'a> {
+        unsafe { ArrayVector::from_raw(duckdb_list_vector_get_child(self.entries.ptr)) }
     }
 
     /// Take the child as [ListVector].
-    pub fn list_child(&self) -> Self {
-        Self::from(unsafe { duckdb_list_vector_get_child(self.entries.ptr) })
+    pub fn list_child(&self) -> ListVector<'a> {
+        unsafe { ListVector::from_raw(duckdb_list_vector_get_child(self.entries.ptr)) }
     }
 
     /// Set primitive data to the child node.
@@ -240,18 +279,29 @@ impl ListVector {
     }
 }
 
-/// A array vector. (fixed-size list)
-pub struct ArrayVector {
+/// A array vector (fixed-size list) borrowed from a [`DataChunkHandle`].
+///
+/// The `'a` lifetime ties the vector to the chunk it was obtained from,
+/// preventing the chunk from being dropped while the vector is still alive
+/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+pub struct ArrayVector<'a> {
     ptr: duckdb_vector,
+    _phantom: PhantomData<&'a ()>,
 }
 
-impl From<duckdb_vector> for ArrayVector {
-    fn from(ptr: duckdb_vector) -> Self {
-        Self { ptr }
+impl<'a> ArrayVector<'a> {
+    /// Build an `ArrayVector` from a raw `duckdb_vector` pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
+    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+        Self {
+            ptr,
+            _phantom: PhantomData,
+        }
     }
-}
 
-impl ArrayVector {
     /// Get the logical type of this ArrayVector.
     pub fn logical_type(&self) -> LogicalTypeHandle {
         unsafe { LogicalTypeHandle::new(duckdb_vector_get_column_type(self.ptr)) }
@@ -266,7 +316,7 @@ impl ArrayVector {
     /// Returns the child vector.
     /// capacity should be a multiple of the array size.
     // TODO: not ideal interface. Where should we keep count.
-    pub fn child(&self, capacity: usize) -> FlatVector {
+    pub fn child(&self, capacity: usize) -> FlatVector<'a> {
         FlatVector::with_capacity(unsafe { duckdb_array_vector_get_child(self.ptr) }, capacity)
     }
 
@@ -285,20 +335,31 @@ impl ArrayVector {
     }
 }
 
-/// A struct vector.
-pub struct StructVector {
+/// A struct vector borrowed from a [`DataChunkHandle`].
+///
+/// The `'a` lifetime ties the vector to the chunk it was obtained from,
+/// preventing the chunk from being dropped while the vector is still alive
+/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+pub struct StructVector<'a> {
     ptr: duckdb_vector,
+    _phantom: PhantomData<&'a ()>,
 }
 
-impl From<duckdb_vector> for StructVector {
-    fn from(ptr: duckdb_vector) -> Self {
-        Self { ptr }
+impl<'a> StructVector<'a> {
+    /// Build a `StructVector` from a raw `duckdb_vector` pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
+    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+        Self {
+            ptr,
+            _phantom: PhantomData,
+        }
     }
-}
 
-impl StructVector {
     /// Returns the child by idx in the list vector.
-    pub fn child(&self, idx: usize, capacity: usize) -> FlatVector {
+    pub fn child(&self, idx: usize, capacity: usize) -> FlatVector<'a> {
         FlatVector::with_capacity(
             unsafe { duckdb_struct_vector_get_child(self.ptr, idx as u64) },
             capacity,
@@ -306,18 +367,18 @@ impl StructVector {
     }
 
     /// Take the child as [StructVector].
-    pub fn struct_vector_child(&self, idx: usize) -> Self {
-        Self::from(unsafe { duckdb_struct_vector_get_child(self.ptr, idx as u64) })
+    pub fn struct_vector_child(&self, idx: usize) -> StructVector<'a> {
+        unsafe { StructVector::from_raw(duckdb_struct_vector_get_child(self.ptr, idx as u64)) }
     }
 
     /// Take the child as [ListVector].
-    pub fn list_vector_child(&self, idx: usize) -> ListVector {
-        ListVector::from(unsafe { duckdb_struct_vector_get_child(self.ptr, idx as u64) })
+    pub fn list_vector_child(&self, idx: usize) -> ListVector<'a> {
+        unsafe { ListVector::from_raw(duckdb_struct_vector_get_child(self.ptr, idx as u64)) }
     }
 
     /// Take the child as [ArrayVector].
-    pub fn array_vector_child(&self, idx: usize) -> ArrayVector {
-        ArrayVector::from(unsafe { duckdb_struct_vector_get_child(self.ptr, idx as u64) })
+    pub fn array_vector_child(&self, idx: usize) -> ArrayVector<'a> {
+        unsafe { ArrayVector::from_raw(duckdb_struct_vector_get_child(self.ptr, idx as u64)) }
     }
 
     /// Get the logical type of this struct vector.

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -1,3 +1,13 @@
+//! Borrowed vector wrappers over [`duckdb_vector`].
+//!
+//! Each wrapper type carries a lifetime `'a`. When obtained via a
+//! [`DataChunkHandle`][crate::core::DataChunkHandle] accessor, `'a` is
+//! bound to the chunk so the wrapper cannot outlive it. When built via
+//! one of the `unsafe fn from_raw` constructors (including the raw
+//! `duckdb_vector` path used by `vtab::arrow`), `'a` is caller-chosen and
+//! must not exceed the DuckDB vector's actual validity — that path does not
+//! track liveness in the type system.
+
 use std::{ffi::CString, marker::PhantomData, slice};
 
 use libduckdb_sys::{
@@ -14,14 +24,8 @@ use crate::ffi::{
     duckdb_vector_get_validity, duckdb_vector_size,
 };
 
-/// A flat vector borrowed from a [`crate::core::DataChunkHandle`].
-///
-/// This is the plain contiguous DuckDB vector representation for scalar rows.
-/// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive.
-/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
-/// handle used to construct the wrapper, so callers must ensure the underlying
-/// DuckDB vector itself outlives the wrapper.
+/// A flat (contiguous, scalar-row) vector borrowed from a
+/// [`DataChunkHandle`][crate::core::DataChunkHandle].
 pub struct FlatVector<'a> {
     ptr: duckdb_vector,
     capacity: usize,
@@ -29,11 +33,10 @@ pub struct FlatVector<'a> {
 }
 
 impl<'a> FlatVector<'a> {
-    /// Build a `FlatVector` from a raw `duckdb_vector` pointer.
+    /// Wrap a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
-    /// entirety of the chosen lifetime `'a`.
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
     pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
@@ -166,22 +169,13 @@ impl Inserter<&Vec<u8>> for FlatVector<'_> {
     }
 }
 
-/// A list vector borrowed from a [`crate::core::DataChunkHandle`].
+/// A list vector borrowed from a [`DataChunkHandle`][crate::core::DataChunkHandle].
 ///
-/// It stores list entry offsets and lengths, with the actual elements living in
-/// a separate child vector.
-/// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive.
-/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
-/// handle used to construct the wrapper, so callers must ensure the underlying
-/// DuckDB vector itself outlives the wrapper.
+/// Stores list entry offsets and lengths; elements live in a separate child vector.
 ///
-/// Regression test for the use-after-free in issue #673: a `ListVector`
-/// must not be allowed to outlive its parent `DataChunkHandle`.
-/// The `compile_fail,E0597` annotation pins the expected borrow-checker error,
-/// since accepting this pattern again would reopen that soundness bug.
+/// Regression guard for #673 — a `ListVector` must not outlive its parent chunk:
 ///
-/// ```compile_fail,E0597
+/// ```compile_fail
 /// use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
 ///
 /// let vec;
@@ -192,7 +186,7 @@ impl Inserter<&Vec<u8>> for FlatVector<'_> {
 ///     let v = chunk.list_vector(0);
 ///     vec = v;
 /// }
-/// // chunk dropped; E0597 proves the wrapper cannot escape this scope.
+/// // chunk goes out of scope here; borrow checking rejects the outer use.
 /// let _ = vec.get_entry(0);
 /// ```
 pub struct ListVector<'a> {
@@ -201,11 +195,10 @@ pub struct ListVector<'a> {
 }
 
 impl<'a> ListVector<'a> {
-    /// Build a `ListVector` from a raw `duckdb_vector` pointer.
+    /// Wrap a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
-    /// entirety of the chosen lifetime `'a`.
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
     pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             entries: unsafe { FlatVector::from_raw(ptr) },
@@ -287,27 +280,20 @@ impl<'a> ListVector<'a> {
     }
 }
 
-/// An array vector (fixed-size list) borrowed from a
-/// [`crate::core::DataChunkHandle`].
+/// A fixed-size list vector borrowed from a
+/// [`DataChunkHandle`][crate::core::DataChunkHandle].
 ///
-/// It exposes a fixed-width list type whose child storage is laid out
-/// contiguously for all rows.
-/// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive.
-/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
-/// handle used to construct the wrapper, so callers must ensure the underlying
-/// DuckDB vector itself outlives the wrapper.
+/// Exposes a fixed-width list whose child storage is contiguous across all rows.
 pub struct ArrayVector<'a> {
     ptr: duckdb_vector,
     _phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> ArrayVector<'a> {
-    /// Build an `ArrayVector` from a raw `duckdb_vector` pointer.
+    /// Wrap a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
-    /// entirety of the chosen lifetime `'a`.
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
     pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
@@ -348,25 +334,19 @@ impl<'a> ArrayVector<'a> {
     }
 }
 
-/// A struct vector borrowed from a [`crate::core::DataChunkHandle`].
+/// A struct vector borrowed from a [`DataChunkHandle`][crate::core::DataChunkHandle].
 ///
-/// It groups one child vector per struct field, all sharing the same row count.
-/// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive.
-/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
-/// handle used to construct the wrapper, so callers must ensure the underlying
-/// DuckDB vector itself outlives the wrapper.
+/// Groups one child vector per struct field, all sharing the same row count.
 pub struct StructVector<'a> {
     ptr: duckdb_vector,
     _phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> StructVector<'a> {
-    /// Build a `StructVector` from a raw `duckdb_vector` pointer.
+    /// Wrap a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
-    /// entirety of the chosen lifetime `'a`.
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
     pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, ffi::CString, slice};
+use std::{ffi::CString, slice};
 
 use libduckdb_sys::{
     DuckDbString, duckdb_array_type_array_size, duckdb_array_vector_get_child, duckdb_validity_row_is_valid,
@@ -14,14 +14,6 @@ use crate::ffi::{
     duckdb_vector_get_validity, duckdb_vector_size,
 };
 
-/// Vector trait.
-pub trait Vector {
-    /// Returns a reference to the underlying Any type that this trait object
-    fn as_any(&self) -> &dyn Any;
-    /// Returns a mutable reference to the underlying Any type that this trait object
-    fn as_mut_any(&mut self) -> &mut dyn Any;
-}
-
 /// A flat vector
 pub struct FlatVector {
     ptr: duckdb_vector,
@@ -34,16 +26,6 @@ impl From<duckdb_vector> for FlatVector {
             ptr,
             capacity: unsafe { duckdb_vector_size() as usize },
         }
-    }
-}
-
-impl Vector for FlatVector {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_mut_any(&mut self) -> &mut dyn Any {
-        self
     }
 }
 

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -32,11 +32,9 @@ impl<'a> FlatVector<'a> {
     /// Build a `FlatVector` from a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
-    /// live wrapper may expose overlapping mutable access to the same
-    /// `duckdb_vector` for that lifetime.
-    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
+    /// entirety of the chosen lifetime `'a`.
+    pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
             capacity: unsafe { duckdb_vector_size() as usize },
@@ -206,11 +204,9 @@ impl<'a> ListVector<'a> {
     /// Build a `ListVector` from a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
-    /// live wrapper may expose overlapping mutable access to the same
-    /// `duckdb_vector` for that lifetime.
-    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
+    /// entirety of the chosen lifetime `'a`.
+    pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             entries: unsafe { FlatVector::from_raw(ptr) },
         }
@@ -310,11 +306,9 @@ impl<'a> ArrayVector<'a> {
     /// Build an `ArrayVector` from a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
-    /// live wrapper may expose overlapping mutable access to the same
-    /// `duckdb_vector` for that lifetime.
-    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
+    /// entirety of the chosen lifetime `'a`.
+    pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
             _phantom: PhantomData,
@@ -371,11 +365,9 @@ impl<'a> StructVector<'a> {
     /// Build a `StructVector` from a raw `duckdb_vector` pointer.
     ///
     /// # Safety
-    /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
-    /// live wrapper may expose overlapping mutable access to the same
-    /// `duckdb_vector` for that lifetime.
-    pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for the
+    /// entirety of the chosen lifetime `'a`.
+    pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
             _phantom: PhantomData,

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -17,8 +17,7 @@ use crate::ffi::{
 /// A flat vector borrowed from a [`DataChunkHandle`].
 ///
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive
-/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+/// preventing the chunk from being dropped while the vector is still alive.
 pub struct FlatVector<'a> {
     ptr: duckdb_vector,
     capacity: usize,
@@ -166,8 +165,7 @@ impl Inserter<&Vec<u8>> for FlatVector<'_> {
 /// A list vector borrowed from a [`DataChunkHandle`].
 ///
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive
-/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+/// preventing the chunk from being dropped while the vector is still alive.
 ///
 /// Regression test for the use-after-free in issue #673: a `ListVector`
 /// must not be allowed to outlive its parent `DataChunkHandle`.
@@ -279,11 +277,10 @@ impl<'a> ListVector<'a> {
     }
 }
 
-/// A array vector (fixed-size list) borrowed from a [`DataChunkHandle`].
+/// An array vector (fixed-size list) borrowed from a [`DataChunkHandle`].
 ///
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive
-/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+/// preventing the chunk from being dropped while the vector is still alive.
 pub struct ArrayVector<'a> {
     ptr: duckdb_vector,
     _phantom: PhantomData<&'a ()>,
@@ -338,8 +335,7 @@ impl<'a> ArrayVector<'a> {
 /// A struct vector borrowed from a [`DataChunkHandle`].
 ///
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
-/// preventing the chunk from being dropped while the vector is still alive
-/// (see <https://github.com/duckdb/duckdb-rs/issues/673>).
+/// preventing the chunk from being dropped while the vector is still alive.
 pub struct StructVector<'a> {
     ptr: duckdb_vector,
     _phantom: PhantomData<&'a ()>,

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -14,10 +14,14 @@ use crate::ffi::{
     duckdb_vector_get_validity, duckdb_vector_size,
 };
 
-/// A flat vector borrowed from a [`DataChunkHandle`].
+/// A flat vector borrowed from a [`crate::core::DataChunkHandle`].
 ///
+/// This is the plain contiguous DuckDB vector representation for scalar rows.
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
 /// preventing the chunk from being dropped while the vector is still alive.
+/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
+/// handle used to construct the wrapper, so callers must ensure the underlying
+/// DuckDB vector itself outlives the wrapper.
 pub struct FlatVector<'a> {
     ptr: duckdb_vector,
     capacity: usize,
@@ -29,7 +33,9 @@ impl<'a> FlatVector<'a> {
     ///
     /// # Safety
     /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
+    /// live wrapper may expose overlapping mutable access to the same
+    /// `duckdb_vector` for that lifetime.
     pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
@@ -162,13 +168,20 @@ impl Inserter<&Vec<u8>> for FlatVector<'_> {
     }
 }
 
-/// A list vector borrowed from a [`DataChunkHandle`].
+/// A list vector borrowed from a [`crate::core::DataChunkHandle`].
 ///
+/// It stores list entry offsets and lengths, with the actual elements living in
+/// a separate child vector.
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
 /// preventing the chunk from being dropped while the vector is still alive.
+/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
+/// handle used to construct the wrapper, so callers must ensure the underlying
+/// DuckDB vector itself outlives the wrapper.
 ///
 /// Regression test for the use-after-free in issue #673: a `ListVector`
 /// must not be allowed to outlive its parent `DataChunkHandle`.
+/// The `compile_fail,E0597` annotation pins the expected borrow-checker error,
+/// since accepting this pattern again would reopen that soundness bug.
 ///
 /// ```compile_fail,E0597
 /// use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
@@ -178,11 +191,10 @@ impl Inserter<&Vec<u8>> for FlatVector<'_> {
 ///     let list_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
 ///     let chunk = DataChunkHandle::new(&[list_type]);
 ///     chunk.set_len(1);
-///     let mut v = chunk.list_vector(0);
-///     v.set_entry(0, 0, 2);
+///     let v = chunk.list_vector(0);
 ///     vec = v;
 /// }
-/// // chunk dropped — borrow checker must reject the next line.
+/// // chunk dropped; E0597 proves the wrapper cannot escape this scope.
 /// let _ = vec.get_entry(0);
 /// ```
 pub struct ListVector<'a> {
@@ -195,7 +207,9 @@ impl<'a> ListVector<'a> {
     ///
     /// # Safety
     /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
+    /// live wrapper may expose overlapping mutable access to the same
+    /// `duckdb_vector` for that lifetime.
     pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             entries: unsafe { FlatVector::from_raw(ptr) },
@@ -277,10 +291,16 @@ impl<'a> ListVector<'a> {
     }
 }
 
-/// An array vector (fixed-size list) borrowed from a [`DataChunkHandle`].
+/// An array vector (fixed-size list) borrowed from a
+/// [`crate::core::DataChunkHandle`].
 ///
+/// It exposes a fixed-width list type whose child storage is laid out
+/// contiguously for all rows.
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
 /// preventing the chunk from being dropped while the vector is still alive.
+/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
+/// handle used to construct the wrapper, so callers must ensure the underlying
+/// DuckDB vector itself outlives the wrapper.
 pub struct ArrayVector<'a> {
     ptr: duckdb_vector,
     _phantom: PhantomData<&'a ()>,
@@ -291,7 +311,9 @@ impl<'a> ArrayVector<'a> {
     ///
     /// # Safety
     /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
+    /// live wrapper may expose overlapping mutable access to the same
+    /// `duckdb_vector` for that lifetime.
     pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,
@@ -332,10 +354,14 @@ impl<'a> ArrayVector<'a> {
     }
 }
 
-/// A struct vector borrowed from a [`DataChunkHandle`].
+/// A struct vector borrowed from a [`crate::core::DataChunkHandle`].
 ///
+/// It groups one child vector per struct field, all sharing the same row count.
 /// The `'a` lifetime ties the vector to the chunk it was obtained from,
 /// preventing the chunk from being dropped while the vector is still alive.
+/// When created from a raw `duckdb_vector`, `'a` instead tracks the borrowed
+/// handle used to construct the wrapper, so callers must ensure the underlying
+/// DuckDB vector itself outlives the wrapper.
 pub struct StructVector<'a> {
     ptr: duckdb_vector,
     _phantom: PhantomData<&'a ()>,
@@ -346,7 +372,9 @@ impl<'a> StructVector<'a> {
     ///
     /// # Safety
     /// The caller must ensure that `ptr` is a valid `duckdb_vector` and that
-    /// it remains valid for the entirety of the chosen lifetime `'a`.
+    /// it remains valid for the entirety of the chosen lifetime `'a`. No other
+    /// live wrapper may expose overlapping mutable access to the same
+    /// `duckdb_vector` for that lifetime.
     pub unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             ptr,

--- a/crates/duckdb/src/vscalar/mod.rs
+++ b/crates/duckdb/src/vscalar/mod.rs
@@ -27,14 +27,19 @@ pub trait VScalar: Sized {
     /// Shared across worker threads and invocations — must not be modified during execution.
     /// Must be `'static` as it is stored in DuckDB and may outlive the current stack frame.
     type State: Sized + Send + Sync + 'static;
-    /// The actual function
+    /// The actual function.
+    ///
+    /// DuckDB guarantees that `input` and `output` stay live for the
+    /// duration of this call. Implementations are expected to populate
+    /// `output` for rows `0..input.len()` and must not read or write beyond
+    /// that range.
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it:
-    ///
-    /// - Dereferences multiple raw pointers (`func`).
-    ///
+    /// This method is `unsafe` because the `input` chunk and `output` vector
+    /// wrap raw DuckDB pointers (see [`DataChunkHandle::new_unowned`] and the
+    /// `WritableVector` impl on `duckdb_vector`). Callers must guarantee those
+    /// pointers are valid DuckDB-owned storage for the duration of the call.
     unsafe fn invoke(
         state: &Self::State,
         input: &mut DataChunkHandle,

--- a/crates/duckdb/src/vscalar/mod.rs
+++ b/crates/duckdb/src/vscalar/mod.rs
@@ -29,20 +29,23 @@ pub trait VScalar: Sized {
     type State: Sized + Send + Sync + 'static;
     /// The actual function.
     ///
-    /// DuckDB guarantees that `input` and `output` stay live for the
-    /// duration of this call. Implementations are expected to populate
-    /// `output` for rows `0..input.len()` and must not read or write beyond
-    /// that range.
+    /// DuckDB guarantees that `input` and `output` stay live for the duration
+    /// of this call. Implementations must populate `output` for rows
+    /// `0..input.len()` and must not read or write beyond that range.
     ///
     /// # Safety
     ///
-    /// This method is `unsafe` because the crate-internal DuckDB trampoline
-    /// invokes it with wrappers around raw DuckDB pointers (see
-    /// DataChunkHandle::new_unowned and the `WritableVector` impl on
-    /// `duckdb_vector`). Implementations may assume those wrappers are valid
-    /// for the duration of the call, but must treat them as borrowed DuckDB
-    /// storage and only read or write within the rows and types DuckDB
-    /// provided for this invocation.
+    /// Called by the DuckDB trampoline with wrappers over borrowed DuckDB
+    /// storage. Implementations must:
+    ///
+    /// - only read and write within the rows and column types DuckDB provided
+    ///   for this invocation;
+    /// - not retain `input`, `output`, or any vector/slice derived from them
+    ///   past return;
+    /// - not hold two writable wrappers over the same column at the same
+    ///   time. The wrapper types do not currently prevent this: calling e.g.
+    ///   `input.flat_vector(0)` twice and then `as_mut_slice` on each yields
+    ///   overlapping `&mut [T]`, which is undefined behavior.
     unsafe fn invoke(
         state: &Self::State,
         input: &mut DataChunkHandle,

--- a/crates/duckdb/src/vscalar/mod.rs
+++ b/crates/duckdb/src/vscalar/mod.rs
@@ -36,10 +36,13 @@ pub trait VScalar: Sized {
     ///
     /// # Safety
     ///
-    /// This method is `unsafe` because the `input` chunk and `output` vector
-    /// wrap raw DuckDB pointers (see [`DataChunkHandle::new_unowned`] and the
-    /// `WritableVector` impl on `duckdb_vector`). Callers must guarantee those
-    /// pointers are valid DuckDB-owned storage for the duration of the call.
+    /// This method is `unsafe` because the crate-internal DuckDB trampoline
+    /// invokes it with wrappers around raw DuckDB pointers (see
+    /// DataChunkHandle::new_unowned and the `WritableVector` impl on
+    /// `duckdb_vector`). Implementations may assume those wrappers are valid
+    /// for the duration of the call, but must treat them as borrowed DuckDB
+    /// storage and only read or write within the rows and types DuckDB
+    /// provided for this invocation.
     unsafe fn invoke(
         state: &Self::State,
         input: &mut DataChunkHandle,

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -2,7 +2,7 @@ use super::{BindInfo, DataChunkHandle, InitInfo, LogicalTypeHandle, TableFunctio
 use std::sync::{Arc, Mutex, atomic::AtomicBool};
 
 use crate::{
-    core::{ArrayVector, FlatVector, Inserter, ListVector, LogicalTypeId, StructVector, Vector},
+    core::{ArrayVector, FlatVector, Inserter, ListVector, LogicalTypeId, StructVector},
     types::DuckString,
 };
 
@@ -683,85 +683,53 @@ fn primitive_array_to_flat_vector<T: ArrowPrimitiveType>(array: &PrimitiveArray<
 fn primitive_array_to_flat_vector_cast<T: ArrowPrimitiveType>(
     data_type: DataType,
     array: &dyn Array,
-    out_vector: &mut dyn Vector,
+    out_vector: &mut FlatVector,
 ) {
     let array = cast(array, &data_type).unwrap_or_else(|_| panic!("array is casted into {data_type}"));
-    let out_vector: &mut FlatVector = out_vector.as_mut_any().downcast_mut().unwrap();
     out_vector.copy::<T::Native>(array.as_primitive::<T>().values());
     set_nulls_in_flat_vector(&array, out_vector);
 }
 
-fn primitive_array_to_vector(array: &dyn Array, out: &mut dyn Vector) -> Result<(), Box<dyn std::error::Error>> {
+fn primitive_array_to_vector(
+    array: &dyn Array,
+    out: &mut FlatVector,
+) -> Result<(), Box<dyn std::error::Error>> {
     match array.data_type() {
         DataType::Boolean => {
-            boolean_array_to_vector(as_boolean_array(array), out.as_mut_any().downcast_mut().unwrap());
+            boolean_array_to_vector(as_boolean_array(array), out);
         }
         DataType::UInt8 => {
-            primitive_array_to_flat_vector::<UInt8Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<UInt8Type>(as_primitive_array(array), out);
         }
         DataType::UInt16 => {
-            primitive_array_to_flat_vector::<UInt16Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<UInt16Type>(as_primitive_array(array), out);
         }
         DataType::UInt32 => {
-            primitive_array_to_flat_vector::<UInt32Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<UInt32Type>(as_primitive_array(array), out);
         }
         DataType::UInt64 => {
-            primitive_array_to_flat_vector::<UInt64Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<UInt64Type>(as_primitive_array(array), out);
         }
         DataType::Int8 => {
-            primitive_array_to_flat_vector::<Int8Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<Int8Type>(as_primitive_array(array), out);
         }
         DataType::Int16 => {
-            primitive_array_to_flat_vector::<Int16Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<Int16Type>(as_primitive_array(array), out);
         }
         DataType::Int32 => {
-            primitive_array_to_flat_vector::<Int32Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<Int32Type>(as_primitive_array(array), out);
         }
         DataType::Int64 => {
-            primitive_array_to_flat_vector::<Int64Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<Int64Type>(as_primitive_array(array), out);
         }
         DataType::Float32 => {
-            primitive_array_to_flat_vector::<Float32Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<Float32Type>(as_primitive_array(array), out);
         }
         DataType::Float64 => {
-            primitive_array_to_flat_vector::<Float64Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<Float64Type>(as_primitive_array(array), out);
         }
         DataType::Decimal128(width, _) => {
-            decimal_array_to_vector(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-                *width,
-            );
+            decimal_array_to_vector(as_primitive_array(array), out, *width);
         }
         DataType::Interval(_) | DataType::Duration(_) => {
             let array = IntervalMonthDayNanoArray::from(
@@ -773,10 +741,7 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut dyn Vector) -> Result<
                     .map(|a| IntervalMonthDayNanoType::make_value(a.months, a.days, a.nanoseconds / 1000))
                     .collect::<Vec<_>>(),
             );
-            primitive_array_to_flat_vector::<IntervalMonthDayNanoType>(
-                as_primitive_array(&array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<IntervalMonthDayNanoType>(as_primitive_array(&array), out);
         }
         // DuckDB Only supports timetamp_tz in microsecond precision
         DataType::Timestamp(_, Some(tz)) => primitive_array_to_flat_vector_cast::<TimestampMicrosecondType>(
@@ -785,28 +750,19 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut dyn Vector) -> Result<
             out,
         ),
         DataType::Timestamp(unit, None) => match unit {
-            TimeUnit::Second => primitive_array_to_flat_vector::<TimestampSecondType>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            ),
-            TimeUnit::Millisecond => primitive_array_to_flat_vector::<TimestampMillisecondType>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            ),
-            TimeUnit::Microsecond => primitive_array_to_flat_vector::<TimestampMicrosecondType>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            ),
-            TimeUnit::Nanosecond => primitive_array_to_flat_vector::<TimestampNanosecondType>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            ),
+            TimeUnit::Second => primitive_array_to_flat_vector::<TimestampSecondType>(as_primitive_array(array), out),
+            TimeUnit::Millisecond => {
+                primitive_array_to_flat_vector::<TimestampMillisecondType>(as_primitive_array(array), out)
+            }
+            TimeUnit::Microsecond => {
+                primitive_array_to_flat_vector::<TimestampMicrosecondType>(as_primitive_array(array), out)
+            }
+            TimeUnit::Nanosecond => {
+                primitive_array_to_flat_vector::<TimestampNanosecondType>(as_primitive_array(array), out)
+            }
         },
         DataType::Date32 => {
-            primitive_array_to_flat_vector::<Date32Type>(
-                as_primitive_array(array),
-                out.as_mut_any().downcast_mut().unwrap(),
-            );
+            primitive_array_to_flat_vector::<Date32Type>(as_primitive_array(array), out);
         }
         DataType::Date64 => primitive_array_to_flat_vector_cast::<Date32Type>(Date32Type::DATA_TYPE, array, out),
         DataType::Time32(_) => {

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -636,36 +636,27 @@ pub fn write_arrow_array_to_vector(
     Ok(())
 }
 
-// `duckdb_vector` is a `Copy` raw pointer typedef, so the `'_` lifetime on the
-// returned wrappers below is tied to `&mut self` (i.e. to the local variable
-// holding the pointer, not to the underlying C++ vector). This prevents reusing
-// the same `duckdb_vector` handle while a wrapper is in flight, but it does **not**
-// track the C++ vector's liveness. Callers must independently guarantee that the
-// underlying DuckDB vector outlives the returned wrapper.
-//
-// TODO(#673 follow-up): this `impl` is reachable from safe downstream code
-// because `WritableVector` is a public safe trait with a public impl for the
-// raw `duckdb_vector` pointer type. Marking the trait `unsafe` (or removing
-// the raw-pointer impl entirely) would move this obligation into the type
-// system instead of relying on caller discipline.
+// Known aliasing hole (#673 follow-up): `duckdb_vector` is a `Copy` raw-pointer
+// typedef, so `&mut self` only locks this particular binding — a caller holding
+// another copy of the same pointer can still call these accessors and obtain
+// aliased wrappers. `WritableVector` is a safe trait, so the obligation is on
+// the caller to ensure the underlying vector outlives the wrapper and that no
+// other copy is used concurrently. Marking the trait `unsafe` (or dropping the
+// raw-pointer impl) would move this into the type system.
 impl WritableVector for duckdb_vector {
     fn array_vector(&mut self) -> ArrayVector<'_> {
-        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { ArrayVector::from_raw(*self) }
     }
 
     fn flat_vector(&mut self) -> FlatVector<'_> {
-        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { FlatVector::from_raw(*self) }
     }
 
     fn list_vector(&mut self) -> ListVector<'_> {
-        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { ListVector::from_raw(*self) }
     }
 
     fn struct_vector(&mut self) -> StructVector<'_> {
-        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { StructVector::from_raw(*self) }
     }
 }

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -636,26 +636,36 @@ pub fn write_arrow_array_to_vector(
     Ok(())
 }
 
+// `duckdb_vector` is a `Copy` raw pointer typedef, so the `'_` lifetime on the
+// returned wrappers below is tied to `&mut self` (i.e. to the local variable
+// holding the pointer, not to the underlying C++ vector). This prevents reusing
+// the same `duckdb_vector` handle while a wrapper is in flight, but it does **not**
+// track the C++ vector's liveness. Callers must independently guarantee that the
+// underlying DuckDB vector outlives the returned wrapper.
+//
+// TODO(#673 follow-up): this `impl` is reachable from safe downstream code
+// because `WritableVector` is a public safe trait with a public impl for the
+// raw `duckdb_vector` pointer type. Marking the trait `unsafe` (or removing
+// the raw-pointer impl entirely) would move this obligation into the type
+// system instead of relying on caller discipline.
 impl WritableVector for duckdb_vector {
     fn array_vector(&mut self) -> ArrayVector<'_> {
-        // SAFETY: the returned vector borrows from `&mut self`, so it cannot
-        // outlive this `duckdb_vector` handle. The caller is responsible for
-        // ensuring the underlying C++ vector outlives this handle.
+        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { ArrayVector::from_raw(*self) }
     }
 
     fn flat_vector(&mut self) -> FlatVector<'_> {
-        // SAFETY: see `array_vector`.
+        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { FlatVector::from_raw(*self) }
     }
 
     fn list_vector(&mut self) -> ListVector<'_> {
-        // SAFETY: see `array_vector`.
+        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { ListVector::from_raw(*self) }
     }
 
     fn struct_vector(&mut self) -> StructVector<'_> {
-        // SAFETY: see `array_vector`.
+        // SAFETY: see module note above `impl WritableVector for duckdb_vector`.
         unsafe { StructVector::from_raw(*self) }
     }
 }

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -256,7 +256,7 @@ fn arrow_map_to_duckdb_logical_type(field: &FieldRef) -> Result<LogicalTypeHandl
 // FIXME: flat vectors don't have all of thsese types. I think they only
 /// Converts flat vector to an arrow array
 pub fn flat_vector_to_arrow_array(
-    vector: &mut FlatVector,
+    vector: &mut FlatVector<'_>,
     len: usize,
 ) -> Result<Arc<dyn Array>, Box<dyn std::error::Error>> {
     let raw_type_id = vector.logical_type().raw_id();
@@ -514,19 +514,19 @@ impl<'a> DataChunkHandleSlice<'a> {
 }
 
 impl WritableVector for DataChunkHandleSlice<'_> {
-    fn array_vector(&mut self) -> ArrayVector {
+    fn array_vector(&mut self) -> ArrayVector<'_> {
         self.chunk.array_vector(self.column_index)
     }
 
-    fn flat_vector(&mut self) -> FlatVector {
+    fn flat_vector(&mut self) -> FlatVector<'_> {
         self.chunk.flat_vector(self.column_index)
     }
 
-    fn struct_vector(&mut self) -> StructVector {
+    fn struct_vector(&mut self) -> StructVector<'_> {
         self.chunk.struct_vector(self.column_index)
     }
 
-    fn list_vector(&mut self) -> ListVector {
+    fn list_vector(&mut self) -> ListVector<'_> {
         self.chunk.list_vector(self.column_index)
     }
 }
@@ -535,13 +535,13 @@ impl WritableVector for DataChunkHandleSlice<'_> {
 /// To get the specific vector type, use the appropriate method.
 pub trait WritableVector {
     /// Get the vector as a `FlatVector`.
-    fn flat_vector(&mut self) -> FlatVector;
+    fn flat_vector(&mut self) -> FlatVector<'_>;
     /// Get the vector as a `ListVector`.
-    fn list_vector(&mut self) -> ListVector;
+    fn list_vector(&mut self) -> ListVector<'_>;
     /// Get the vector as a `ArrayVector`.
-    fn array_vector(&mut self) -> ArrayVector;
+    fn array_vector(&mut self) -> ArrayVector<'_>;
     /// Get the vector as a `StructVector`.
-    fn struct_vector(&mut self) -> StructVector;
+    fn struct_vector(&mut self) -> StructVector<'_>;
 }
 
 /// Writes an Arrow array to a `WritableVector`.
@@ -637,20 +637,26 @@ pub fn write_arrow_array_to_vector(
 }
 
 impl WritableVector for duckdb_vector {
-    fn array_vector(&mut self) -> ArrayVector {
-        ArrayVector::from(*self)
+    fn array_vector(&mut self) -> ArrayVector<'_> {
+        // SAFETY: the returned vector borrows from `&mut self`, so it cannot
+        // outlive this `duckdb_vector` handle. The caller is responsible for
+        // ensuring the underlying C++ vector outlives this handle.
+        unsafe { ArrayVector::from_raw(*self) }
     }
 
-    fn flat_vector(&mut self) -> FlatVector {
-        FlatVector::from(*self)
+    fn flat_vector(&mut self) -> FlatVector<'_> {
+        // SAFETY: see `array_vector`.
+        unsafe { FlatVector::from_raw(*self) }
     }
 
-    fn list_vector(&mut self) -> ListVector {
-        ListVector::from(*self)
+    fn list_vector(&mut self) -> ListVector<'_> {
+        // SAFETY: see `array_vector`.
+        unsafe { ListVector::from_raw(*self) }
     }
 
-    fn struct_vector(&mut self) -> StructVector {
-        StructVector::from(*self)
+    fn struct_vector(&mut self) -> StructVector<'_> {
+        // SAFETY: see `array_vector`.
+        unsafe { StructVector::from_raw(*self) }
     }
 }
 
@@ -674,7 +680,7 @@ pub fn record_batch_to_duckdb_data_chunk(
     Ok(())
 }
 
-fn primitive_array_to_flat_vector<T: ArrowPrimitiveType>(array: &PrimitiveArray<T>, out_vector: &mut FlatVector) {
+fn primitive_array_to_flat_vector<T: ArrowPrimitiveType>(array: &PrimitiveArray<T>, out_vector: &mut FlatVector<'_>) {
     // assert!(array.len() <= out_vector.capacity());
     out_vector.copy::<T::Native>(array.values());
     set_nulls_in_flat_vector(array, out_vector);
@@ -683,17 +689,14 @@ fn primitive_array_to_flat_vector<T: ArrowPrimitiveType>(array: &PrimitiveArray<
 fn primitive_array_to_flat_vector_cast<T: ArrowPrimitiveType>(
     data_type: DataType,
     array: &dyn Array,
-    out_vector: &mut FlatVector,
+    out_vector: &mut FlatVector<'_>,
 ) {
     let array = cast(array, &data_type).unwrap_or_else(|_| panic!("array is casted into {data_type}"));
     out_vector.copy::<T::Native>(array.as_primitive::<T>().values());
     set_nulls_in_flat_vector(&array, out_vector);
 }
 
-fn primitive_array_to_vector(
-    array: &dyn Array,
-    out: &mut FlatVector,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn primitive_array_to_vector(array: &dyn Array, out: &mut FlatVector<'_>) -> Result<(), Box<dyn std::error::Error>> {
     match array.data_type() {
         DataType::Boolean => {
             boolean_array_to_vector(as_boolean_array(array), out);
@@ -777,7 +780,7 @@ fn primitive_array_to_vector(
 }
 
 /// Convert Arrow [Decimal128Array] to a duckdb vector.
-fn decimal_array_to_vector(array: &Decimal128Array, out: &mut FlatVector, width: u8) {
+fn decimal_array_to_vector(array: &Decimal128Array, out: &mut FlatVector<'_>, width: u8) {
     match width {
         1..=4 => {
             let out_data = out.as_mut_slice();
@@ -812,7 +815,7 @@ fn decimal_array_to_vector(array: &Decimal128Array, out: &mut FlatVector, width:
 }
 
 /// Convert Arrow [BooleanArray] to a duckdb vector.
-fn boolean_array_to_vector(array: &BooleanArray, out: &mut FlatVector) {
+fn boolean_array_to_vector(array: &BooleanArray, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     for i in 0..array.len() {
@@ -821,7 +824,7 @@ fn boolean_array_to_vector(array: &BooleanArray, out: &mut FlatVector) {
     set_nulls_in_flat_vector(array, out);
 }
 
-fn string_array_to_vector<O: OffsetSizeTrait>(array: &GenericStringArray<O>, out: &mut FlatVector) {
+fn string_array_to_vector<O: OffsetSizeTrait>(array: &GenericStringArray<O>, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     // TODO: zero copy assignment
@@ -832,7 +835,7 @@ fn string_array_to_vector<O: OffsetSizeTrait>(array: &GenericStringArray<O>, out
     set_nulls_in_flat_vector(array, out);
 }
 
-fn string_view_array_to_vector(array: &StringViewArray, out: &mut FlatVector) {
+fn string_view_array_to_vector(array: &StringViewArray, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     for i in 0..array.len() {
@@ -842,7 +845,7 @@ fn string_view_array_to_vector(array: &StringViewArray, out: &mut FlatVector) {
     set_nulls_in_flat_vector(array, out);
 }
 
-fn binary_array_to_vector(array: &BinaryArray, out: &mut FlatVector) {
+fn binary_array_to_vector(array: &BinaryArray, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     for i in 0..array.len() {
@@ -852,7 +855,7 @@ fn binary_array_to_vector(array: &BinaryArray, out: &mut FlatVector) {
     set_nulls_in_flat_vector(array, out);
 }
 
-fn binary_view_array_to_vector(array: &BinaryViewArray, out: &mut FlatVector) {
+fn binary_view_array_to_vector(array: &BinaryViewArray, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     for i in 0..array.len() {
@@ -862,7 +865,7 @@ fn binary_view_array_to_vector(array: &BinaryViewArray, out: &mut FlatVector) {
     set_nulls_in_flat_vector(array, out);
 }
 
-fn fixed_size_binary_array_to_vector(array: &FixedSizeBinaryArray, out: &mut FlatVector) {
+fn fixed_size_binary_array_to_vector(array: &FixedSizeBinaryArray, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     for i in 0..array.len() {
@@ -873,7 +876,7 @@ fn fixed_size_binary_array_to_vector(array: &FixedSizeBinaryArray, out: &mut Fla
     // set_nulls_in_flat_vector(array, out);
 }
 
-fn large_binary_array_to_vector(array: &LargeBinaryArray, out: &mut FlatVector) {
+fn large_binary_array_to_vector(array: &LargeBinaryArray, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     for i in 0..array.len() {
@@ -886,7 +889,7 @@ fn large_binary_array_to_vector(array: &LargeBinaryArray, out: &mut FlatVector) 
 
 fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
     array: &GenericListArray<O>,
-    out: &mut ListVector,
+    out: &mut ListVector<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let value_array = array.values();
     match value_array.data_type() {
@@ -955,7 +958,7 @@ fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
 
 fn fixed_size_list_array_to_vector(
     array: &FixedSizeListArray,
-    out: &mut ArrayVector,
+    out: &mut ArrayVector<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let value_array = array.values();
     let mut child = out.child(value_array.len());
@@ -988,7 +991,7 @@ fn as_fixed_size_list_array(arr: &dyn Array) -> &FixedSizeListArray {
     arr.as_any().downcast_ref::<FixedSizeListArray>().unwrap()
 }
 
-fn struct_array_to_vector(array: &StructArray, out: &mut StructVector) -> Result<(), Box<dyn std::error::Error>> {
+fn struct_array_to_vector(array: &StructArray, out: &mut StructVector<'_>) -> Result<(), Box<dyn std::error::Error>> {
     for i in 0..array.num_columns() {
         let column = array.column(i);
         match column.data_type() {
@@ -1069,7 +1072,7 @@ pub fn arrow_ffi_to_query_params(array: FFI_ArrowArray, schema: FFI_ArrowSchema)
     [arr as *mut _ as usize, sch as *mut _ as usize]
 }
 
-fn set_nulls_in_flat_vector(array: &dyn Array, out_vector: &mut FlatVector) {
+fn set_nulls_in_flat_vector(array: &dyn Array, out_vector: &mut FlatVector<'_>) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {
@@ -1079,7 +1082,7 @@ fn set_nulls_in_flat_vector(array: &dyn Array, out_vector: &mut FlatVector) {
     }
 }
 
-fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector) {
+fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector<'_>) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {
@@ -1089,7 +1092,7 @@ fn set_nulls_in_struct_vector(array: &dyn Array, out_vector: &mut StructVector) 
     }
 }
 
-fn set_nulls_in_array_vector(array: &dyn Array, out_vector: &mut ArrayVector) {
+fn set_nulls_in_array_vector(array: &dyn Array, out_vector: &mut ArrayVector<'_>) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {
@@ -1099,7 +1102,7 @@ fn set_nulls_in_array_vector(array: &dyn Array, out_vector: &mut ArrayVector) {
     }
 }
 
-fn set_nulls_in_list_vector(array: &dyn Array, out_vector: &mut ListVector) {
+fn set_nulls_in_list_vector(array: &dyn Array, out_vector: &mut ListVector<'_>) {
     if let Some(nulls) = array.nulls() {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {


### PR DESCRIPTION
Problem: `FlatVector` / `ListVector` / `ArrayVector` / `StructVector` could outlive their parent `DataChunkHandle` and read freed memory.

This PR:
- adds `'a` plus `PhantomData<&'a ()>` to all four vector wrappers
- ties `DataChunkHandle` accessors to `&self` so returned vectors cannot outlive the chunk
- propagates the same lifetime through child-vector accessors
- adds a `compile_fail` doctest for the `ListVector` reproducer from #673
- removes the public raw vector constructors by making `from_raw` crate-private

Breaking:
- downstream code that names these types now needs `FlatVector<'_>`, `ListVector<'_>`, etc.
- direct raw construction from `duckdb_vector` is no longer part of the public API, raw callback code should go through `WritableVector`

Fixes #673