### PR TITLE
Allow to disable extension install/load support

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -120,21 +120,36 @@ jobs:
       RUSTC_WRAPPER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      DUCKDB_DISABLE_EXTENSION_LOAD: "1"
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: mozilla-actions/sccache-action@v0.0.9
-      - name: Verify static linking
+
+      - name: Verify static linking with extension loading disabled
         shell: bash
         run: |
-          output=$(cargo run -p duckdb --example repl --no-default-features --features "bundled-cmake,icu" -- -c "from duckdb_extensions() where extension_name = 'icu';")
+          output=$(cargo run -p duckdb --example repl --features icu -- -c "SELECT install_mode || ',' || install_path FROM duckdb_extensions() WHERE extension_name = 'icu';")
           echo "$output"
-          grep -qF "STATICALLY_LINKED" <<<"$output"
-          grep -qF "(BUILT-IN)" <<<"$output"
+          grep -qF "STATICALLY_LINKED,(BUILT-IN)" <<<"$output"
+
+          output=$(cargo run -p duckdb --example repl --features icu -- -c "SELECT current_setting('autoload_known_extensions') || ',' || current_setting('autoinstall_known_extensions');")
+          echo "$output"
+          grep -qF "false,false" <<<"$output"
+
+          set +e
+          output=$(cargo run -p duckdb --example repl --features icu -- -c "LOAD sqlite_scanner;" 2>&1)
+          status=$?
+          set -e
+
+          echo "$output"
+          test $status -ne 0
+          grep -qF "Loading external extensions is disabled through a compile time flag" <<<"$output"
+
       - name: ICU functional test
-        run: cargo test -p duckdb --no-default-features --features "bundled-cmake,icu" --lib extension::test::test_extension_icu -- --exact
+        run: cargo test -p duckdb --features icu --lib extension::test::test_extension_icu -- --exact
 
   msrv:
     name: MSRV Check

--- a/README.md
+++ b/README.md
@@ -205,9 +205,10 @@ You can adjust this behavior in a number of ways:
    - `bundled-cmake` is *experimental* and requires a git/workspace checkout. It is not available from crates.io because the full `duckdb-sources` tree is not packaged there.
    - `bundled-cmake` implies `bundled` (for conditional-compilation gates) but replaces the `cc` build backend with CMake. Enabling any CMake-only extension feature (e.g. `icu`) automatically activates `bundled-cmake`.
    - `bundled-cmake` always links DuckDB's default static extensions (`core_functions` and `parquet`), so it also implies the `parquet` Cargo feature.
-   - Extension autoload/autoinstall are forced on to match the existing `bundled` backend, even though upstream CMake defaults are off.
+   - Extension autoload/autoinstall are forced on to match the existing `bundled` backend, even though upstream CMake defaults are off. If `DUCKDB_DISABLE_EXTENSION_LOAD=1` is set, both defaults are forced off as well.
    - When `ninja` is on `PATH`, the Ninja generator is preferred automatically. Set `CMAKE_GENERATOR` to override.
    - Builds DuckDB in `Release` mode by default, even in Rust debug builds, to avoid DuckDB's much slower debug/sanitizer profile. Set `DUCKDB_CMAKE_BUILD_TYPE` or `CMAKE_BUILD_TYPE` to override. `DUCKDB_CMAKE_BUILD_TYPE` takes precedence.
+   - Setting `DUCKDB_DISABLE_EXTENSION_LOAD=1` (or `DISABLE_EXTENSION_LOAD=1`) in the build environment compiles DuckDB without external extension install/load support. Statically linked extensions remain available.
    - `DUCKDB_EXTENSION_CONFIGS` is not yet supported; the build fails fast rather than producing a broken binary.
    - Use `cargo build -vv -F bundled-cmake` to surface CMake configure/build logs.
 

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -31,6 +31,8 @@ pub fn main(_out_dir: &str, out_path: &Path) {
     println!("cargo:rerun-if-env-changed=DUCKDB_EXTENSION_CONFIGS");
     println!("cargo:rerun-if-env-changed=DUCKDB_CMAKE_BUILD_TYPE");
     println!("cargo:rerun-if-env-changed=DUCKDB_DISABLE_UNITY");
+    println!("cargo:rerun-if-env-changed=DUCKDB_DISABLE_EXTENSION_LOAD");
+    println!("cargo:rerun-if-env-changed=DISABLE_EXTENSION_LOAD");
     println!("cargo:rerun-if-env-changed=CMAKE_BUILD_TYPE");
     println!("cargo:rerun-if-env-changed=CMAKE_GENERATOR");
     println!("cargo:rerun-if-env-changed=CMAKE_C_COMPILER_LAUNCHER");
@@ -75,18 +77,13 @@ pub fn main(_out_dir: &str, out_path: &Path) {
     // Unity builds (DuckDB's default) combine .cpp files into fewer translation
     // units and compile significantly faster. Allow opting out for debugging.
     // Always set explicitly so the CMake cache doesn't keep a stale value.
-    let disable_unity = match env_var("DUCKDB_DISABLE_UNITY").as_deref() {
-        Some("1" | "true" | "on" | "yes") => true,
-        Some("0" | "false" | "off" | "no") => false,
-        Some(other) => {
-            cargo_warning(&format!(
-                "Ignoring unsupported DUCKDB_DISABLE_UNITY value {other:?}; expected true/false or 1/0, yes/no, on/off"
-            ));
-            false
-        }
-        None => false,
-    };
+    let disable_unity = env_flag("DUCKDB_DISABLE_UNITY");
     config.define("DISABLE_UNITY", if disable_unity { "1" } else { "0" });
+
+    // Always set explicitly so the CMake cache does not keep a stale value when
+    // the environment variable changes between builds.
+    let disable_extension_load = env_flag_aliases(&["DUCKDB_DISABLE_EXTENSION_LOAD", "DISABLE_EXTENSION_LOAD"]);
+    config.define("DISABLE_EXTENSION_LOAD", if disable_extension_load { "1" } else { "0" });
 
     // Forward compiler launcher for sccache/ccache integration.
     for var in ["CMAKE_C_COMPILER_LAUNCHER", "CMAKE_CXX_COMPILER_LAUNCHER"] {
@@ -103,10 +100,17 @@ pub fn main(_out_dir: &str, out_path: &Path) {
     config.define("SKIP_EXTENSIONS", SKIPPED_EXTENSIONS.join(";"));
 
     // Upstream CMake defaults these to OFF, but duckdb-rs `bundled` has historically
-    // shipped with both enabled. Keep `bundled-cmake` aligned with `bundled` for now.
+    // shipped with both enabled. Keep `bundled-cmake` aligned with `bundled` unless
+    // extension loading is compiled out entirely.
     config
-        .define("ENABLE_EXTENSION_AUTOLOADING", "1")
-        .define("ENABLE_EXTENSION_AUTOINSTALL", "1");
+        .define(
+            "ENABLE_EXTENSION_AUTOLOADING",
+            if disable_extension_load { "0" } else { "1" },
+        )
+        .define(
+            "ENABLE_EXTENSION_AUTOINSTALL",
+            if disable_extension_load { "0" } else { "1" },
+        );
 
     let dst = config.build();
     let lib_dir = dst.join("lib");
@@ -265,6 +269,47 @@ fn env_var(name: &str) -> Option<String> {
             panic!("bundled-cmake expects a valid UTF-8 value for environment variable `{name}`")
         }
     }
+}
+
+fn parse_env_flag(name: &str) -> Option<bool> {
+    match env_var(name).as_deref() {
+        Some("1" | "true" | "on" | "yes") => Some(true),
+        Some("0" | "false" | "off" | "no") => Some(false),
+        Some(other) => {
+            cargo_warning(&format!(
+                "Ignoring unsupported {name} value {other:?}; expected true/false or 1/0, yes/no, on/off"
+            ));
+            None
+        }
+        None => None,
+    }
+}
+
+fn env_flag(name: &str) -> bool {
+    parse_env_flag(name).unwrap_or(false)
+}
+
+fn env_flag_aliases(names: &[&str]) -> bool {
+    let mut values = Vec::new();
+    for name in names {
+        if let Some(value) = parse_env_flag(name) {
+            values.push((*name, value));
+        }
+    }
+    let Some((selected_name, selected_value)) = values.first().copied() else {
+        return false;
+    };
+    if values.iter().any(|(_, value)| *value != selected_value) {
+        let sources = values
+            .iter()
+            .map(|(name, value)| format!("{name}={}", if *value { 1 } else { 0 }))
+            .collect::<Vec<_>>()
+            .join(", ");
+        cargo_warning(&format!(
+            "Conflicting values for equivalent environment variables ({sources}); using {selected_name}"
+        ));
+    }
+    selected_value
 }
 
 fn sanitize_path_component(input: &str) -> String {


### PR DESCRIPTION
By propagating `DISABLE_EXTENSION_LOAD` to DuckDB.

Blocked by https://github.com/duckdb/duckdb/pull/22019 - merged but unreleased as of v1.5.2