### PR TITLE
fix(libduckdb-sys): link rstrtmgr on Windows for bundled cc backend

### DIFF
--- a/crates/libduckdb-sys/build_bundled_cc.rs
+++ b/crates/libduckdb-sys/build_bundled_cc.rs
@@ -179,6 +179,14 @@ pub fn main(out_dir: &str, out_path: &Path) {
 
     if win_target() {
         cfg.define("DUCKDB_BUILD_LIBRARY", None);
+        // Bundled DuckDB's AdditionalLockInfo helper calls the Windows
+        // Restart Manager APIs (RmStartSession, RmRegisterResources,
+        // RmGetList, RmEndSession), which live in rstrtmgr.lib. The
+        // cmake backend already emits this link directive; mirror it
+        // here so the cc backend produces the same link line. Without
+        // it, downstream crates get LNK2019 "unresolved external symbol
+        // RmStartSession" at link time (see duckdb/duckdb-rs#544).
+        println!("cargo:rustc-link-lib=dylib=rstrtmgr");
     }
     cfg.compile("duckdb");
 


### PR DESCRIPTION
## Summary

Emit `cargo:rustc-link-lib=dylib=rstrtmgr` from `build_bundled_cc.rs` on Windows, bringing the cc backend to parity with `build_bundled_cmake.rs` which already links `rstrtmgr` (see `crates/libduckdb-sys/build_bundled_cmake.rs:435`).

## The bug

Bundled DuckDB's `AdditionalLockInfo` helper references the Windows Restart Manager APIs (`RmStartSession`, `RmRegisterResources`, `RmGetList`, `RmEndSession`), which live in `rstrtmgr.lib`. Downstream crates that depend on `libduckdb-sys` with the (default) bundled cc backend hit `LNK2019` at link time:

```
error LNK2019: unresolved external symbol RmStartSession
    referenced in function "duckdb::AdditionalLockInfo(...)"
error LNK2019: unresolved external symbol RmRegisterResources ...
error LNK2019: unresolved external symbol RmGetList ...
error LNK2019: unresolved external symbol RmEndSession ...
fatal error LNK1120: 4 unresolved externals
```

The error is deterministic — every downstream project building `libduckdb-sys` bundled on MSVC x64 hits it. It does not affect the cmake backend because `build_bundled_cmake.rs` already emits the correct link directive inside its `win_target()` block.

## Context

Issue #544 tracks this exact failure, with multiple confirmed reports and a community-validated workaround: every affected user copy-pastes a one-line `build.rs` into their project containing the same link directive this PR adds upstream. Examples from #544:

```rust
// Workaround currently required in every downstream project:
fn main() {
    if cfg!(target_os = "windows") {
        println!("cargo:rustc-link-lib=Rstrtmgr");
    }
}
```

Emitting it from `libduckdb-sys` itself removes the need for every downstream crate to carry the workaround.

## The fix

Inside the existing `if win_target() { ... }` block in `build_bundled_cc.rs` (which already sets `DUCKDB_BUILD_LIBRARY`), add:

```rust
println!("cargo:rustc-link-lib=dylib=rstrtmgr");
```

This mirrors `build_bundled_cmake.rs:435`. Eight lines including a code comment explaining why. No behavior change on non-Windows platforms (`win_target()` guard), and no change for users of the cmake backend.

## Test plan

- [x] Reproduced `LNK2019: unresolved external symbol RmStartSession` on Windows 11 / MSVC 14.44 / `libduckdb-sys 1.10501.0` by depending on `duckdb = { version = "1", features = ["bundled"] }` and running `cargo test`.
- [x] Verified the fix resolves the link error and all tests pass in my downstream workspace (`ios-timelinerx` — a Rust forensic tool).
- [ ] CI on this PR should exercise the Windows bundled-cc path if such a job exists.

Fixes #544.