### PR TITLE
Pass Rust edition to rust.vim for proper formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
+edition = "2024"
 max_width = 120


### PR DESCRIPTION
Otherwise, `vim` and `cargo fmt` will format code differently.