### PR TITLE
Stop panicking when binding/appending unsupported Value variants

### DIFF
--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -131,7 +131,10 @@ impl Appender<'_> {
         self.validate_parameter_values(&values)?;
 
         let _ = unsafe { ffi::duckdb_appender_begin_row(self.app) };
-        self.bind_parameter_values(&values)?;
+        if let Err(err) = self.bind_parameter_values(&values) {
+            let _ = unsafe { ffi::duckdb_appender_end_row(self.app) };
+            return Err(err);
+        }
         // NOTE: we only check end_row return value
         let rc = unsafe { ffi::duckdb_appender_end_row(self.app) };
         result_from_duckdb_appender(rc, &mut self.app)
@@ -212,7 +215,7 @@ impl Appender<'_> {
             },
             _ => {
                 return Err(Error::ToSqlConversionFailure(
-                    format!("appending value of type {} is not yet supported", value.data_type()).into(),
+                    appending_unsupported_value(value.data_type()).into(),
                 ));
             }
         };
@@ -343,15 +346,44 @@ mod test {
 
     #[test]
     fn test_append_unsupported_container_type_returns_error() -> Result<()> {
+        use arrow::{array::ListArray, datatypes::Int32Type};
+
         use crate::{
             ToSql,
-            types::{ToSqlOutput, Value},
+            types::{ListType, ToSqlOutput, Value, ValueRef},
         };
 
         struct OwnedList;
         impl ToSql for OwnedList {
             fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
                 Ok(ToSqlOutput::Owned(Value::List(vec![Value::Int(1), Value::Int(2)])))
+            }
+        }
+
+        struct BorrowedList(ListArray);
+        impl BorrowedList {
+            fn new() -> Self {
+                Self(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(vec![
+                    Some(1),
+                    Some(2),
+                ])]))
+            }
+        }
+        impl ToSql for BorrowedList {
+            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+                Ok(ToSqlOutput::Borrowed(ValueRef::List(ListType::Regular(&self.0), 0)))
+            }
+        }
+
+        fn assert_unsupported_list_error(err: Error) {
+            match err {
+                Error::ToSqlConversionFailure(e) => {
+                    assert!(
+                        e.to_string().contains("appending List values is not yet supported"),
+                        "unexpected message: {e}"
+                    );
+                }
+                other => panic!("expected ToSqlConversionFailure, got {other:?}"),
             }
         }
 
@@ -363,16 +395,11 @@ mod test {
         app.append_row(params![10, "before"])?;
         app.append_row(params![11, "also before"])?;
         let err = app.append_row(params![1, list]).unwrap_err();
+        assert_unsupported_list_error(err);
 
-        match err {
-            Error::ToSqlConversionFailure(e) => {
-                assert!(
-                    e.to_string().contains("appending List values is not yet supported"),
-                    "unexpected message: {e}"
-                );
-            }
-            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
-        }
+        let borrowed_list = BorrowedList::new();
+        let err = app.append_row(params![3, borrowed_list]).unwrap_err();
+        assert_unsupported_list_error(err);
         app.append_row(params![2, "ok"])?;
         app.flush()?;
 

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -130,7 +130,8 @@ impl Appender<'_> {
 
         let _ = unsafe { ffi::duckdb_appender_begin_row(self.app) };
         if let Err(err) = self.bind_parameter_values(&values) {
-            // Best-effort cleanup for defensive post-validation bind failures.
+            // validate_parameter_values catches unsupported types up-front; this guards
+            // against an unmapped variant slipping through bind_parameter.
             let _ = unsafe { ffi::duckdb_appender_end_row(self.app) };
             return Err(err);
         }

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -136,7 +136,30 @@ impl Appender<'_> {
         let ptr = self.app;
         let value = match value {
             ToSqlOutput::Borrowed(v) => v,
-            ToSqlOutput::Owned(ref v) => ValueRef::from(v),
+            // `From<&Value> for ValueRef` panics on container/enum variants.
+            // Refuse them here so callers see a clean error.
+            //
+            // Caveat: returning an error mid-row leaves the appender row in
+            // a partially populated state. Callers should treat this as a
+            // fatal row error and not attempt to reuse the partially built row.
+            ToSqlOutput::Owned(ref v) => {
+                use crate::types::Value;
+                let variant = match v {
+                    Value::List(_) => Some("List"),
+                    Value::Array(_) => Some("Array"),
+                    Value::Struct(_) => Some("Struct"),
+                    Value::Map(_) => Some("Map"),
+                    Value::Union(_) => Some("Union"),
+                    Value::Enum(_) => Some("Enum"),
+                    _ => None,
+                };
+                if let Some(variant) = variant {
+                    return Err(Error::ToSqlConversionFailure(
+                        format!("appending {variant} values is not yet supported").into(),
+                    ));
+                }
+                ValueRef::from(v)
+            }
         };
         // NOTE: we ignore the return value here
         //       because if anything failed, end_row will fail
@@ -193,7 +216,11 @@ impl Appender<'_> {
                 ffi::duckdb_destroy_value(&mut value);
                 res
             },
-            _ => unreachable!("not supported"),
+            _ => {
+                return Err(Error::ToSqlConversionFailure(
+                    format!("appending value of type {} is not yet supported", value.data_type()).into(),
+                ));
+            }
         };
         if rc != 0 {
             return Err(Error::AppendError);
@@ -275,6 +302,28 @@ mod test {
 
         let val = db.query_row("SELECT x FROM foo", [], |row| <(i32,)>::try_from(row))?;
         assert_eq!(val, (42,));
+        Ok(())
+    }
+
+    // Same gap as in `Statement::bind_parameter`: container types aren't yet
+    // wired up. Ensure they return an error rather than panic from safe Rust.
+    #[test]
+    fn test_append_unsupported_container_type_returns_error() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE foo(x INTEGER[])")?;
+
+        let list = Value::List(vec![Value::Int(1), Value::Int(2)]);
+        let mut app = db.appender("foo")?;
+        let err = app.append_row(params![&list]).unwrap_err();
+
+        match err {
+            Error::ToSqlConversionFailure(e) => {
+                assert!(e.to_string().contains("List"), "unexpected message: {e}");
+            }
+            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
+        }
         Ok(())
     }
 

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -117,7 +117,7 @@ impl Appender<'_> {
     }
 
     #[inline]
-    pub(crate) fn bind_parameters<P>(&mut self, params: P) -> Result<()>
+    pub(crate) fn append_parameter_row<P>(&mut self, params: P) -> Result<()>
     where
         P: IntoIterator,
         P::Item: ToSql,
@@ -128,18 +128,28 @@ impl Appender<'_> {
             .map(ToSql::to_sql)
             .collect::<Result<Vec<ToSqlOutput<'_>>>>()?;
 
-        for value in &values {
-            let value = to_value_ref(value)?;
-            validate_appender_value_ref(value)?;
-        }
+        self.validate_parameter_values(&values)?;
 
         let _ = unsafe { ffi::duckdb_appender_begin_row(self.app) };
-        for value in &values {
-            self.bind_parameter(value)?;
-        }
+        self.bind_parameter_values(&values)?;
         // NOTE: we only check end_row return value
         let rc = unsafe { ffi::duckdb_appender_end_row(self.app) };
         result_from_duckdb_appender(rc, &mut self.app)
+    }
+
+    fn validate_parameter_values(&self, values: &[ToSqlOutput<'_>]) -> Result<()> {
+        for value in values {
+            let value = to_value_ref(value)?;
+            validate_appender_value_ref(value)?;
+        }
+        Ok(())
+    }
+
+    fn bind_parameter_values(&self, values: &[ToSqlOutput<'_>]) -> Result<()> {
+        for value in values {
+            self.bind_parameter(value)?;
+        }
+        Ok(())
     }
 
     fn bind_parameter(&self, value: &ToSqlOutput<'_>) -> Result<()> {

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -4,7 +4,7 @@ use std::{ffi::c_void, fmt, os::raw::c_char};
 use crate::{
     Error,
     error::result_from_duckdb_appender,
-    types::{ToSql, ToSqlOutput},
+    types::{ToSql, ToSqlOutput, value_ref_from_value},
 };
 
 /// Appender for fast import data
@@ -80,7 +80,8 @@ impl Appender<'_> {
     ///
     /// # Failure
     ///
-    /// Will return `Err` if append column count not the same with the table schema
+    /// Will return `Err` if append column count not the same with the table
+    /// schema, or if a value cannot be converted for appending.
     #[inline]
     pub fn append_rows<P, I>(&mut self, rows: I) -> Result<()>
     where
@@ -108,14 +109,11 @@ impl Appender<'_> {
     ///
     /// # Failure
     ///
-    /// Will return `Err` if append column count not the same with the table schema
+    /// Will return `Err` if append column count not the same with the table
+    /// schema, or if a value cannot be converted for appending.
     #[inline]
     pub fn append_row<P: AppenderParams>(&mut self, params: P) -> Result<()> {
-        let _ = unsafe { ffi::duckdb_appender_begin_row(self.app) };
-        params.__bind_in(self)?;
-        // NOTE: we only check end_row return value
-        let rc = unsafe { ffi::duckdb_appender_end_row(self.app) };
-        result_from_duckdb_appender(rc, &mut self.app)
+        params.__bind_in(self)
     }
 
     #[inline]
@@ -124,43 +122,29 @@ impl Appender<'_> {
         P: IntoIterator,
         P::Item: ToSql,
     {
-        for p in params.into_iter() {
-            self.bind_parameter(&p)?;
+        let params = params.into_iter().collect::<Vec<_>>();
+        let values = params
+            .iter()
+            .map(ToSql::to_sql)
+            .collect::<Result<Vec<ToSqlOutput<'_>>>>()?;
+
+        for value in &values {
+            let value = to_value_ref(value)?;
+            validate_appender_value_ref(value)?;
         }
-        Ok(())
+
+        let _ = unsafe { ffi::duckdb_appender_begin_row(self.app) };
+        for value in &values {
+            self.bind_parameter(value)?;
+        }
+        // NOTE: we only check end_row return value
+        let rc = unsafe { ffi::duckdb_appender_end_row(self.app) };
+        result_from_duckdb_appender(rc, &mut self.app)
     }
 
-    fn bind_parameter<P: ?Sized + ToSql>(&self, param: &P) -> Result<()> {
-        let value = param.to_sql()?;
-
+    fn bind_parameter(&self, value: &ToSqlOutput<'_>) -> Result<()> {
         let ptr = self.app;
-        let value = match value {
-            ToSqlOutput::Borrowed(v) => v,
-            // `From<&Value> for ValueRef` panics on container/enum variants.
-            // Refuse them here so callers see a clean error.
-            //
-            // Caveat: returning an error mid-row leaves the appender row in
-            // a partially populated state. Callers should treat this as a
-            // fatal row error and not attempt to reuse the partially built row.
-            ToSqlOutput::Owned(ref v) => {
-                use crate::types::Value;
-                let variant = match v {
-                    Value::List(_) => Some("List"),
-                    Value::Array(_) => Some("Array"),
-                    Value::Struct(_) => Some("Struct"),
-                    Value::Map(_) => Some("Map"),
-                    Value::Union(_) => Some("Union"),
-                    Value::Enum(_) => Some("Enum"),
-                    _ => None,
-                };
-                if let Some(variant) = variant {
-                    return Err(Error::ToSqlConversionFailure(
-                        format!("appending {variant} values is not yet supported").into(),
-                    ));
-                }
-                ValueRef::from(v)
-            }
-        };
+        let value = to_value_ref(value)?;
         // NOTE: we ignore the return value here
         //       because if anything failed, end_row will fail
         // TODO: append more
@@ -284,6 +268,48 @@ impl fmt::Debug for Appender<'_> {
     }
 }
 
+fn appending_unsupported_value(value_type: impl fmt::Display) -> String {
+    format!("appending {value_type} values is not yet supported")
+}
+
+fn to_value_ref<'value, 'output>(value: &'value ToSqlOutput<'output>) -> Result<ValueRef<'value>>
+where
+    'output: 'value,
+{
+    match *value {
+        ToSqlOutput::Borrowed(v) => Ok(v),
+        ToSqlOutput::Owned(ref v) => value_ref_from_value(v, appending_unsupported_value),
+    }
+}
+
+fn validate_appender_value_ref(value: ValueRef<'_>) -> Result<()> {
+    match value {
+        ValueRef::Null
+        | ValueRef::Boolean(_)
+        | ValueRef::TinyInt(_)
+        | ValueRef::SmallInt(_)
+        | ValueRef::Int(_)
+        | ValueRef::BigInt(_)
+        | ValueRef::HugeInt(_)
+        | ValueRef::UTinyInt(_)
+        | ValueRef::USmallInt(_)
+        | ValueRef::UInt(_)
+        | ValueRef::UBigInt(_)
+        | ValueRef::Float(_)
+        | ValueRef::Double(_)
+        | ValueRef::Text(_)
+        | ValueRef::Timestamp(_, _)
+        | ValueRef::Blob(_)
+        | ValueRef::Date32(_)
+        | ValueRef::Time64(_, _)
+        | ValueRef::Interval { .. }
+        | ValueRef::Decimal(_) => Ok(()),
+        _ => Err(Error::ToSqlConversionFailure(
+            appending_unsupported_value(value.data_type()).into(),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use rust_decimal::Decimal;
@@ -305,25 +331,55 @@ mod test {
         Ok(())
     }
 
-    // Same gap as in `Statement::bind_parameter`: container types aren't yet
-    // wired up. Ensure they return an error rather than panic from safe Rust.
     #[test]
     fn test_append_unsupported_container_type_returns_error() -> Result<()> {
-        use crate::types::Value;
+        use crate::{
+            ToSql,
+            types::{ToSqlOutput, Value},
+        };
+
+        struct OwnedList;
+        impl ToSql for OwnedList {
+            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+                Ok(ToSqlOutput::Owned(Value::List(vec![Value::Int(1), Value::Int(2)])))
+            }
+        }
 
         let db = Connection::open_in_memory()?;
-        db.execute_batch("CREATE TABLE foo(x INTEGER[])")?;
+        db.execute_batch("CREATE TABLE foo(id INTEGER, name TEXT)")?;
 
-        let list = Value::List(vec![Value::Int(1), Value::Int(2)]);
+        let list = OwnedList;
         let mut app = db.appender("foo")?;
-        let err = app.append_row(params![&list]).unwrap_err();
+        app.append_row(params![10, "before"])?;
+        app.append_row(params![11, "also before"])?;
+        let err = app.append_row(params![1, list]).unwrap_err();
 
         match err {
             Error::ToSqlConversionFailure(e) => {
-                assert!(e.to_string().contains("List"), "unexpected message: {e}");
+                assert!(
+                    e.to_string().contains("appending List values is not yet supported"),
+                    "unexpected message: {e}"
+                );
             }
             other => panic!("expected ToSqlConversionFailure, got {other:?}"),
         }
+        app.append_row(params![2, "ok"])?;
+        app.flush()?;
+
+        let rows = db
+            .prepare("SELECT id, name FROM foo ORDER BY id")?
+            .query_map([], |row| Ok((row.get::<_, i32>(0)?, row.get::<_, String>(1)?)))?
+            .collect::<Result<Vec<_>>>()?;
+        assert_eq!(
+            rows,
+            vec![
+                (2, "ok".to_string()),
+                (10, "before".to_string()),
+                (11, "also before".to_string())
+            ]
+        );
+        let count: i32 = db.query_row("SELECT COUNT(*) FROM foo", [], |row| row.get(0))?;
+        assert_eq!(count, 3);
         Ok(())
     }
 

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -111,6 +111,9 @@ impl Appender<'_> {
     /// Returns `Err` if the row cannot be appended.
     #[inline]
     pub fn append_row<P: AppenderParams>(&mut self, params: P) -> Result<()> {
+        // AppenderParams normalizes arrays, tuples, slices, and iterators into
+        // append_parameter_row, which owns begin_row/end_row around validation
+        // and binding.
         params.__bind_in(self)
     }
 

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -80,8 +80,7 @@ impl Appender<'_> {
     ///
     /// # Failure
     ///
-    /// Will return `Err` if append column count not the same with the table
-    /// schema, or if a value cannot be converted for appending.
+    /// Returns `Err` if a row cannot be appended.
     #[inline]
     pub fn append_rows<P, I>(&mut self, rows: I) -> Result<()>
     where
@@ -109,8 +108,7 @@ impl Appender<'_> {
     ///
     /// # Failure
     ///
-    /// Will return `Err` if append column count not the same with the table
-    /// schema, or if a value cannot be converted for appending.
+    /// Returns `Err` if the row cannot be appended.
     #[inline]
     pub fn append_row<P: AppenderParams>(&mut self, params: P) -> Result<()> {
         params.__bind_in(self)
@@ -132,6 +130,7 @@ impl Appender<'_> {
 
         let _ = unsafe { ffi::duckdb_appender_begin_row(self.app) };
         if let Err(err) = self.bind_parameter_values(&values) {
+            // Best-effort cleanup for defensive post-validation bind failures.
             let _ = unsafe { ffi::duckdb_appender_end_row(self.app) };
             return Err(err);
         }
@@ -158,8 +157,6 @@ impl Appender<'_> {
     fn bind_parameter(&self, value: &ToSqlOutput<'_>) -> Result<()> {
         let ptr = self.app;
         let value = to_value_ref(value)?;
-        // NOTE: we ignore the return value here
-        //       because if anything failed, end_row will fail
         // TODO: append more
         let rc = match value {
             ValueRef::Null => unsafe { ffi::duckdb_append_null(ptr) },

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -112,8 +112,8 @@ impl Appender<'_> {
     #[inline]
     pub fn append_row<P: AppenderParams>(&mut self, params: P) -> Result<()> {
         // AppenderParams normalizes arrays, tuples, slices, and iterators into
-        // append_parameter_row, which owns begin_row/end_row around validation
-        // and binding.
+        // append_parameter_row, which validates up-front, then wraps binding
+        // with begin_row/end_row.
         params.__bind_in(self)
     }
 
@@ -135,10 +135,12 @@ impl Appender<'_> {
         if let Err(err) = self.bind_parameter_values(&values) {
             // validate_parameter_values catches unsupported types up-front; this guards
             // against an unmapped variant slipping through bind_parameter.
-            let _ = unsafe { ffi::duckdb_appender_end_row(self.app) };
+            let rc = unsafe { ffi::duckdb_appender_end_row(self.app) };
+            // Prefer cleanup failure here: result_from_duckdb_appender destroys
+            // an appender that DuckDB reports as invalid after a partial row.
+            result_from_duckdb_appender(rc, &mut self.app)?;
             return Err(err);
         }
-        // NOTE: we only check end_row return value
         let rc = unsafe { ffi::duckdb_appender_end_row(self.app) };
         result_from_duckdb_appender(rc, &mut self.app)
     }
@@ -418,6 +420,27 @@ mod test {
         );
         let count: i32 = db.query_row("SELECT COUNT(*) FROM foo", [], |row| row.get(0))?;
         assert_eq!(count, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_append_bind_failure_prefers_cleanup_error() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE foo(id INTEGER, value UUID)")?;
+
+        let mut app = db.appender("foo")?;
+        let err = app.append_row(params![1, 2]).unwrap_err();
+
+        match err {
+            Error::DuckDBFailure(_, Some(msg)) => {
+                assert!(
+                    msg.contains("Call to EndRow before all columns have been appended to"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected DuckDBFailure from appender cleanup, got {other:?}"),
+        }
+        assert!(app.app.is_null());
         Ok(())
     }
 

--- a/crates/duckdb/src/appender_params.rs
+++ b/crates/duckdb/src/appender_params.rs
@@ -119,7 +119,7 @@ pub trait AppenderParams: Sealed {
     // XXX not public api, might not need to expose.
     //
     // Binds the parameters to the statement. It is unlikely calling this
-    // explicitly will do what you want. Please use `Statement::query` or
+    // explicitly will do what you want. Please use `Appender::append_row` or
     // similar directly.
     //
     // For now, just hide the function in the docs...
@@ -137,7 +137,7 @@ impl AppenderParams for [&dyn ToSql; 0] {
         // Note: Can't just return `Ok(())` — `Statement::bind_parameters`
         // checks that the right number of params were passed too.
         // TODO: we should have tests for `Error::InvalidParameterCount`...
-        stmt.bind_parameters(&[] as &[&dyn ToSql])
+        stmt.append_parameter_row(&[] as &[&dyn ToSql])
     }
 }
 
@@ -145,7 +145,7 @@ impl Sealed for &[&dyn ToSql] {}
 impl AppenderParams for &[&dyn ToSql] {
     #[inline]
     fn __bind_in(self, stmt: &mut Appender<'_>) -> Result<()> {
-        stmt.bind_parameters(self)
+        stmt.append_parameter_row(self)
     }
 }
 
@@ -156,14 +156,14 @@ macro_rules! impl_for_array_ref {
         impl<T: ToSql + ?Sized> Sealed for &[&T; $N] {}
         impl<T: ToSql + ?Sized> AppenderParams for &[&T; $N] {
             fn __bind_in(self, stmt: &mut Appender<'_>) -> Result<()> {
-                stmt.bind_parameters(self)
+                stmt.append_parameter_row(self)
             }
         }
         impl<T: ToSql> Sealed for [T; $N] {}
         impl<T: ToSql> AppenderParams for [T; $N] {
             #[inline]
             fn __bind_in(self, stmt: &mut Appender<'_>) -> Result<()> {
-                stmt.bind_parameters(&self)
+                stmt.append_parameter_row(&self)
             }
         }
     )+};
@@ -189,7 +189,7 @@ macro_rules! impl_appender_params_for_tuple {
             fn __bind_in(self, stmt: &mut Appender<'_>) -> Result<()> {
                 #[allow(non_snake_case)]
                 let ($($T,)+) = &self;
-                stmt.bind_parameters(&[$($T as &dyn ToSql),+])
+                stmt.append_parameter_row([$($T as &dyn ToSql),+])
             }
         }
     };
@@ -340,7 +340,7 @@ where
 {
     #[inline]
     fn __bind_in(self, stmt: &mut Appender<'_>) -> Result<()> {
-        stmt.bind_parameters(self.0)
+        stmt.append_parameter_row(self.0)
     }
 }
 

--- a/crates/duckdb/src/appender_params.rs
+++ b/crates/duckdb/src/appender_params.rs
@@ -118,7 +118,7 @@ use sealed::Sealed;
 pub trait AppenderParams: Sealed {
     // XXX not public api, might not need to expose.
     //
-    // Binds the parameters to the statement. It is unlikely calling this
+    // Binds the parameters to the appender. It is unlikely calling this
     // explicitly will do what you want. Please use `Appender::append_row` or
     // similar directly.
     //
@@ -134,9 +134,8 @@ impl Sealed for [&dyn ToSql; 0] {}
 impl AppenderParams for [&dyn ToSql; 0] {
     #[inline]
     fn __bind_in(self, stmt: &mut Appender<'_>) -> Result<()> {
-        // Note: Can't just return `Ok(())` — `Statement::bind_parameters`
-        // checks that the right number of params were passed too.
-        // TODO: we should have tests for `Error::InvalidParameterCount`...
+        // Route through the normal append path so DuckDB can reject empty rows
+        // for tables that require values.
         stmt.append_parameter_row(&[] as &[&dyn ToSql])
     }
 }

--- a/crates/duckdb/src/pragma.rs
+++ b/crates/duckdb/src/pragma.rs
@@ -76,7 +76,7 @@ impl Sql {
             _ => {
                 return Err(Error::DuckDBFailure(
                     ffi::Error::new(ffi::DuckDBError),
-                    Some(format!("Unsupported value \"{value:?}\"")),
+                    Some(format!("Unsupported value type {}", value.data_type())),
                 ));
             }
         };

--- a/crates/duckdb/src/pragma.rs
+++ b/crates/duckdb/src/pragma.rs
@@ -6,7 +6,7 @@ use crate::{
     Connection, DatabaseName, Result, Row,
     error::Error,
     ffi,
-    types::{ToSql, ToSqlOutput, ValueRef},
+    types::{ToSql, ToSqlOutput, ValueRef, binding_unsupported_value, value_ref_from_value},
 };
 
 pub struct Sql {
@@ -60,7 +60,7 @@ impl Sql {
         let value = value.to_sql()?;
         let value = match value {
             ToSqlOutput::Borrowed(v) => v,
-            ToSqlOutput::Owned(ref v) => ValueRef::from(v),
+            ToSqlOutput::Owned(ref v) => value_ref_from_value(v, binding_unsupported_value)?,
         };
         match value {
             ValueRef::BigInt(i) => {

--- a/crates/duckdb/src/pragma.rs
+++ b/crates/duckdb/src/pragma.rs
@@ -306,6 +306,27 @@ mod test {
     }
 
     #[test]
+    fn pragma_rejects_unsupported_container_type() -> Result<()> {
+        use crate::{Error, types::Value};
+
+        let db = Connection::open_in_memory()?;
+        let err = db
+            .pragma(None, "table_info", &Value::List(vec![Value::Int(1)]), |_| Ok(()))
+            .unwrap_err();
+
+        match err {
+            Error::ToSqlConversionFailure(e) => {
+                assert!(
+                    e.to_string().contains("binding List parameters is not yet supported"),
+                    "unexpected message: {e}"
+                );
+            }
+            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
     fn pragma_update() -> Result<()> {
         let db = Connection::open_in_memory()?;
         db.pragma_update(None, "explain_output", &"PHYSICAL_ONLY")

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -567,7 +567,26 @@ impl Statement<'_> {
         let ptr = unsafe { self.stmt.ptr() };
         let value = match value {
             ToSqlOutput::Borrowed(v) => v,
-            ToSqlOutput::Owned(ref v) => ValueRef::from(v),
+            // `From<&Value> for ValueRef` panics on container/enum variants.
+            // Refuse them up front so callers see a clean error.
+            ToSqlOutput::Owned(ref v) => {
+                use crate::types::Value;
+                let variant = match v {
+                    Value::List(_) => Some("List"),
+                    Value::Array(_) => Some("Array"),
+                    Value::Struct(_) => Some("Struct"),
+                    Value::Map(_) => Some("Map"),
+                    Value::Union(_) => Some("Union"),
+                    Value::Enum(_) => Some("Enum"),
+                    _ => None,
+                };
+                if let Some(variant) = variant {
+                    return Err(Error::ToSqlConversionFailure(
+                        format!("binding {variant} parameters is not yet supported").into(),
+                    ));
+                }
+                ValueRef::from(v)
+            }
         };
         // TODO: bind more
         let rc = match value {
@@ -611,7 +630,11 @@ impl Statement<'_> {
                 let decimal = crate::types::to_duckdb_decimal(d);
                 ffi::duckdb_bind_decimal(ptr, col as u64, decimal)
             },
-            _ => unreachable!("not supported: {}", value.data_type()),
+            _ => {
+                return Err(Error::ToSqlConversionFailure(
+                    format!("binding parameter of type {} is not yet supported", value.data_type()).into(),
+                ));
+            }
         };
         result_from_duckdb_prepare(rc, ptr)
     }
@@ -1681,6 +1704,29 @@ mod test {
         let row: Decimal = db.query_row("SELECT 12345678901234567890::HUGEINT", [], |r| r.get(0))?;
         assert_eq!(row, Decimal::from_i128_with_scale(12345678901234567890, 0));
 
+        Ok(())
+    }
+
+    // Container types (List, Array, Struct, Map, Union) aren't yet wired up in `bind_parameter`.
+    // Until they are, binding one must surface an error rather than panic from safe Rust.
+    #[test]
+    fn test_bind_unsupported_container_type_returns_error() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE t (id INTEGER, numbers INTEGER[])", [])?;
+
+        let list = Value::List(vec![Value::Int(1), Value::Int(2)]);
+        let err = db
+            .execute("INSERT INTO t VALUES (?, ?)", crate::params![1, &list])
+            .unwrap_err();
+
+        match err {
+            Error::ToSqlConversionFailure(e) => {
+                assert!(e.to_string().contains("List"), "unexpected message: {e}");
+            }
+            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
+        }
         Ok(())
     }
 }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -416,27 +416,32 @@ impl Statement<'_> {
         P: IntoIterator,
         P::Item: ToSql,
     {
-        let result = (|| {
-            let expected = self.stmt.bind_parameter_count();
-            let mut index = 0;
-            for p in params.into_iter() {
-                index += 1; // The leftmost SQL parameter has an index of 1.
-                if index > expected {
-                    break;
-                }
-                self.bind_parameter(&p, index)?;
-            }
-            if index != expected {
-                Err(Error::InvalidParameterCount(index, expected))
-            } else {
-                Ok(())
-            }
-        })();
-
+        let result = self.try_bind_parameters(params);
         if result.is_err() {
             let _ = self.stmt.clear_bindings();
         }
         result
+    }
+
+    fn try_bind_parameters<P>(&mut self, params: P) -> Result<()>
+    where
+        P: IntoIterator,
+        P::Item: ToSql,
+    {
+        let expected = self.stmt.bind_parameter_count();
+        let mut index = 0;
+        for p in params.into_iter() {
+            index += 1; // The leftmost SQL parameter has an index of 1.
+            if index > expected {
+                break;
+            }
+            self.bind_parameter(&p, index)?;
+        }
+        if index != expected {
+            Err(Error::InvalidParameterCount(index, expected))
+        } else {
+            Ok(())
+        }
     }
 
     /// Return the number of parameters that can be bound to this statement.

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -416,20 +416,27 @@ impl Statement<'_> {
         P: IntoIterator,
         P::Item: ToSql,
     {
-        let expected = self.stmt.bind_parameter_count();
-        let mut index = 0;
-        for p in params.into_iter() {
-            index += 1; // The leftmost SQL parameter has an index of 1.
-            if index > expected {
-                break;
+        let result = (|| {
+            let expected = self.stmt.bind_parameter_count();
+            let mut index = 0;
+            for p in params.into_iter() {
+                index += 1; // The leftmost SQL parameter has an index of 1.
+                if index > expected {
+                    break;
+                }
+                self.bind_parameter(&p, index)?;
             }
-            self.bind_parameter(&p, index)?;
+            if index != expected {
+                Err(Error::InvalidParameterCount(index, expected))
+            } else {
+                Ok(())
+            }
+        })();
+
+        if result.is_err() {
+            let _ = self.stmt.clear_bindings();
         }
-        if index != expected {
-            Err(Error::InvalidParameterCount(index, expected))
-        } else {
-            Ok(())
-        }
+        result
     }
 
     /// Return the number of parameters that can be bound to this statement.
@@ -660,8 +667,40 @@ impl Statement<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Connection, Error, Result, params_from_iter, types::ToSql};
+    use arrow::{array::ListArray, datatypes::Int32Type};
+
+    use crate::{
+        Connection, Error, Result, params_from_iter,
+        types::{ListType, ToSql, ToSqlOutput, ValueRef},
+    };
     use rust_decimal::Decimal;
+
+    struct BorrowedList(ListArray);
+    impl BorrowedList {
+        fn new() -> Self {
+            Self(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(vec![
+                Some(1),
+                Some(2),
+            ])]))
+        }
+    }
+    impl ToSql for BorrowedList {
+        fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+            Ok(ToSqlOutput::Borrowed(ValueRef::List(ListType::Regular(&self.0), 0)))
+        }
+    }
+
+    fn assert_binding_list_error(err: Error) {
+        match err {
+            Error::ToSqlConversionFailure(e) => {
+                assert!(
+                    e.to_string().contains("binding List parameters is not yet supported"),
+                    "unexpected message: {e}"
+                );
+            }
+            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_execute() -> Result<()> {
@@ -1688,12 +1727,10 @@ mod test {
         Ok(())
     }
 
-    // Container and enum types (List, Array, Struct, Map, Union, Enum) aren't
-    // yet wired up in `bind_parameter`.
-    // Until they are, binding one must surface an error rather than panic from safe Rust.
+    // Unsupported Value variants must surface an error instead of panicking.
     #[test]
     fn test_bind_unsupported_container_type_returns_error() -> Result<()> {
-        use crate::types::{ToSqlOutput, Value};
+        use crate::types::Value;
 
         struct OwnedList;
         impl ToSql for OwnedList {
@@ -1710,15 +1747,31 @@ mod test {
             .execute("INSERT INTO t VALUES (?, ?)", crate::params![1, list])
             .unwrap_err();
 
-        match err {
-            Error::ToSqlConversionFailure(e) => {
-                assert!(
-                    e.to_string().contains("binding List parameters is not yet supported"),
-                    "unexpected message: {e}"
-                );
-            }
-            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
-        }
+        assert_binding_list_error(err);
+
+        let borrowed_list = BorrowedList::new();
+        let err = db
+            .execute("INSERT INTO t VALUES (?, ?)", crate::params![2, borrowed_list])
+            .unwrap_err();
+        assert_binding_list_error(err);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_error_clears_partial_parameter_state() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE t (id INTEGER NOT NULL, name TEXT)", [])?;
+
+        let mut stmt = db.prepare("INSERT INTO t VALUES (?, ?)")?;
+        let list = BorrowedList::new();
+        let err = stmt.execute(crate::params![1, list]).unwrap_err();
+        assert_binding_list_error(err);
+
+        stmt.raw_bind_parameter(2, "ok")?;
+        assert!(stmt.raw_execute().is_err());
+
+        let count: i32 = db.query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))?;
+        assert_eq!(count, 0);
         Ok(())
     }
 }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -8,7 +8,7 @@ use crate::polars_dataframe::Polars;
 use crate::{
     arrow_batch::{Arrow, ArrowStream},
     error::result_from_duckdb_prepare,
-    types::{ToSql, ToSqlOutput},
+    types::{ToSql, ToSqlOutput, binding_unsupported_value, value_ref_from_value},
 };
 #[cfg(feature = "polars")]
 use polars_core::utils::arrow as polars_arrow;
@@ -567,26 +567,7 @@ impl Statement<'_> {
         let ptr = unsafe { self.stmt.ptr() };
         let value = match value {
             ToSqlOutput::Borrowed(v) => v,
-            // `From<&Value> for ValueRef` panics on container/enum variants.
-            // Refuse them up front so callers see a clean error.
-            ToSqlOutput::Owned(ref v) => {
-                use crate::types::Value;
-                let variant = match v {
-                    Value::List(_) => Some("List"),
-                    Value::Array(_) => Some("Array"),
-                    Value::Struct(_) => Some("Struct"),
-                    Value::Map(_) => Some("Map"),
-                    Value::Union(_) => Some("Union"),
-                    Value::Enum(_) => Some("Enum"),
-                    _ => None,
-                };
-                if let Some(variant) = variant {
-                    return Err(Error::ToSqlConversionFailure(
-                        format!("binding {variant} parameters is not yet supported").into(),
-                    ));
-                }
-                ValueRef::from(v)
-            }
+            ToSqlOutput::Owned(ref v) => value_ref_from_value(v, binding_unsupported_value)?,
         };
         // TODO: bind more
         let rc = match value {
@@ -632,7 +613,7 @@ impl Statement<'_> {
             },
             _ => {
                 return Err(Error::ToSqlConversionFailure(
-                    format!("binding parameter of type {} is not yet supported", value.data_type()).into(),
+                    binding_unsupported_value(value.data_type()).into(),
                 ));
             }
         };
@@ -1707,23 +1688,34 @@ mod test {
         Ok(())
     }
 
-    // Container types (List, Array, Struct, Map, Union) aren't yet wired up in `bind_parameter`.
+    // Container and enum types (List, Array, Struct, Map, Union, Enum) aren't
+    // yet wired up in `bind_parameter`.
     // Until they are, binding one must surface an error rather than panic from safe Rust.
     #[test]
     fn test_bind_unsupported_container_type_returns_error() -> Result<()> {
-        use crate::types::Value;
+        use crate::types::{ToSqlOutput, Value};
+
+        struct OwnedList;
+        impl ToSql for OwnedList {
+            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+                Ok(ToSqlOutput::Owned(Value::List(vec![Value::Int(1), Value::Int(2)])))
+            }
+        }
 
         let db = Connection::open_in_memory()?;
         db.execute("CREATE TABLE t (id INTEGER, numbers INTEGER[])", [])?;
 
-        let list = Value::List(vec![Value::Int(1), Value::Int(2)]);
+        let list = OwnedList;
         let err = db
-            .execute("INSERT INTO t VALUES (?, ?)", crate::params![1, &list])
+            .execute("INSERT INTO t VALUES (?, ?)", crate::params![1, list])
             .unwrap_err();
 
         match err {
             Error::ToSqlConversionFailure(e) => {
-                assert!(e.to_string().contains("List"), "unexpected message: {e}");
+                assert!(
+                    e.to_string().contains("binding List parameters is not yet supported"),
+                    "unexpected message: {e}"
+                );
             }
             other => panic!("expected ToSqlConversionFailure, got {other:?}"),
         }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -1772,6 +1772,15 @@ mod test {
 
         let count: i32 = db.query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))?;
         assert_eq!(count, 0);
+
+        stmt.raw_bind_parameter(1, 7)?;
+        stmt.raw_bind_parameter(2, "ok")?;
+        assert_eq!(stmt.raw_execute()?, 1);
+
+        let row = db.query_row("SELECT id, name FROM t", [], |row| {
+            Ok((row.get::<_, i32>(0)?, row.get::<_, String>(1)?))
+        })?;
+        assert_eq!(row, (7, "ok".to_string()));
         Ok(())
     }
 }

--- a/crates/duckdb/src/types/chrono.rs
+++ b/crates/duckdb/src/types/chrono.rs
@@ -211,7 +211,7 @@ impl ToSql for Duration {
 mod test {
     use crate::{
         Connection, Result,
-        types::{FromSql, FromSqlError, ToSql, ToSqlOutput, ValueRef},
+        types::{FromSql, FromSqlError, ToSql, ToSqlOutput, ValueRef, binding_unsupported_value, value_ref_from_value},
     };
     use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta, TimeZone, Utc};
 
@@ -319,7 +319,7 @@ mod test {
         let sqled = td.to_sql().unwrap();
         let value = match sqled {
             ToSqlOutput::Borrowed(v) => v,
-            ToSqlOutput::Owned(ref v) => ValueRef::from(v),
+            ToSqlOutput::Owned(ref v) => value_ref_from_value(v, binding_unsupported_value).unwrap(),
         };
         let reversed = FromSql::column_result(value).unwrap();
 

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -11,6 +11,7 @@ pub use self::{
     value_ref::{EnumType, ListType, TimeUnit, ValueRef},
 };
 pub(crate) use decimal::to_duckdb_decimal;
+pub(crate) use value_ref::{binding_unsupported_value, value_ref_from_value};
 
 use arrow::datatypes::DataType;
 use std::fmt;

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -1,5 +1,5 @@
 use super::{Null, TimeUnit, Value, ValueRef};
-use crate::Result;
+use crate::{Error, Result};
 use std::borrow::Cow;
 
 /// `ToSqlOutput` represents the possible output types for implementers of the
@@ -188,7 +188,20 @@ impl ToSql for [u8] {
 impl ToSql for Value {
     #[inline]
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        Ok(ToSqlOutput::from(self))
+        // `From<&Value> for ValueRef` panics for container/enum variants.
+        // Refuse them here so callers get a clean `ToSqlConversionFailure` instead.
+        let variant = match self {
+            Value::List(_) => "List",
+            Value::Array(_) => "Array",
+            Value::Struct(_) => "Struct",
+            Value::Map(_) => "Map",
+            Value::Union(_) => "Union",
+            Value::Enum(_) => "Enum",
+            _ => return Ok(ToSqlOutput::from(self)),
+        };
+        Err(Error::ToSqlConversionFailure(
+            format!("binding {variant} parameters is not yet supported").into(),
+        ))
     }
 }
 
@@ -226,6 +239,40 @@ mod test {
         is_to_sql::<u8>();
         is_to_sql::<u16>();
         is_to_sql::<u32>();
+    }
+
+    #[test]
+    fn test_value_to_sql_rejects_unsupported_variants() {
+        use crate::{
+            Error,
+            types::{OrderedMap, Value},
+        };
+
+        let cases: &[(&str, Value)] = &[
+            ("List", Value::List(vec![Value::Int(1)])),
+            ("Array", Value::Array(vec![Value::Int(1)])),
+            (
+                "Struct",
+                Value::Struct(OrderedMap::from(vec![("k".to_string(), Value::Int(1))])),
+            ),
+            (
+                "Map",
+                Value::Map(OrderedMap::from(vec![(Value::Int(1), Value::Int(2))])),
+            ),
+            ("Union", Value::Union(Box::new(Value::Int(1)))),
+            ("Enum", Value::Enum("variant".to_string())),
+        ];
+
+        for (variant, value) in cases {
+            match value.to_sql() {
+                Err(Error::ToSqlConversionFailure(e)) => {
+                    let msg = e.to_string();
+                    assert!(msg.contains(variant), "{variant}: unexpected message {msg}");
+                }
+                Err(other) => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
+                Ok(_) => panic!("{variant}: expected error, got Ok"),
+            }
+        }
     }
 
     #[test]

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -1,5 +1,5 @@
-use super::{Null, TimeUnit, Value, ValueRef};
-use crate::{Error, Result};
+use super::{Null, TimeUnit, Value, ValueRef, binding_unsupported_value, value_ref_from_value};
+use crate::Result;
 use std::borrow::Cow;
 
 /// `ToSqlOutput` represents the possible output types for implementers of the
@@ -65,7 +65,7 @@ impl ToSql for ToSqlOutput<'_> {
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
         Ok(match *self {
             ToSqlOutput::Borrowed(v) => ToSqlOutput::Borrowed(v),
-            ToSqlOutput::Owned(ref v) => ToSqlOutput::Borrowed(ValueRef::from(v)),
+            ToSqlOutput::Owned(ref v) => ToSqlOutput::Borrowed(value_ref_from_value(v, binding_unsupported_value)?),
         })
     }
 }
@@ -188,20 +188,10 @@ impl ToSql for [u8] {
 impl ToSql for Value {
     #[inline]
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        // `From<&Value> for ValueRef` panics for container/enum variants.
-        // Refuse them here so callers get a clean `ToSqlConversionFailure` instead.
-        let variant = match self {
-            Value::List(_) => "List",
-            Value::Array(_) => "Array",
-            Value::Struct(_) => "Struct",
-            Value::Map(_) => "Map",
-            Value::Union(_) => "Union",
-            Value::Enum(_) => "Enum",
-            _ => return Ok(ToSqlOutput::from(self)),
-        };
-        Err(Error::ToSqlConversionFailure(
-            format!("binding {variant} parameters is not yet supported").into(),
-        ))
+        Ok(ToSqlOutput::Borrowed(value_ref_from_value(
+            self,
+            binding_unsupported_value,
+        )?))
     }
 }
 
@@ -226,7 +216,7 @@ impl ToSql for std::time::Duration {
 
 #[cfg(test)]
 mod test {
-    use super::ToSql;
+    use super::{ToSql, ToSqlOutput};
 
     fn is_to_sql<T: ToSql>() {}
 
@@ -267,7 +257,21 @@ mod test {
             match value.to_sql() {
                 Err(Error::ToSqlConversionFailure(e)) => {
                     let msg = e.to_string();
-                    assert!(msg.contains(variant), "{variant}: unexpected message {msg}");
+                    assert!(
+                        msg.contains(&format!("binding {variant} parameters is not yet supported")),
+                        "{variant}: unexpected message {msg}"
+                    );
+                }
+                Err(other) => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
+                Ok(_) => panic!("{variant}: expected error, got Ok"),
+            }
+            match ToSqlOutput::Owned(value.clone()).to_sql() {
+                Err(Error::ToSqlConversionFailure(e)) => {
+                    let msg = e.to_string();
+                    assert!(
+                        msg.contains(&format!("binding {variant} parameters is not yet supported")),
+                        "{variant}: unexpected message {msg}"
+                    );
                 }
                 Err(other) => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
                 Ok(_) => panic!("{variant}: expected error, got Ok"),

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -389,14 +389,14 @@ fn unsupported_value_variant(value: &Value) -> Option<&'static str> {
     }
 }
 
-/// Converts non-container `Value` variants into a borrowed `ValueRef`.
-///
-/// # Panics
-///
-/// Panics for `Value::Enum`, `Value::List`, `Value::Struct`, `Value::Map`,
-/// `Value::Array`, and `Value::Union`. Internal bind and append paths use
-/// `value_ref_from_value` for fallible conversion.
 impl<'a> From<&'a Value> for ValueRef<'a> {
+    /// Converts non-container `Value` variants into a borrowed `ValueRef`.
+    ///
+    /// # Panics
+    ///
+    /// Panics for `Value::Enum`, `Value::List`, `Value::Struct`, `Value::Map`,
+    /// `Value::Array`, and `Value::Union`. Internal bind and append paths use
+    /// `value_ref_from_value` for fallible conversion.
     #[inline]
     fn from(value: &'a Value) -> Self {
         match *value {

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -1,7 +1,7 @@
 use super::{Type, Value};
 use crate::types::{FromSqlError, FromSqlResult, OrderedMap};
 
-use crate::Row;
+use crate::{Error, Result, Row};
 use rust_decimal::prelude::*;
 
 use arrow::{
@@ -343,6 +343,33 @@ impl<'a> From<&'a [u8]> for ValueRef<'a> {
     }
 }
 
+pub(crate) fn value_ref_from_value<'a>(
+    value: &'a Value,
+    unsupported_message: impl FnOnce(&'static str) -> String,
+) -> Result<ValueRef<'a>> {
+    if let Some(variant) = unsupported_value_variant(value) {
+        return Err(Error::ToSqlConversionFailure(unsupported_message(variant).into()));
+    }
+
+    Ok(ValueRef::from(value))
+}
+
+pub(crate) fn binding_unsupported_value(value_type: impl std::fmt::Display) -> String {
+    format!("binding {value_type} parameters is not yet supported")
+}
+
+fn unsupported_value_variant(value: &Value) -> Option<&'static str> {
+    match value {
+        Value::List(_) => Some("List"),
+        Value::Array(_) => Some("Array"),
+        Value::Struct(_) => Some("Struct"),
+        Value::Map(_) => Some("Map"),
+        Value::Union(_) => Some("Union"),
+        Value::Enum(_) => Some("Enum"),
+        _ => None,
+    }
+}
+
 impl<'a> From<&'a Value> for ValueRef<'a> {
     #[inline]
     fn from(value: &'a Value) -> Self {
@@ -367,6 +394,8 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
             Value::Date32(d) => ValueRef::Date32(d),
             Value::Time64(t, d) => ValueRef::Time64(t, d),
             Value::Interval { months, days, nanos } => ValueRef::Interval { months, days, nanos },
+            // Use `value_ref_from_value` at bind sites that need fallible
+            // conversion for unsupported Value variants.
             Value::Enum(..) => todo!(),
             Value::List(..) | Value::Struct(..) | Value::Map(..) | Value::Array(..) | Value::Union(..) => {
                 unimplemented!()

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -370,6 +370,13 @@ fn unsupported_value_variant(value: &Value) -> Option<&'static str> {
     }
 }
 
+/// Converts scalar `Value` variants into a borrowed `ValueRef`.
+///
+/// # Panics
+///
+/// Panics for `Value::Enum`, `Value::List`, `Value::Struct`, `Value::Map`,
+/// `Value::Array`, and `Value::Union`. Internal bind and append paths use
+/// `value_ref_from_value` for fallible conversion.
 impl<'a> From<&'a Value> for ValueRef<'a> {
     #[inline]
     fn from(value: &'a Value) -> Self {
@@ -394,11 +401,14 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
             Value::Date32(d) => ValueRef::Date32(d),
             Value::Time64(t, d) => ValueRef::Time64(t, d),
             Value::Interval { months, days, nanos } => ValueRef::Interval { months, days, nanos },
-            // Use `value_ref_from_value` at bind sites that need fallible
-            // conversion for unsupported Value variants.
-            Value::Enum(..) => todo!(),
-            Value::List(..) | Value::Struct(..) | Value::Map(..) | Value::Array(..) | Value::Union(..) => {
-                unimplemented!()
+            Value::Enum(..)
+            | Value::List(..)
+            | Value::Struct(..)
+            | Value::Map(..)
+            | Value::Array(..)
+            | Value::Union(..) => {
+                let variant = unsupported_value_variant(value).expect("unsupported Value variant");
+                panic!("ValueRef::from(&Value::{variant}) is not supported; use value_ref_from_value")
             }
         }
     }

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -360,17 +360,36 @@ pub(crate) fn binding_unsupported_value(value_type: impl std::fmt::Display) -> S
 
 fn unsupported_value_variant(value: &Value) -> Option<&'static str> {
     match value {
+        Value::Null
+        | Value::Boolean(_)
+        | Value::TinyInt(_)
+        | Value::SmallInt(_)
+        | Value::Int(_)
+        | Value::BigInt(_)
+        | Value::HugeInt(_)
+        | Value::UTinyInt(_)
+        | Value::USmallInt(_)
+        | Value::UInt(_)
+        | Value::UBigInt(_)
+        | Value::Float(_)
+        | Value::Double(_)
+        | Value::Decimal(_)
+        | Value::Timestamp(_, _)
+        | Value::Text(_)
+        | Value::Blob(_)
+        | Value::Date32(_)
+        | Value::Time64(_, _)
+        | Value::Interval { .. } => None,
         Value::List(_) => Some("List"),
         Value::Array(_) => Some("Array"),
         Value::Struct(_) => Some("Struct"),
         Value::Map(_) => Some("Map"),
         Value::Union(_) => Some("Union"),
         Value::Enum(_) => Some("Enum"),
-        _ => None,
     }
 }
 
-/// Converts scalar `Value` variants into a borrowed `ValueRef`.
+/// Converts non-container `Value` variants into a borrowed `ValueRef`.
 ///
 /// # Panics
 ///
@@ -429,8 +448,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::types::Type;
+    use crate::types::{Type, Value, ValueRef};
     use crate::{Connection, Result};
+
+    #[test]
+    #[should_panic(expected = "ValueRef::from(&Value::List)")]
+    fn value_ref_from_list_value_panics() {
+        let value = Value::List(vec![Value::Int(1)]);
+        let _ = ValueRef::from(&value);
+    }
 
     #[test]
     fn test_list_types() -> Result<()> {


### PR DESCRIPTION
A safe Rust API should not panic in that case.

Stopgap for #680 and #533 (that also clarifies current gaps).