### PR TITLE
libduckdb-sys: expose DEP_DUCKDB_INCLUDE for downstream C/C++ shims

### DIFF
--- a/crates/libduckdb-sys/Cargo.toml
+++ b/crates/libduckdb-sys/Cargo.toml
@@ -8,6 +8,12 @@ homepage = { workspace = true }
 keywords = { workspace = true }
 readme = { workspace = true }
 build = "build.rs"
+# `links = "duckdb"` lets the build script publish metadata
+# (`cargo:include`, `cargo:lib_dir`) that downstream crates can read
+# via `DEP_DUCKDB_*` environment variables in their own build scripts.
+# Required for crates that need to compile their own C/C++ code that
+# `#include "duckdb.hpp"` against the bundled headers.
+links = "duckdb"
 categories = ["external-ffi-bindings", "database"]
 description = "Native bindings to the libduckdb library, C API"
 exclude = ["duckdb-sources"]

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -154,7 +154,15 @@ mod build_linked {
     fn include_dir_for(header: &HeaderLocation) -> Option<String> {
         match header {
             HeaderLocation::FromEnvironment => env::var("DUCKDB_INCLUDE_DIR")
-                .or_else(|_| env::var("DUCKDB_LIB_DIR"))
+                .or_else(|_| {
+                    env::var("DUCKDB_LIB_DIR").and_then(|dir| {
+                        if Path::new(&dir).join("duckdb.h").exists() {
+                            Ok(dir)
+                        } else {
+                            Err(env::VarError::NotPresent)
+                        }
+                    })
+                })
                 .ok(),
             HeaderLocation::FromPath(path) => Some(path.clone()),
             HeaderLocation::Wrapper => None,

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -120,6 +120,16 @@ mod build_linked {
         #[allow(unused_variables)]
         let header = find_duckdb(out_dir);
 
+        // Publish the resolved include directory so downstream crates
+        // that compile their own C/C++ code can read it from
+        // `DEP_DUCKDB_INCLUDE`. Wrapper-only mode (no explicit dir
+        // from env / vcpkg / pkg-config / download) intentionally
+        // skips the emission — there's no single directory to point
+        // at; the system header is on the default search path already.
+        if let Some(include_dir) = include_dir_for(&header) {
+            println!("cargo:include={include_dir}");
+        }
+
         #[cfg(not(feature = "buildtime_bindgen"))]
         {
             std::fs::copy(
@@ -135,6 +145,19 @@ mod build_linked {
         #[cfg(feature = "buildtime_bindgen")]
         {
             bindings::write_to_out_dir(header, out_path);
+        }
+    }
+
+    /// The `HeaderLocation` enum string conversion appends a filename to
+    /// the path it resolved. For `cargo:include=...` we want the
+    /// directory itself, not a file path. Re-derive it.
+    fn include_dir_for(header: &HeaderLocation) -> Option<String> {
+        match header {
+            HeaderLocation::FromEnvironment => env::var("DUCKDB_INCLUDE_DIR")
+                .or_else(|_| env::var("DUCKDB_LIB_DIR"))
+                .ok(),
+            HeaderLocation::FromPath(path) => Some(path.clone()),
+            HeaderLocation::Wrapper => None,
         }
     }
 

--- a/crates/libduckdb-sys/build_bundled_cc.rs
+++ b/crates/libduckdb-sys/build_bundled_cc.rs
@@ -116,7 +116,15 @@ fn untar_archive(out_dir: &str) {
 pub fn main(out_dir: &str, out_path: &Path) {
     untar_archive(out_dir);
 
-    write_bindings(&Path::new(out_dir).join("duckdb/src/include"), out_path);
+    let include_path = Path::new(out_dir).join("duckdb/src/include");
+    write_bindings(&include_path, out_path);
+
+    // Publish the include directory so downstream crates that compile
+    // their own C/C++ code (e.g. extension shims that #include
+    // "duckdb.hpp") can pick it up from `DEP_DUCKDB_INCLUDE` without
+    // having to glob the target tree. Requires `links = "duckdb"` in
+    // the package manifest.
+    println!("cargo:include={}", include_path.display());
 
     let manifest_file = std::fs::File::open(format!("{out_dir}/duckdb/manifest.json")).expect("manifest file");
     let manifest: Manifest = serde_json::from_reader(manifest_file).expect("reading manifest file");

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -37,7 +37,14 @@ pub fn main(_out_dir: &str, out_path: &Path) {
     println!("cargo:rerun-if-env-changed=CMAKE_CXX_COMPILER_LAUNCHER");
     println!("cargo:rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET");
 
-    write_bindings(&source_dir.join("src/include"), out_path);
+    let include_path = source_dir.join("src/include").canonicalize().unwrap();
+    write_bindings(&include_path, out_path);
+
+    // Publish the include directory so downstream crates that compile
+    // their own C/C++ code can read it from `DEP_DUCKDB_INCLUDE`.
+    // See the matching emission in build_bundled_cc.rs.
+    println!("cargo:include={}", include_path.display());
+
     if let Some(configs) = env_var("DUCKDB_EXTENSION_CONFIGS") {
         if !configs.trim().is_empty() {
             panic!(


### PR DESCRIPTION
## What

Add `links = "duckdb"` to `libduckdb-sys`'s manifest and emit `cargo:include=<path>` from each backend so downstream crates that compile their own C/C++ code can read the resolved DuckDB include directory from `DEP_DUCKDB_INCLUDE` in their own build scripts.

## Why

Crates that ship native extension code (e.g. an `OptimizerExtension` shim that `#include "duckdb.hpp"`) need access to libduckdb-sys's DuckDB headers at their own build time.

Today they have to either:
- Glob `target/<profile>/build/libduckdb-sys-<hash>/out/duckdb/src/include` from their `build.rs`, or
- Vendor a copy of the DuckDB headers into their own crate.

Both are fragile: the glob breaks across cargo versions and is awkward in cross-builds; vendoring drifts from the bundled DuckDB ABI on every `libduckdb-sys` upgrade.

The standard Cargo mechanism for this is the `links` directive plus `cargo:KEY=VALUE` metadata. With this PR, downstream code can simply:

```rust
// downstream build.rs
fn main() {
    let inc = std::env::var("DEP_DUCKDB_INCLUDE").unwrap();
    cc::Build::new()
        .cpp(true)
        .file("cpp/extension_shim.cpp")
        .include(&inc)
        .compile("my_extension_shim");
}
```

This unblocks downstream crates from registering things like `duckdb::OptimizerExtension` from their own native code without resorting to the C API (which the issue at duckdb/duckdb#19093 is still working out).

## Changes

- `crates/libduckdb-sys/Cargo.toml`: add `links = "duckdb"` so build-script metadata flows to downstream `DEP_DUCKDB_*` env vars.
- `crates/libduckdb-sys/build_bundled_cc.rs`: emit `cargo:include=<OUT_DIR>/duckdb/src/include`.
- `crates/libduckdb-sys/build_bundled_cmake.rs`: emit `cargo:include=<duckdb-sources>/src/include`.
- `crates/libduckdb-sys/build.rs` (the `build_linked` path): emit `cargo:include=...` derived from the resolved `HeaderLocation` — `DUCKDB_INCLUDE_DIR`, `DUCKDB_LIB_DIR`, vcpkg, pkg-config, or download dir.

Wrapper-only mode (system DuckDB found via pkg-config without an explicit include path) intentionally skips the emission — there's no single directory to publish; the system header is already on the default search path, and downstream shims fall through to the same default include resolution.

## Behaviour change

None for existing Rust consumers — the only public-surface change is a new `links` directive, which doesn't affect compilation of crates that don't run their own `build.rs` against duckdb headers.

## Validation

The companion downstream project that motivated this PR (`dbfy` — embedded SQL federation engine, [github.com/frhack/dbfy](https://github.com/frhack/dbfy)) ships an `OptimizerExtension` shim in bundled mode (`--features duckdb`) that needs these headers. Its `build.rs` currently uses the target-tree glob hack as a documented workaround; once this PR is in a release, the shim can switch to the clean `DEP_DUCKDB_INCLUDE` path.

Happy to add a small test or example exercising the metadata if useful.