### PR TITLE
Fix unsound vector slice API

### DIFF
--- a/crates/duckdb/src/core/data_chunk.rs
+++ b/crates/duckdb/src/core/data_chunk.rs
@@ -116,7 +116,7 @@ mod test {
     fn test_vector() {
         let datachunk = DataChunkHandle::new(&[LogicalTypeHandle::from(LogicalTypeId::Bigint)]);
         let mut vector = datachunk.flat_vector(0);
-        let data = vector.as_mut_slice::<i64>();
+        let data = unsafe { vector.as_mut_slice::<i64>() };
 
         data[0] = 42;
     }

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -78,10 +78,12 @@ impl<'a> FlatVector<'a> {
 
     /// Returns a mutable pointer to the vector's backing data cast to `T`.
     ///
-    /// DuckDB stores this as untyped vector data. Dereferencing the returned
-    /// pointer is only valid when `T` matches the vector's physical storage and
-    /// the accessed element is initialized.
-    pub fn as_mut_ptr<T>(&self) -> *mut T {
+    /// # Safety
+    /// The caller must ensure `T` matches the DuckDB vector's physical storage.
+    /// Before dereferencing the pointer, the caller must also ensure the target
+    /// element is initialized, in bounds, and not accessed through another
+    /// incompatible or aliased reference.
+    pub unsafe fn as_mut_ptr<T>(&self) -> *mut T {
         unsafe { duckdb_vector_get_data(self.ptr).cast() }
     }
 

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -76,28 +76,55 @@ impl<'a> FlatVector<'a> {
         !valid
     }
 
-    /// Returns an unsafe mutable pointer to the vector’s
+    /// Returns a mutable pointer to the vector's backing data cast to `T`.
+    ///
+    /// DuckDB stores this as untyped vector data. Dereferencing the returned
+    /// pointer is only valid when `T` matches the vector's physical storage and
+    /// the accessed element is initialized.
     pub fn as_mut_ptr<T>(&self) -> *mut T {
         unsafe { duckdb_vector_get_data(self.ptr).cast() }
     }
 
-    /// Returns a slice of the vector
-    pub fn as_slice<T>(&self) -> &[T] {
+    /// Returns a typed slice of the vector.
+    ///
+    /// # Safety
+    /// The caller must ensure `T` matches the DuckDB vector's physical storage,
+    /// the backing allocation is sized for `self.capacity()` elements of `T`,
+    /// each returned element is initialized before it is read, and no `&mut`
+    /// references to the same storage exist for the returned lifetime.
+    pub unsafe fn as_slice<T>(&self) -> &[T] {
         unsafe { slice::from_raw_parts(self.as_mut_ptr(), self.capacity()) }
     }
 
-    /// Returns a slice of the vector up to a certain length
-    pub fn as_slice_with_len<T>(&self, len: usize) -> &[T] {
+    /// Returns a typed slice of the vector up to a certain length.
+    ///
+    /// # Safety
+    /// The caller must ensure `T` matches the DuckDB vector's physical storage,
+    /// the backing allocation is sized for at least `len` elements of `T`, each
+    /// returned element is initialized before it is read, and no `&mut`
+    /// references to the same storage exist for the returned lifetime.
+    pub unsafe fn as_slice_with_len<T>(&self, len: usize) -> &[T] {
         unsafe { slice::from_raw_parts(self.as_mut_ptr(), len) }
     }
 
-    /// Returns a mutable slice of the vector
-    pub fn as_mut_slice<T>(&mut self) -> &mut [T] {
+    /// Returns a typed mutable slice of the vector.
+    ///
+    /// # Safety
+    /// The caller must ensure `T` matches the DuckDB vector's physical storage,
+    /// the backing allocation is sized for `self.capacity()` elements of `T`,
+    /// and no other references to the same storage exist for the returned
+    /// lifetime.
+    pub unsafe fn as_mut_slice<T>(&mut self) -> &mut [T] {
         unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.capacity()) }
     }
 
-    /// Returns a mutable slice of the vector up to a certain length
-    pub fn as_mut_slice_with_len<T>(&mut self, len: usize) -> &mut [T] {
+    /// Returns a typed mutable slice of the vector up to a certain length.
+    ///
+    /// # Safety
+    /// The caller must ensure `T` matches the DuckDB vector's physical storage,
+    /// the backing allocation is sized for at least `len` elements of `T`, and
+    /// no other references to the same storage exist for the returned lifetime.
+    pub unsafe fn as_mut_slice_with_len<T>(&mut self, len: usize) -> &mut [T] {
         unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 
@@ -115,10 +142,17 @@ impl<'a> FlatVector<'a> {
         }
     }
 
-    /// Copy data to the vector.
-    pub fn copy<T: Copy>(&mut self, data: &[T]) {
+    /// Copy typed data to the vector.
+    ///
+    /// # Safety
+    /// The caller must ensure `T` matches the DuckDB vector's physical storage
+    /// and no other references to the same storage exist during the copy.
+    ///
+    /// # Panics
+    /// Panics if `data.len()` exceeds the vector capacity.
+    pub unsafe fn copy<T: Copy>(&mut self, data: &[T]) {
         assert!(data.len() <= self.capacity());
-        self.as_mut_slice::<T>()[0..data.len()].copy_from_slice(data);
+        (unsafe { self.as_mut_slice::<T>() })[0..data.len()].copy_from_slice(data);
     }
 }
 
@@ -239,20 +273,25 @@ impl<'a> ListVector<'a> {
     }
 
     /// Set primitive data to the child node.
-    pub fn set_child<T: Copy>(&self, data: &[T]) {
-        self.child(data.len()).copy(data);
+    ///
+    /// # Safety
+    /// The caller must ensure `T` matches the child vector's physical storage
+    /// and no other references to the same storage exist during the copy.
+    pub unsafe fn set_child<T: Copy>(&self, data: &[T]) {
+        unsafe { self.child(data.len()).copy(data) };
         self.set_len(data.len());
     }
 
     /// Set offset and length to the entry.
     pub fn set_entry(&mut self, idx: usize, offset: usize, length: usize) {
-        self.entries.as_mut_slice::<duckdb_list_entry>()[idx].offset = offset as u64;
-        self.entries.as_mut_slice::<duckdb_list_entry>()[idx].length = length as u64;
+        let entries = unsafe { self.entries.as_mut_slice::<duckdb_list_entry>() };
+        entries[idx].offset = offset as u64;
+        entries[idx].length = length as u64;
     }
 
     /// Get offset and length for the entry at index.
     pub fn get_entry(&self, idx: usize) -> (usize, usize) {
-        let entry = self.entries.as_slice::<duckdb_list_entry>()[idx];
+        let entry = (unsafe { self.entries.as_slice::<duckdb_list_entry>() })[idx];
         (entry.offset as usize, entry.length as usize)
     }
 
@@ -320,8 +359,12 @@ impl<'a> ArrayVector<'a> {
     }
 
     /// Set primitive data to the child node.
-    pub fn set_child<T: Copy>(&self, data: &[T]) {
-        self.child(data.len()).copy(data);
+    ///
+    /// # Safety
+    /// The caller must ensure `T` matches the child vector's physical storage
+    /// and no other references to the same storage exist during the copy.
+    pub unsafe fn set_child<T: Copy>(&self, data: &[T]) {
+        unsafe { self.child(data.len()).copy(data) };
     }
 
     /// Set row as null

--- a/crates/duckdb/src/vscalar/mod.rs
+++ b/crates/duckdb/src/vscalar/mod.rs
@@ -237,7 +237,8 @@ mod test {
             input: &mut DataChunkHandle,
             _: &mut dyn WritableVector,
         ) -> Result<(), Box<dyn std::error::Error>> {
-            let mut msg = input.flat_vector(0).as_slice_with_len::<duckdb_string_t>(input.len())[0];
+            let vector = input.flat_vector(0);
+            let mut msg = unsafe { vector.as_slice_with_len::<duckdb_string_t>(input.len()) }[0];
             let string = DuckString::new(&mut msg).as_str();
             Err(format!("Error: {string}").into())
         }
@@ -276,7 +277,7 @@ mod test {
             output: &mut dyn WritableVector,
         ) -> Result<(), Box<dyn std::error::Error>> {
             let values = input.flat_vector(0);
-            let values = values.as_slice_with_len::<duckdb_string_t>(input.len());
+            let values = unsafe { values.as_slice_with_len::<duckdb_string_t>(input.len()) };
             let strings = values
                 .iter()
                 .map(|ptr| DuckString::new(&mut { *ptr }).as_str().to_string())
@@ -311,11 +312,11 @@ mod test {
             let output = output.flat_vector();
             let counts = input.flat_vector(1);
             let values = input.flat_vector(0);
-            let values = values.as_slice_with_len::<duckdb_string_t>(input.len());
+            let values = unsafe { values.as_slice_with_len::<duckdb_string_t>(input.len()) };
             let strings = values
                 .iter()
                 .map(|ptr| DuckString::new(&mut { *ptr }).as_str().to_string());
-            let counts = counts.as_slice_with_len::<i32>(input.len());
+            let counts = unsafe { counts.as_slice_with_len::<i32>(input.len()) };
             for (count, value) in counts.iter().zip(strings).take(input.len()) {
                 output.insert(0, value.repeat((*count) as usize).as_str());
             }
@@ -426,7 +427,7 @@ mod test {
         ) -> Result<(), Box<dyn std::error::Error>> {
             let len = input.len();
             let mut output_vec = output.flat_vector();
-            let data = output_vec.as_mut_slice::<i64>();
+            let data = unsafe { output_vec.as_mut_slice::<i64>() };
 
             for item in data.iter_mut().take(len) {
                 *item = NON_VOLATILE_COUNTER.fetch_add(1, Ordering::SeqCst) as i64;
@@ -454,7 +455,7 @@ mod test {
         ) -> Result<(), Box<dyn std::error::Error>> {
             let len = input.len();
             let mut output_vec = output.flat_vector();
-            let data = output_vec.as_mut_slice::<i64>();
+            let data = unsafe { output_vec.as_mut_slice::<i64>() };
 
             for item in data.iter_mut().take(len) {
                 *item = VOLATILE_COUNTER.fetch_add(1, Ordering::SeqCst) as i64;

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -265,7 +265,7 @@ pub fn flat_vector_to_arrow_array(
         LogicalTypeId::Invalid => Err("Cannot convert invalid logical type returned by DuckDB".into()),
         LogicalTypeId::Unsupported => Err(format!("Unsupported DuckDB logical type ID {raw_type_id}").into()),
         LogicalTypeId::Integer => {
-            let data = vector.as_slice_with_len::<i32>(len);
+            let data = unsafe { vector.as_slice_with_len::<i32>(len) };
 
             Ok(Arc::new(PrimitiveArray::<Int32Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -278,7 +278,7 @@ pub fn flat_vector_to_arrow_array(
         | LogicalTypeId::TimestampMs
         | LogicalTypeId::TimestampS
         | LogicalTypeId::TimestampTZ => {
-            let data = vector.as_slice_with_len::<duckdb_timestamp>(len);
+            let data = unsafe { vector.as_slice_with_len::<duckdb_timestamp>(len) };
             let micros = data.iter().map(|duckdb_timestamp { micros }| *micros);
             let structs = TimestampMicrosecondArray::from_iter_values_with_nulls(
                 micros,
@@ -290,7 +290,7 @@ pub fn flat_vector_to_arrow_array(
             Ok(Arc::new(structs))
         }
         LogicalTypeId::Varchar => {
-            let data = vector.as_slice_with_len::<duckdb_string_t>(len);
+            let data = unsafe { vector.as_slice_with_len::<duckdb_string_t>(len) };
 
             let duck_strings = data.iter().enumerate().map(|(i, s)| {
                 if vector.row_is_null(i as u64) {
@@ -306,7 +306,7 @@ pub fn flat_vector_to_arrow_array(
             Ok(Arc::new(StringArray::from(values)))
         }
         LogicalTypeId::Boolean => {
-            let data = vector.as_slice_with_len::<bool>(len);
+            let data = unsafe { vector.as_slice_with_len::<bool>(len) };
 
             Ok(Arc::new(BooleanArray::new(
                 BooleanBuffer::from_iter(data.iter().copied()),
@@ -316,7 +316,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::Float => {
-            let data = vector.as_slice_with_len::<f32>(len);
+            let data = unsafe { vector.as_slice_with_len::<f32>(len) };
 
             Ok(Arc::new(PrimitiveArray::<Float32Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -326,7 +326,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::Double => {
-            let data = vector.as_slice_with_len::<f64>(len);
+            let data = unsafe { vector.as_slice_with_len::<f64>(len) };
 
             Ok(Arc::new(PrimitiveArray::<Float64Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -336,7 +336,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::Date => {
-            let data = vector.as_slice_with_len::<duckdb_date>(len);
+            let data = unsafe { vector.as_slice_with_len::<duckdb_date>(len) };
 
             Ok(Arc::new(Date32Array::from_iter_values_with_nulls(
                 data.iter().map(|duckdb_date { days }| *days),
@@ -346,7 +346,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::Time => {
-            let data = vector.as_slice_with_len::<duckdb_time>(len);
+            let data = unsafe { vector.as_slice_with_len::<duckdb_time>(len) };
 
             Ok(Arc::new(
                 PrimitiveArray::<Time64MicrosecondType>::from_iter_values_with_nulls(
@@ -358,7 +358,7 @@ pub fn flat_vector_to_arrow_array(
             ))
         }
         LogicalTypeId::Smallint => {
-            let data = vector.as_slice_with_len::<i16>(len);
+            let data = unsafe { vector.as_slice_with_len::<i16>(len) };
 
             Ok(Arc::new(PrimitiveArray::<Int16Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -368,7 +368,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::USmallint => {
-            let data = vector.as_slice_with_len::<u16>(len);
+            let data = unsafe { vector.as_slice_with_len::<u16>(len) };
 
             Ok(Arc::new(PrimitiveArray::<UInt16Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -378,7 +378,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::Blob => {
-            let mut data = vector.as_slice_with_len::<duckdb_string_t>(len).to_vec();
+            let mut data = unsafe { vector.as_slice_with_len::<duckdb_string_t>(len) }.to_vec();
 
             let duck_strings = data.iter_mut().enumerate().map(|(i, ptr)| {
                 if vector.row_is_null(i as u64) {
@@ -400,7 +400,7 @@ pub fn flat_vector_to_arrow_array(
             Ok(Arc::new(builder.finish()))
         }
         LogicalTypeId::Tinyint => {
-            let data = vector.as_slice_with_len::<i8>(len);
+            let data = unsafe { vector.as_slice_with_len::<i8>(len) };
 
             Ok(Arc::new(PrimitiveArray::<Int8Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -410,7 +410,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::Bigint => {
-            let data = vector.as_slice_with_len::<i64>(len);
+            let data = unsafe { vector.as_slice_with_len::<i64>(len) };
 
             Ok(Arc::new(PrimitiveArray::<Int64Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -420,7 +420,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::UBigint => {
-            let data = vector.as_slice_with_len::<u64>(len);
+            let data = unsafe { vector.as_slice_with_len::<u64>(len) };
 
             Ok(Arc::new(PrimitiveArray::<UInt64Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -430,7 +430,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::UTinyint => {
-            let data = vector.as_slice_with_len::<u8>(len);
+            let data = unsafe { vector.as_slice_with_len::<u8>(len) };
 
             Ok(Arc::new(PrimitiveArray::<UInt8Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -440,7 +440,7 @@ pub fn flat_vector_to_arrow_array(
             )))
         }
         LogicalTypeId::UInteger => {
-            let data = vector.as_slice_with_len::<u32>(len);
+            let data = unsafe { vector.as_slice_with_len::<u32>(len) };
 
             Ok(Arc::new(PrimitiveArray::<UInt32Type>::from_iter_values_with_nulls(
                 data.iter().copied(),
@@ -451,7 +451,7 @@ pub fn flat_vector_to_arrow_array(
         }
         LogicalTypeId::TimestampNs => {
             // even nano second precision is stored in micros when using the c api
-            let data = vector.as_slice_with_len::<duckdb_timestamp>(len);
+            let data = unsafe { vector.as_slice_with_len::<duckdb_timestamp>(len) };
             let nanos = data.iter().map(|duckdb_timestamp { micros }| *micros * 1000);
             let structs = TimestampNanosecondArray::from_iter_values_with_nulls(
                 nanos,
@@ -683,7 +683,7 @@ pub fn record_batch_to_duckdb_data_chunk(
 
 fn primitive_array_to_flat_vector<T: ArrowPrimitiveType>(array: &PrimitiveArray<T>, out_vector: &mut FlatVector<'_>) {
     // assert!(array.len() <= out_vector.capacity());
-    out_vector.copy::<T::Native>(array.values());
+    unsafe { out_vector.copy::<T::Native>(array.values()) };
     set_nulls_in_flat_vector(array, out_vector);
 }
 
@@ -693,7 +693,7 @@ fn primitive_array_to_flat_vector_cast<T: ArrowPrimitiveType>(
     out_vector: &mut FlatVector<'_>,
 ) {
     let array = cast(array, &data_type).unwrap_or_else(|_| panic!("array is casted into {data_type}"));
-    out_vector.copy::<T::Native>(array.as_primitive::<T>().values());
+    unsafe { out_vector.copy::<T::Native>(array.as_primitive::<T>().values()) };
     set_nulls_in_flat_vector(&array, out_vector);
 }
 
@@ -784,25 +784,25 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut FlatVector<'_>) -> Res
 fn decimal_array_to_vector(array: &Decimal128Array, out: &mut FlatVector<'_>, width: u8) {
     match width {
         1..=4 => {
-            let out_data = out.as_mut_slice();
+            let out_data = unsafe { out.as_mut_slice() };
             for (i, value) in array.values().iter().enumerate() {
                 out_data[i] = value.to_i16().unwrap();
             }
         }
         5..=9 => {
-            let out_data = out.as_mut_slice();
+            let out_data = unsafe { out.as_mut_slice() };
             for (i, value) in array.values().iter().enumerate() {
                 out_data[i] = value.to_i32().unwrap();
             }
         }
         10..=18 => {
-            let out_data = out.as_mut_slice();
+            let out_data = unsafe { out.as_mut_slice() };
             for (i, value) in array.values().iter().enumerate() {
                 out_data[i] = value.to_i64().unwrap();
             }
         }
         19..=38 => {
-            let out_data = out.as_mut_slice();
+            let out_data = unsafe { out.as_mut_slice() };
             for (i, value) in array.values().iter().enumerate() {
                 out_data[i] = value.to_i128().unwrap();
             }
@@ -820,7 +820,7 @@ fn boolean_array_to_vector(array: &BooleanArray, out: &mut FlatVector<'_>) {
     assert!(array.len() <= out.capacity());
 
     for i in 0..array.len() {
-        out.as_mut_slice()[i] = array.value(i);
+        (unsafe { out.as_mut_slice() })[i] = array.value(i);
     }
     set_nulls_in_flat_vector(array, out);
 }

--- a/crates/duckdb/src/vtab/excel.rs
+++ b/crates/duckdb/src/vtab/excel.rs
@@ -140,17 +140,17 @@ impl VTab for ExcelVTab {
                             vector.insert(j, s.as_str());
                         }
                         Data::Float(f) => {
-                            vector.as_mut_slice::<f64>()[j] = *f;
+                            (unsafe { vector.as_mut_slice::<f64>() })[j] = *f;
                         }
                         Data::Int(ii) => {
-                            vector.as_mut_slice::<i64>()[j] = *ii;
+                            (unsafe { vector.as_mut_slice::<i64>() })[j] = *ii;
                         }
                         Data::Bool(b) => {
-                            vector.as_mut_slice::<bool>()[j] = *b;
+                            (unsafe { vector.as_mut_slice::<bool>() })[j] = *b;
                         }
                         Data::DateTime(d) => {
                             // 25569 = number of days between Unix and Excel epochs
-                            vector.as_mut_slice::<i32>()[j] = d.as_f64().round() as i32 - 25569;
+                            (unsafe { vector.as_mut_slice::<i32>() })[j] = d.as_f64().round() as i32 - 25569;
                         }
                         _ => {
                             vector.set_null(j);


### PR DESCRIPTION
By making typed vector slices unsafe.

**Breaking**: `FlatVector::{as_slice, as_slice_with_len, as_mut_slice, as_mut_slice_with_len, copy}`, `ListVector::set_child`, and `ArrayVector::set_child` are now unsafe, requiring downstream callers to update call sites.

https://github.com/rustsec/advisory-db/issues/2767