### PR TITLE
Implement binding for List

### DIFF
--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -4,7 +4,8 @@ use std::{ffi::c_void, fmt, os::raw::c_char};
 use crate::{
     Error,
     error::result_from_duckdb_appender,
-    types::{ToSql, ToSqlOutput},
+    statement::{value_ref_to_duckdb, value_to_duckdb},
+    types::{ToSql, ToSqlOutput, Value},
 };
 
 /// Appender for fast import data
@@ -147,8 +148,10 @@ impl Appender<'_> {
 
     fn validate_parameter_values(&self, values: &[ToSqlOutput<'_>]) -> Result<()> {
         for value in values {
-            let value = to_value_ref(value)?;
-            validate_appender_value_ref(value)?;
+            match value.as_value_ref() {
+                Ok(r) => validate_appender_value_ref(r)?,
+                Err(v) => validate_appender_value(v)?,
+            }
         }
         Ok(())
     }
@@ -162,9 +165,21 @@ impl Appender<'_> {
 
     fn bind_parameter(&self, value: &ToSqlOutput<'_>) -> Result<()> {
         let ptr = self.app;
-        let value = to_value_ref(value)?;
+
+        let value_ref = match value.as_value_ref() {
+            Ok(r) => r,
+            Err(value) => unsafe {
+                // Container types cannot be converted to ValueRef.
+                // Bind them as duckdb_value instead.
+                let duckdb_val = value_to_duckdb(value)?;
+                let rc = ffi::duckdb_append_value(ptr, duckdb_val);
+                ffi::duckdb_destroy_value(&mut { duckdb_val });
+                return if rc != 0 { Err(Error::AppendError) } else { Ok(()) };
+            },
+        };
+
         // TODO: append more
-        let rc = match value {
+        let rc = match value_ref {
             ValueRef::Null => unsafe { ffi::duckdb_append_null(ptr) },
             ValueRef::Boolean(i) => unsafe { ffi::duckdb_append_bool(ptr, i) },
             ValueRef::TinyInt(i) => unsafe { ffi::duckdb_append_int8(ptr, i) },
@@ -216,9 +231,17 @@ impl Appender<'_> {
                 ffi::duckdb_destroy_value(&mut value);
                 res
             },
-            _ => {
-                return Err(appending_unsupported_value(value.data_type()));
-            }
+            ValueRef::List(..)
+            | ValueRef::Struct(..)
+            | ValueRef::Map(..)
+            | ValueRef::Array(..)
+            | ValueRef::Union(..)
+            | ValueRef::Enum(..) => unsafe {
+                let mut duckdb_val = value_ref_to_duckdb(value_ref)?;
+                let res = ffi::duckdb_append_value(ptr, duckdb_val);
+                ffi::duckdb_destroy_value(&mut duckdb_val);
+                res
+            },
         };
         if rc != 0 {
             return Err(Error::AppendError);
@@ -286,13 +309,6 @@ fn appending_unsupported_value(value_type: impl fmt::Display) -> crate::Error {
     crate::Error::ToSqlConversionFailure(format!("appending {value_type} values is not yet supported").into())
 }
 
-fn to_value_ref<'value>(value: &'value ToSqlOutput<'_>) -> Result<ValueRef<'value>> {
-    match value.as_value_ref() {
-        Ok(v) => Ok(v),
-        Err(v) => Err(appending_unsupported_value(v.data_type_name())),
-    }
-}
-
 fn validate_appender_value_ref(value: ValueRef<'_>) -> Result<()> {
     match value {
         ValueRef::Null
@@ -314,16 +330,63 @@ fn validate_appender_value_ref(value: ValueRef<'_>) -> Result<()> {
         | ValueRef::Date32(_)
         | ValueRef::Time64(_, _)
         | ValueRef::Interval { .. }
-        | ValueRef::Decimal(_) => Ok(()),
-        _ => Err(appending_unsupported_value(value.data_type())),
+        | ValueRef::Decimal(_)
+        | ValueRef::List(..) => Ok(()),
+        _ => Err(Error::ToSqlConversionFailure(
+            appending_unsupported_value(value.data_type()).into(),
+        )),
+    }
+}
+
+fn validate_appender_value(value: &Value) -> Result<()> {
+    match value {
+        Value::Null
+        | Value::Boolean(_)
+        | Value::TinyInt(_)
+        | Value::SmallInt(_)
+        | Value::Int(_)
+        | Value::BigInt(_)
+        | Value::HugeInt(_)
+        | Value::UTinyInt(_)
+        | Value::USmallInt(_)
+        | Value::UInt(_)
+        | Value::UBigInt(_)
+        | Value::Float(_)
+        | Value::Double(_)
+        | Value::Text(_)
+        | Value::Timestamp(_, _)
+        | Value::Blob(_)
+        | Value::Date32(_)
+        | Value::Time64(_, _)
+        | Value::Interval { .. }
+        | Value::Decimal(_)
+        | Value::List(_) => Ok(()),
+        _ => Err(Error::ToSqlConversionFailure(
+            appending_unsupported_value(value.data_type_name()).into(),
+        )),
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::ToSql;
+    use crate::types::{ListType, ToSqlOutput, ValueRef};
+    use arrow::{array::ListArray, datatypes::Int32Type};
     use rust_decimal::Decimal;
 
     use crate::{Connection, Error, Result, params};
+
+    struct BorrowedList(ListArray);
+    impl BorrowedList {
+        fn new(value: Vec<Option<i32>>) -> Self {
+            Self(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(value)]))
+        }
+    }
+    impl ToSql for BorrowedList {
+        fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+            Ok(ToSqlOutput::Borrowed(ValueRef::List(ListType::Regular(&self.0), 0)))
+        }
+    }
 
     #[test]
     fn test_append_one_row() -> Result<()> {
@@ -341,78 +404,56 @@ mod test {
     }
 
     #[test]
-    fn test_append_unsupported_container_type_returns_error() -> Result<()> {
-        use arrow::{array::ListArray, datatypes::Int32Type};
-
-        use crate::{
-            ToSql,
-            types::{ListType, ToSqlOutput, Value, ValueRef},
-        };
-
-        struct OwnedList;
-        impl ToSql for OwnedList {
-            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-                Ok(ToSqlOutput::Owned(Value::List(vec![Value::Int(1), Value::Int(2)])))
-            }
-        }
-
-        struct BorrowedList(ListArray);
-        impl BorrowedList {
-            fn new() -> Self {
-                Self(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(vec![
-                    Some(1),
-                    Some(2),
-                ])]))
-            }
-        }
-        impl ToSql for BorrowedList {
-            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-                Ok(ToSqlOutput::Borrowed(ValueRef::List(ListType::Regular(&self.0), 0)))
-            }
-        }
-
-        fn assert_unsupported_list_error(err: Error) {
-            match err {
-                Error::ToSqlConversionFailure(e) => {
-                    assert!(
-                        e.to_string().contains("appending List values is not yet supported"),
-                        "unexpected message: {e}"
-                    );
-                }
-                other => panic!("expected ToSqlConversionFailure, got {other:?}"),
-            }
-        }
+    fn test_append_list() -> Result<()> {
+        use crate::types::Value;
 
         let db = Connection::open_in_memory()?;
-        db.execute_batch("CREATE TABLE foo(id INTEGER, name TEXT)")?;
+        db.execute_batch("CREATE TABLE foo(numbers INTEGER[])")?;
 
-        let list = OwnedList;
-        let mut app = db.appender("foo")?;
-        app.append_row(params![10, "before"])?;
-        app.append_row(params![11, "also before"])?;
-        let err = app.append_row(params![1, list]).unwrap_err();
-        assert_unsupported_list_error(err);
+        {
+            let mut app = db.appender("foo")?;
+            let list = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+            app.append_row(params![&list])?;
+        }
 
-        let borrowed_list = BorrowedList::new();
-        let err = app.append_row(params![3, borrowed_list]).unwrap_err();
-        assert_unsupported_list_error(err);
-        app.append_row(params![2, "ok"])?;
-        app.flush()?;
+        let result: Value = db.query_row("SELECT numbers FROM foo", [], |r| r.get(0))?;
+        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]));
+        Ok(())
+    }
 
-        let rows = db
-            .prepare("SELECT id, name FROM foo ORDER BY id")?
-            .query_map([], |row| Ok((row.get::<_, i32>(0)?, row.get::<_, String>(1)?)))?
-            .collect::<Result<Vec<_>>>()?;
-        assert_eq!(
-            rows,
-            vec![
-                (2, "ok".to_string()),
-                (10, "before".to_string()),
-                (11, "also before".to_string())
-            ]
-        );
-        let count: i32 = db.query_row("SELECT COUNT(*) FROM foo", [], |row| row.get(0))?;
-        assert_eq!(count, 3);
+    #[test]
+    fn test_append_borrowed_list() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE foo(numbers INTEGER[])")?;
+
+        {
+            let mut app = db.appender("foo")?;
+            let borrowed_list = BorrowedList::new(vec![Some(1), Some(2), Some(3)]);
+            app.append_row(params![borrowed_list]).unwrap();
+        }
+
+        let result: Value = db.query_row("SELECT numbers FROM foo", [], |r| r.get(0))?;
+        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_append_borrowed_list_nulls() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE foo(numbers INTEGER[])")?;
+
+        {
+            let mut app = db.appender("foo")?;
+            let borrowed_list = BorrowedList::new(vec![Some(1), None, Some(3)]);
+            app.append_row(params![borrowed_list]).unwrap();
+        }
+
+        let result: Value = db.query_row("SELECT numbers FROM foo", [], |r| r.get(0))?;
+        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Null, Value::Int(3)]));
         Ok(())
     }
 

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -4,7 +4,7 @@ use std::{ffi::c_void, fmt, os::raw::c_char};
 use crate::{
     Error,
     error::result_from_duckdb_appender,
-    types::{ToSql, ToSqlOutput, value_ref_from_value},
+    types::{ToSql, ToSqlOutput},
 };
 
 /// Appender for fast import data
@@ -217,9 +217,7 @@ impl Appender<'_> {
                 res
             },
             _ => {
-                return Err(Error::ToSqlConversionFailure(
-                    appending_unsupported_value(value.data_type()).into(),
-                ));
+                return Err(appending_unsupported_value(value.data_type()));
             }
         };
         if rc != 0 {
@@ -284,17 +282,14 @@ impl fmt::Debug for Appender<'_> {
     }
 }
 
-fn appending_unsupported_value(value_type: impl fmt::Display) -> String {
-    format!("appending {value_type} values is not yet supported")
+fn appending_unsupported_value(value_type: impl fmt::Display) -> crate::Error {
+    crate::Error::ToSqlConversionFailure(format!("appending {value_type} values is not yet supported").into())
 }
 
-fn to_value_ref<'value, 'output>(value: &'value ToSqlOutput<'output>) -> Result<ValueRef<'value>>
-where
-    'output: 'value,
-{
-    match *value {
-        ToSqlOutput::Borrowed(v) => Ok(v),
-        ToSqlOutput::Owned(ref v) => value_ref_from_value(v, appending_unsupported_value),
+fn to_value_ref<'value>(value: &'value ToSqlOutput<'_>) -> Result<ValueRef<'value>> {
+    match value.as_value_ref() {
+        Ok(v) => Ok(v),
+        Err(v) => Err(appending_unsupported_value(v.data_type_name())),
     }
 }
 
@@ -320,9 +315,7 @@ fn validate_appender_value_ref(value: ValueRef<'_>) -> Result<()> {
         | ValueRef::Time64(_, _)
         | ValueRef::Interval { .. }
         | ValueRef::Decimal(_) => Ok(()),
-        _ => Err(Error::ToSqlConversionFailure(
-            appending_unsupported_value(value.data_type()).into(),
-        )),
+        _ => Err(appending_unsupported_value(value.data_type())),
     }
 }
 

--- a/crates/duckdb/src/pragma.rs
+++ b/crates/duckdb/src/pragma.rs
@@ -6,7 +6,7 @@ use crate::{
     Connection, DatabaseName, Result, Row,
     error::Error,
     ffi,
-    types::{ToSql, ToSqlOutput, ValueRef, binding_unsupported_value, value_ref_from_value},
+    types::{ToSql, ValueRef},
 };
 
 pub struct Sql {
@@ -58,25 +58,22 @@ impl Sql {
 
     pub fn push_value(&mut self, value: &dyn ToSql) -> Result<()> {
         let value = value.to_sql()?;
-        let value = match value {
-            ToSqlOutput::Borrowed(v) => v,
-            ToSqlOutput::Owned(ref v) => value_ref_from_value(v, binding_unsupported_value)?,
-        };
-        match value {
-            ValueRef::BigInt(i) => {
+        let value_ref = value.as_value_ref();
+        match value_ref {
+            Ok(ValueRef::BigInt(i)) => {
                 self.push_int(i);
             }
-            ValueRef::Double(r) => {
+            Ok(ValueRef::Double(r)) => {
                 self.push_real(r);
             }
-            ValueRef::Text(s) => {
+            Ok(ValueRef::Text(s)) => {
                 let s = std::str::from_utf8(s)?;
                 self.push_string_literal(s);
             }
             _ => {
                 return Err(Error::DuckDBFailure(
                     ffi::Error::new(ffi::DuckDBError),
-                    Some(format!("Unsupported value type {}", value.data_type())),
+                    Some(format!("Unsupported value type {}", value.data_type_name())),
                 ));
             }
         };
@@ -315,13 +312,10 @@ mod test {
             .unwrap_err();
 
         match err {
-            Error::ToSqlConversionFailure(e) => {
-                assert!(
-                    e.to_string().contains("binding List parameters is not yet supported"),
-                    "unexpected message: {e}"
-                );
+            Error::DuckDBFailure(_, Some(msg)) => {
+                assert!(msg.contains("Unsupported value type List"), "unexpected message: {msg}");
             }
-            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
+            other => panic!("expected DuckDBFailure, got {other:?}"),
         }
         Ok(())
     }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -8,7 +8,7 @@ use crate::polars_dataframe::Polars;
 use crate::{
     arrow_batch::{Arrow, ArrowStream},
     error::result_from_duckdb_prepare,
-    types::{ToSql, ToSqlOutput, binding_unsupported_value, value_ref_from_value},
+    types::{ToSql, ToSqlOutput},
 };
 #[cfg(feature = "polars")]
 use polars_core::utils::arrow as polars_arrow;
@@ -577,9 +577,9 @@ impl Statement<'_> {
         let value = param.to_sql()?;
 
         let ptr = unsafe { self.stmt.ptr() };
-        let value = match value {
-            ToSqlOutput::Borrowed(v) => v,
-            ToSqlOutput::Owned(ref v) => value_ref_from_value(v, binding_unsupported_value)?,
+        let value = match value.as_value_ref() {
+            Ok(v) => v,
+            Err(v) => return Err(binding_unsupported_value(v.data_type_name())),
         };
         // TODO: bind more
         let rc = match value {
@@ -624,9 +624,7 @@ impl Statement<'_> {
                 ffi::duckdb_bind_decimal(ptr, col as u64, decimal)
             },
             _ => {
-                return Err(Error::ToSqlConversionFailure(
-                    binding_unsupported_value(value.data_type()).into(),
-                ));
+                return Err(binding_unsupported_value(value.data_type().name()));
             }
         };
         result_from_duckdb_prepare(rc, ptr)
@@ -661,6 +659,10 @@ impl fmt::Debug for Statement<'_> {
             .field("sql", &sql)
             .finish()
     }
+}
+
+fn binding_unsupported_value(type_name: &'static str) -> Error {
+    Error::ToSqlConversionFailure(format!("binding {type_name} parameters is not yet supported").into())
 }
 
 impl Statement<'_> {

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -1,6 +1,9 @@
 use std::{convert, ffi::c_void, fmt, mem, os::raw::c_char, ptr, str};
 
-use arrow::{array::StructArray, datatypes::SchemaRef};
+use arrow::{
+    array::StructArray,
+    datatypes::{DataType, SchemaRef},
+};
 
 use super::{AndThenRows, Connection, Error, MappedRows, Params, RawStatement, Result, Row, Rows, ValueRef, ffi};
 #[cfg(feature = "polars")]
@@ -8,7 +11,7 @@ use crate::polars_dataframe::Polars;
 use crate::{
     arrow_batch::{Arrow, ArrowStream},
     error::result_from_duckdb_prepare,
-    types::{ToSql, ToSqlOutput},
+    types::{ToSql, Value},
 };
 #[cfg(feature = "polars")]
 use polars_core::utils::arrow as polars_arrow;
@@ -577,12 +580,20 @@ impl Statement<'_> {
         let value = param.to_sql()?;
 
         let ptr = unsafe { self.stmt.ptr() };
-        let value = match value.as_value_ref() {
-            Ok(v) => v,
-            Err(v) => return Err(binding_unsupported_value(v.data_type_name())),
+
+        let value_ref = match value.as_value_ref() {
+            Ok(r) => r,
+            Err(value) => unsafe {
+                // Container types (List, Struct, etc.) are not convertible to ValueRef.
+                // Instead, bind them via duckdb_value C API.
+                let duckdb_val = value_to_duckdb(value)?;
+                let rc = ffi::duckdb_bind_value(ptr, col as u64, duckdb_val);
+                ffi::duckdb_destroy_value(&mut { duckdb_val });
+                return result_from_duckdb_prepare(rc, ptr);
+            },
         };
         // TODO: bind more
-        let rc = match value {
+        let rc = match value_ref {
             ValueRef::Null => unsafe { ffi::duckdb_bind_null(ptr, col as u64) },
             ValueRef::Boolean(i) => unsafe { ffi::duckdb_bind_boolean(ptr, col as u64, i) },
             ValueRef::TinyInt(i) => unsafe { ffi::duckdb_bind_int8(ptr, col as u64, i) },
@@ -623,9 +634,17 @@ impl Statement<'_> {
                 let decimal = crate::types::to_duckdb_decimal(d);
                 ffi::duckdb_bind_decimal(ptr, col as u64, decimal)
             },
-            _ => {
-                return Err(binding_unsupported_value(value.data_type().name()));
-            }
+            ValueRef::List(..)
+            | ValueRef::Struct(..)
+            | ValueRef::Map(..)
+            | ValueRef::Array(..)
+            | ValueRef::Union(..)
+            | ValueRef::Enum(..) => unsafe {
+                let mut duckdb_val = value_ref_to_duckdb(value_ref)?;
+                let rc = ffi::duckdb_bind_value(ptr, col as u64, duckdb_val);
+                ffi::duckdb_destroy_value(&mut duckdb_val);
+                return result_from_duckdb_prepare(rc, ptr);
+            },
         };
         result_from_duckdb_prepare(rc, ptr)
     }
@@ -646,6 +665,10 @@ impl Statement<'_> {
     }
 }
 
+fn binding_unsupported_value(type_name: &'static str) -> Error {
+    Error::ToSqlConversionFailure(format!("binding {type_name} parameters is not yet supported").into())
+}
+
 impl fmt::Debug for Statement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let sql = if self.stmt.is_null() {
@@ -661,15 +684,250 @@ impl fmt::Debug for Statement<'_> {
     }
 }
 
-fn binding_unsupported_value(type_name: &'static str) -> Error {
-    Error::ToSqlConversionFailure(format!("binding {type_name} parameters is not yet supported").into())
-}
-
 impl Statement<'_> {
     #[inline]
     pub(super) fn new(conn: &Connection, stmt: RawStatement) -> Statement<'_> {
         Statement { conn, stmt }
     }
+}
+
+/// Convert a `Value` to a `duckdb_value`. The caller must destroy the returned value.
+pub(crate) fn value_to_duckdb(value: &Value) -> Result<ffi::duckdb_value> {
+    Ok(match value {
+        Value::Null => unsafe { ffi::duckdb_create_null_value() },
+        Value::Boolean(b) => unsafe { ffi::duckdb_create_bool(*b) },
+        Value::TinyInt(i) => unsafe { ffi::duckdb_create_int8(*i) },
+        Value::SmallInt(i) => unsafe { ffi::duckdb_create_int16(*i) },
+        Value::Int(i) => unsafe { ffi::duckdb_create_int32(*i) },
+        Value::BigInt(i) => unsafe { ffi::duckdb_create_int64(*i) },
+        Value::HugeInt(i) => unsafe {
+            ffi::duckdb_create_hugeint(ffi::duckdb_hugeint {
+                lower: *i as u64,
+                upper: (*i >> 64) as i64,
+            })
+        },
+        Value::UTinyInt(i) => unsafe { ffi::duckdb_create_uint8(*i) },
+        Value::USmallInt(i) => unsafe { ffi::duckdb_create_uint16(*i) },
+        Value::UInt(i) => unsafe { ffi::duckdb_create_uint32(*i) },
+        Value::UBigInt(i) => unsafe { ffi::duckdb_create_uint64(*i) },
+        Value::Float(f) => unsafe { ffi::duckdb_create_float(*f) },
+        Value::Double(f) => unsafe { ffi::duckdb_create_double(*f) },
+        Value::Decimal(d) => unsafe {
+            let decimal = crate::types::to_duckdb_decimal(*d);
+            ffi::duckdb_create_decimal(decimal)
+        },
+        Value::Timestamp(u, i) => unsafe {
+            ffi::duckdb_create_timestamp(ffi::duckdb_timestamp {
+                micros: u.to_micros(*i),
+            })
+        },
+        Value::Text(s) => unsafe { ffi::duckdb_create_varchar_length(s.as_ptr() as *const c_char, s.len() as u64) },
+        Value::Blob(b) => unsafe { ffi::duckdb_create_blob(b.as_ptr(), b.len() as u64) },
+        Value::Date32(days) => unsafe { ffi::duckdb_create_date(ffi::duckdb_date { days: *days }) },
+        Value::Time64(u, i) => unsafe {
+            ffi::duckdb_create_time(ffi::duckdb_time {
+                micros: u.to_micros(*i),
+            })
+        },
+        Value::Interval { months, days, nanos } => unsafe {
+            ffi::duckdb_create_interval(ffi::duckdb_interval {
+                months: *months,
+                days: *days,
+                micros: *nanos / 1_000,
+            })
+        },
+        Value::List(items) => unsafe {
+            let child_type = infer_list_child_logical_type(items)?;
+            let mut duckdb_values: Vec<ffi::duckdb_value> = Vec::with_capacity(items.len());
+            // Track how many we've created for cleanup on error
+            let result = (|| -> Result<ffi::duckdb_value> {
+                for item in items {
+                    duckdb_values.push(value_to_duckdb(item)?);
+                }
+                let list_val =
+                    ffi::duckdb_create_list_value(child_type, duckdb_values.as_mut_ptr(), items.len() as u64);
+                Ok(list_val)
+            })();
+            // Cleanup: destroy child values and logical type
+            for mut v in duckdb_values {
+                ffi::duckdb_destroy_value(&mut v);
+            }
+            ffi::duckdb_destroy_logical_type(&mut { child_type });
+            return result;
+        },
+        Value::Enum(_) | Value::Struct(_) | Value::Map(_) | Value::Array(_) | Value::Union(_) => {
+            return Err(binding_unsupported_value(value.data_type_name()));
+        }
+    })
+}
+
+/// Infer the child logical type of a list from its elements.
+/// Uses the first non-null element. Errors on empty or all-null lists.
+fn infer_list_child_logical_type(items: &[Value]) -> Result<ffi::duckdb_logical_type> {
+    for item in items {
+        if !matches!(item, Value::Null) {
+            return value_to_logical_type(item);
+        }
+    }
+    Err(Error::ToSqlConversionFailure(
+        "cannot infer element type of empty or all-null list".into(),
+    ))
+}
+
+/// Convert a `Value` to its DuckDB logical type.
+fn value_to_logical_type(value: &Value) -> Result<ffi::duckdb_logical_type> {
+    use crate::core::LogicalTypeId;
+    let id = match value {
+        Value::Null => {
+            return Err(Error::ToSqlConversionFailure(
+                "cannot infer logical type from Value::Null".into(),
+            ));
+        }
+        Value::Boolean(_) => LogicalTypeId::Boolean,
+        Value::TinyInt(_) => LogicalTypeId::Tinyint,
+        Value::SmallInt(_) => LogicalTypeId::Smallint,
+        Value::Int(_) => LogicalTypeId::Integer,
+        Value::BigInt(_) => LogicalTypeId::Bigint,
+        Value::HugeInt(_) => LogicalTypeId::Hugeint,
+        Value::UTinyInt(_) => LogicalTypeId::UTinyint,
+        Value::USmallInt(_) => LogicalTypeId::USmallint,
+        Value::UInt(_) => LogicalTypeId::UInteger,
+        Value::UBigInt(_) => LogicalTypeId::UBigint,
+        Value::Float(_) => LogicalTypeId::Float,
+        Value::Double(_) => LogicalTypeId::Double,
+        Value::Decimal(_) => LogicalTypeId::Decimal,
+        Value::Timestamp(_, _) => LogicalTypeId::Timestamp,
+        Value::Text(_) => LogicalTypeId::Varchar,
+        Value::Blob(_) => LogicalTypeId::Blob,
+        Value::Date32(_) => LogicalTypeId::Date,
+        Value::Time64(_, _) => LogicalTypeId::Time,
+        Value::Interval { .. } => LogicalTypeId::Interval,
+        Value::Enum(_) => LogicalTypeId::Enum,
+        Value::List(items) => unsafe {
+            let child_type = infer_list_child_logical_type(items)?;
+            let list_type = ffi::duckdb_create_list_type(child_type);
+            ffi::duckdb_destroy_logical_type(&mut { child_type });
+            return Ok(list_type);
+        },
+        Value::Struct(_) | Value::Map(_) | Value::Array(_) | Value::Union(_) => {
+            return Err(binding_unsupported_value(value.data_type_name()));
+        }
+    };
+    Ok(unsafe { ffi::duckdb_create_logical_type(id as u32) })
+}
+
+/// Convert a `ValueRef` to a `duckdb_value`. The caller must destroy the returned value.
+pub(crate) fn value_ref_to_duckdb(value: ValueRef<'_>) -> Result<ffi::duckdb_value> {
+    use crate::types::ListType;
+    match value {
+        ValueRef::Null => Ok(unsafe { ffi::duckdb_create_null_value() }),
+        ValueRef::Boolean(b) => Ok(unsafe { ffi::duckdb_create_bool(b) }),
+        ValueRef::TinyInt(i) => Ok(unsafe { ffi::duckdb_create_int8(i) }),
+        ValueRef::SmallInt(i) => Ok(unsafe { ffi::duckdb_create_int16(i) }),
+        ValueRef::Int(i) => Ok(unsafe { ffi::duckdb_create_int32(i) }),
+        ValueRef::BigInt(i) => Ok(unsafe { ffi::duckdb_create_int64(i) }),
+        ValueRef::HugeInt(i) => Ok(unsafe {
+            ffi::duckdb_create_hugeint(ffi::duckdb_hugeint {
+                lower: i as u64,
+                upper: (i >> 64) as i64,
+            })
+        }),
+        ValueRef::UTinyInt(i) => Ok(unsafe { ffi::duckdb_create_uint8(i) }),
+        ValueRef::USmallInt(i) => Ok(unsafe { ffi::duckdb_create_uint16(i) }),
+        ValueRef::UInt(i) => Ok(unsafe { ffi::duckdb_create_uint32(i) }),
+        ValueRef::UBigInt(i) => Ok(unsafe { ffi::duckdb_create_uint64(i) }),
+        ValueRef::Float(f) => Ok(unsafe { ffi::duckdb_create_float(f) }),
+        ValueRef::Double(f) => Ok(unsafe { ffi::duckdb_create_double(f) }),
+        ValueRef::Decimal(d) => Ok(unsafe { ffi::duckdb_create_decimal(crate::types::to_duckdb_decimal(d)) }),
+        ValueRef::Timestamp(u, i) => {
+            Ok(unsafe { ffi::duckdb_create_timestamp(ffi::duckdb_timestamp { micros: u.to_micros(i) }) })
+        }
+        ValueRef::Text(s) => {
+            Ok(unsafe { ffi::duckdb_create_varchar_length(s.as_ptr() as *const c_char, s.len() as u64) })
+        }
+        ValueRef::Blob(b) => Ok(unsafe { ffi::duckdb_create_blob(b.as_ptr(), b.len() as u64) }),
+        ValueRef::Date32(days) => Ok(unsafe { ffi::duckdb_create_date(ffi::duckdb_date { days }) }),
+        ValueRef::Time64(u, i) => Ok(unsafe { ffi::duckdb_create_time(ffi::duckdb_time { micros: u.to_micros(i) }) }),
+        ValueRef::Interval { months, days, nanos } => Ok(unsafe {
+            ffi::duckdb_create_interval(ffi::duckdb_interval {
+                months,
+                days,
+                micros: nanos / 1_000,
+            })
+        }),
+        ValueRef::List(list_type, idx) => unsafe {
+            let (start, end, values, child_dt) = match list_type {
+                ListType::Regular(arr) => {
+                    let offsets = arr.offsets();
+                    let s: usize = offsets[idx].try_into().unwrap();
+                    let e: usize = offsets[idx + 1].try_into().unwrap();
+                    (s, e, arr.values(), arr.value_type())
+                }
+                ListType::Large(arr) => {
+                    let offsets = arr.offsets();
+                    let s: usize = offsets[idx].try_into().unwrap();
+                    let e: usize = offsets[idx + 1].try_into().unwrap();
+                    (s, e, arr.values(), arr.value_type())
+                }
+            };
+            let child_logical = arrow_datatype_to_logical_type(&child_dt)?;
+            let mut duckdb_values: Vec<ffi::duckdb_value> = Vec::with_capacity(end - start);
+            let result = (|| -> Result<ffi::duckdb_value> {
+                for row in start..end {
+                    let elem = Row::value_ref_internal(row, idx, values);
+                    duckdb_values.push(value_ref_to_duckdb(elem)?);
+                }
+                Ok(ffi::duckdb_create_list_value(
+                    child_logical,
+                    duckdb_values.as_mut_ptr(),
+                    duckdb_values.len() as u64,
+                ))
+            })();
+            for mut v in duckdb_values {
+                ffi::duckdb_destroy_value(&mut v);
+            }
+            ffi::duckdb_destroy_logical_type(&mut { child_logical });
+            result
+        },
+        _ => Err(binding_unsupported_value(value.data_type().name())),
+    }
+}
+
+/// Convert an Arrow `DataType` to a DuckDB logical type.
+fn arrow_datatype_to_logical_type(dt: &DataType) -> Result<ffi::duckdb_logical_type> {
+    use crate::core::LogicalTypeId;
+    let id = match dt {
+        DataType::Boolean => LogicalTypeId::Boolean,
+        DataType::Int8 => LogicalTypeId::Tinyint,
+        DataType::Int16 => LogicalTypeId::Smallint,
+        DataType::Int32 => LogicalTypeId::Integer,
+        DataType::Int64 => LogicalTypeId::Bigint,
+        DataType::UInt8 => LogicalTypeId::UTinyint,
+        DataType::UInt16 => LogicalTypeId::USmallint,
+        DataType::UInt32 => LogicalTypeId::UInteger,
+        DataType::UInt64 => LogicalTypeId::UBigint,
+        DataType::Float32 => LogicalTypeId::Float,
+        DataType::Float64 => LogicalTypeId::Double,
+        DataType::Utf8 | DataType::LargeUtf8 => LogicalTypeId::Varchar,
+        DataType::Binary | DataType::LargeBinary | DataType::FixedSizeBinary(_) => LogicalTypeId::Blob,
+        DataType::Date32 => LogicalTypeId::Date,
+        DataType::Timestamp(_, _) => LogicalTypeId::Timestamp,
+        DataType::Time64(_) => LogicalTypeId::Time,
+        DataType::Interval(_) => LogicalTypeId::Interval,
+        DataType::Decimal128(_, _) => LogicalTypeId::Decimal,
+        DataType::List(field) | DataType::LargeList(field) => unsafe {
+            let child = arrow_datatype_to_logical_type(field.data_type())?;
+            let list_type = ffi::duckdb_create_list_type(child);
+            ffi::duckdb_destroy_logical_type(&mut { child });
+            return Ok(list_type);
+        },
+        _ => {
+            return Err(Error::ToSqlConversionFailure(
+                format!("unsupported Arrow DataType for binding: {dt}").into(),
+            ));
+        }
+    };
+    Ok(unsafe { ffi::duckdb_create_logical_type(id as u32) })
 }
 
 #[cfg(test)]
@@ -684,28 +942,13 @@ mod test {
 
     struct BorrowedList(ListArray);
     impl BorrowedList {
-        fn new() -> Self {
-            Self(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(vec![
-                Some(1),
-                Some(2),
-            ])]))
+        fn new(value: Vec<Option<i32>>) -> Self {
+            Self(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![Some(value)]))
         }
     }
     impl ToSql for BorrowedList {
         fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
             Ok(ToSqlOutput::Borrowed(ValueRef::List(ListType::Regular(&self.0), 0)))
-        }
-    }
-
-    fn assert_binding_list_error(err: Error) {
-        match err {
-            Error::ToSqlConversionFailure(e) => {
-                assert!(
-                    e.to_string().contains("binding List parameters is not yet supported"),
-                    "unexpected message: {e}"
-                );
-            }
-            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
         }
     }
 
@@ -1734,45 +1977,13 @@ mod test {
         Ok(())
     }
 
-    // Unsupported Value variants must surface an error instead of panicking.
-    #[test]
-    fn test_bind_unsupported_container_type_returns_error() -> Result<()> {
-        use crate::types::Value;
-
-        struct OwnedList;
-        impl ToSql for OwnedList {
-            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-                Ok(ToSqlOutput::Owned(Value::List(vec![Value::Int(1), Value::Int(2)])))
-            }
-        }
-
-        let db = Connection::open_in_memory()?;
-        db.execute("CREATE TABLE t (id INTEGER, numbers INTEGER[])", [])?;
-
-        let list = OwnedList;
-        let err = db
-            .execute("INSERT INTO t VALUES (?, ?)", crate::params![1, list])
-            .unwrap_err();
-
-        assert_binding_list_error(err);
-
-        let borrowed_list = BorrowedList::new();
-        let err = db
-            .execute("INSERT INTO t VALUES (?, ?)", crate::params![2, borrowed_list])
-            .unwrap_err();
-        assert_binding_list_error(err);
-        Ok(())
-    }
-
     #[test]
     fn test_bind_error_clears_partial_parameter_state() -> Result<()> {
         let db = Connection::open_in_memory()?;
         db.execute("CREATE TABLE t (id INTEGER NOT NULL, name TEXT)", [])?;
 
         let mut stmt = db.prepare("INSERT INTO t VALUES (?, ?)")?;
-        let list = BorrowedList::new();
-        let err = stmt.execute(crate::params![1, list]).unwrap_err();
-        assert_binding_list_error(err);
+        stmt.execute(crate::params![1]).unwrap_err();
 
         stmt.raw_bind_parameter(2, "ok")?;
         assert!(stmt.raw_execute().is_err());
@@ -1788,6 +1999,119 @@ mod test {
             Ok((row.get::<_, i32>(0)?, row.get::<_, String>(1)?))
         })?;
         assert_eq!(row, (7, "ok".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_list() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE test (numbers INTEGER[])", [])?;
+
+        let list_value = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        db.execute("INSERT INTO test VALUES (?)", crate::params![&list_value])?;
+
+        let result = db.query_row("SELECT numbers FROM test", [], |row| row.get::<_, Value>(0))?;
+        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_list_with_nulls() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE test (numbers INTEGER[])", [])?;
+
+        let list_value = Value::List(vec![Value::Int(1), Value::Null, Value::Int(3)]);
+        db.execute("INSERT INTO test VALUES (?)", crate::params![&list_value])?;
+
+        let result = db.query_row("SELECT numbers FROM test", [], |row| row.get::<_, Value>(0))?;
+        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Null, Value::Int(3)]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_empty_list_returns_error() {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory().unwrap();
+        db.execute("CREATE TABLE test (numbers INTEGER[])", []).unwrap();
+
+        let list_value = Value::List(vec![]);
+        let err = db
+            .execute("INSERT INTO test VALUES (?)", crate::params![&list_value])
+            .unwrap_err();
+
+        match err {
+            Error::ToSqlConversionFailure(e) => {
+                assert!(e.to_string().contains("empty or all-null"), "unexpected message: {e}");
+            }
+            other => panic!("expected ToSqlConversionFailure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_bind_nested_list() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE test (matrix INTEGER[][])", [])?;
+
+        let inner1 = Value::List(vec![Value::Int(1), Value::Int(2)]);
+        let inner2 = Value::List(vec![Value::Int(3), Value::Int(4)]);
+        let list_value = Value::List(vec![inner1.clone(), inner2.clone()]);
+        db.execute("INSERT INTO test VALUES (?)", crate::params![&list_value])?;
+
+        let result: Value = db.query_row("SELECT matrix FROM test", [], |row| row.get::<_, Value>(0))?;
+
+        assert_eq!(result, Value::List(vec![inner1, inner2]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_list_ref() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE test (numbers INTEGER[])", [])?;
+
+        let list_array = BorrowedList::new(vec![Some(1), Some(2), Some(3)]);
+        db.execute("INSERT INTO test VALUES (?)", crate::params![list_array])?;
+
+        let result = db.query_row("SELECT numbers FROM test", [], |row| row.get::<_, Value>(0))?;
+        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_list_ref_nulls() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE test (numbers INTEGER[])", [])?;
+
+        let list_array = BorrowedList::new(vec![Some(3), None, Some(5)]);
+        db.execute("INSERT INTO test VALUES (?)", crate::params![list_array])?;
+
+        let result = db.query_row("SELECT numbers FROM test", [], |r| r.get::<_, Value>(0))?;
+        assert_eq!(result, Value::List(vec![Value::Int(3), Value::Null, Value::Int(5)]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_list_ref_empty() -> Result<()> {
+        use crate::types::Value;
+
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE test (numbers INTEGER[])", [])?;
+
+        let list_array = BorrowedList::new(vec![]);
+        db.execute("INSERT INTO test VALUES (?)", crate::params![list_array])?;
+
+        let result = db.query_row("SELECT numbers FROM test", [], |r| r.get::<_, Value>(0))?;
+        assert_eq!(result, Value::List(vec![]));
         Ok(())
     }
 }

--- a/crates/duckdb/src/types/chrono.rs
+++ b/crates/duckdb/src/types/chrono.rs
@@ -211,7 +211,7 @@ impl ToSql for Duration {
 mod test {
     use crate::{
         Connection, Result,
-        types::{FromSql, FromSqlError, ToSql, ToSqlOutput, ValueRef, binding_unsupported_value, value_ref_from_value},
+        types::{FromSql, FromSqlError, ToSql, ToSqlOutput, ValueRef, value_ref_from_value},
     };
     use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta, TimeZone, Utc};
 
@@ -319,7 +319,7 @@ mod test {
         let sqled = td.to_sql().unwrap();
         let value = match sqled {
             ToSqlOutput::Borrowed(v) => v,
-            ToSqlOutput::Owned(ref v) => value_ref_from_value(v, binding_unsupported_value).unwrap(),
+            ToSqlOutput::Owned(ref v) => value_ref_from_value(v).unwrap(),
         };
         let reversed = FromSql::column_result(value).unwrap();
 

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -163,37 +163,43 @@ impl From<&DataType> for Type {
     }
 }
 
+impl Type {
+    pub(crate) const fn name(&self) -> &'static str {
+        match self {
+            Self::Null => "Null",
+            Self::Boolean => "Boolean",
+            Self::TinyInt => "TinyInt",
+            Self::SmallInt => "SmallInt",
+            Self::Int => "Int",
+            Self::BigInt => "BigInt",
+            Self::HugeInt => "HugeInt",
+            Self::UTinyInt => "UTinyInt",
+            Self::USmallInt => "USmallInt",
+            Self::UInt => "UInt",
+            Self::UBigInt => "UBigInt",
+            Self::Float => "Float",
+            Self::Double => "Double",
+            Self::Decimal => "Decimal",
+            Self::Timestamp => "Timestamp",
+            Self::Text => "Text",
+            Self::Blob => "Blob",
+            Self::Date32 => "Date32",
+            Self::Time64 => "Time64",
+            Self::Interval => "Interval",
+            Self::Struct(..) => "Struct",
+            Self::List(..) => "List",
+            Self::Enum => "Enum",
+            Self::Map(..) => "Map",
+            Self::Array(..) => "Array",
+            Self::Union => "Union",
+            Self::Any => "Any",
+        }
+    }
+}
+
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Self::Null => f.pad("Null"),
-            Self::Boolean => f.pad("Boolean"),
-            Self::TinyInt => f.pad("TinyInt"),
-            Self::SmallInt => f.pad("SmallInt"),
-            Self::Int => f.pad("Int"),
-            Self::BigInt => f.pad("BigInt"),
-            Self::HugeInt => f.pad("HugeInt"),
-            Self::UTinyInt => f.pad("UTinyInt"),
-            Self::USmallInt => f.pad("USmallInt"),
-            Self::UInt => f.pad("UInt"),
-            Self::UBigInt => f.pad("UBigInt"),
-            Self::Float => f.pad("Float"),
-            Self::Double => f.pad("Double"),
-            Self::Decimal => f.pad("Decimal"),
-            Self::Timestamp => f.pad("Timestamp"),
-            Self::Text => f.pad("Text"),
-            Self::Blob => f.pad("Blob"),
-            Self::Date32 => f.pad("Date32"),
-            Self::Time64 => f.pad("Time64"),
-            Self::Interval => f.pad("Interval"),
-            Self::Struct(..) => f.pad("Struct"),
-            Self::List(..) => f.pad("List"),
-            Self::Enum => f.pad("Enum"),
-            Self::Map(..) => f.pad("Map"),
-            Self::Array(..) => f.pad("Array"),
-            Self::Union => f.pad("Union"),
-            Self::Any => f.pad("Any"),
-        }
+        f.pad(self.name())
     }
 }
 

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     value_ref::{EnumType, ListType, TimeUnit, ValueRef},
 };
 pub(crate) use decimal::to_duckdb_decimal;
-pub(crate) use value_ref::{binding_unsupported_value, value_ref_from_value};
+pub(crate) use value_ref::value_ref_from_value;
 
 use arrow::datatypes::DataType;
 use std::fmt;

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -1,4 +1,4 @@
-use super::{Null, TimeUnit, Value, ValueRef, binding_unsupported_value, value_ref_from_value};
+use super::{Null, TimeUnit, Value, ValueRef, value_ref_from_value};
 use crate::Result;
 use std::borrow::Cow;
 
@@ -7,11 +7,37 @@ use std::borrow::Cow;
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum ToSqlOutput<'a> {
-    /// A borrowed SQLite-representable value.
+    /// A borrowed statically typed value.
     Borrowed(ValueRef<'a>),
 
-    /// An owned SQLite-representable value.
+    /// An owned dynamically typed value.
     Owned(Value),
+
+    /// A borrowed dynamically typed value. If possible, use [ToSqlOutput::Borrowed] instead.
+    /// Used for container types (List, Struct, Map, etc.) that cannot be represented
+    /// as [`ValueRef<'a>`].
+    BorrowedValue(&'a Value),
+}
+
+impl<'a> ToSqlOutput<'a> {
+    /// Tries to converts to `ValueRef` and falls back to `&Value`.
+    ///
+    /// The fallback happens for container types that would have to allocate arrow arrays.
+    pub(crate) fn as_value_ref<'b>(&'b self) -> Result<ValueRef<'b>, &'b Value> {
+        match self {
+            ToSqlOutput::Borrowed(v) => Ok(*v),
+            ToSqlOutput::Owned(v) => value_ref_from_value(v).ok_or(v),
+            ToSqlOutput::BorrowedValue(v) => value_ref_from_value(v).ok_or(v),
+        }
+    }
+
+    pub(crate) fn data_type_name(&self) -> &'static str {
+        match self {
+            ToSqlOutput::Borrowed(value_ref) => value_ref.data_type().name(),
+            ToSqlOutput::Owned(value) => value.data_type_name(),
+            ToSqlOutput::BorrowedValue(value) => value.data_type_name(),
+        }
+    }
 }
 
 // Generically allow any type that can be converted into a ValueRef
@@ -63,9 +89,16 @@ from_value!(uuid::Uuid);
 impl ToSql for ToSqlOutput<'_> {
     #[inline]
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        Ok(match *self {
-            ToSqlOutput::Borrowed(v) => ToSqlOutput::Borrowed(v),
-            ToSqlOutput::Owned(ref v) => ToSqlOutput::Borrowed(value_ref_from_value(v, binding_unsupported_value)?),
+        Ok(match self {
+            ToSqlOutput::Borrowed(v) => ToSqlOutput::Borrowed(*v),
+            ToSqlOutput::BorrowedValue(v) => ToSqlOutput::BorrowedValue(v),
+            ToSqlOutput::Owned(v) => {
+                if let Some(r) = value_ref_from_value(v) {
+                    ToSqlOutput::Borrowed(r)
+                } else {
+                    ToSqlOutput::BorrowedValue(v)
+                }
+            }
         })
     }
 }
@@ -188,10 +221,11 @@ impl ToSql for [u8] {
 impl ToSql for Value {
     #[inline]
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        Ok(ToSqlOutput::Borrowed(value_ref_from_value(
-            self,
-            binding_unsupported_value,
-        )?))
+        Ok(if let Some(r) = value_ref_from_value(self) {
+            ToSqlOutput::Borrowed(r)
+        } else {
+            ToSqlOutput::BorrowedValue(self)
+        })
     }
 }
 
@@ -216,7 +250,9 @@ impl ToSql for std::time::Duration {
 
 #[cfg(test)]
 mod test {
-    use super::{ToSql, ToSqlOutput};
+    use crate::types::ToSqlOutput;
+
+    use super::ToSql;
 
     fn is_to_sql<T: ToSql>() {}
 
@@ -232,11 +268,8 @@ mod test {
     }
 
     #[test]
-    fn test_value_to_sql_rejects_unsupported_variants() {
-        use crate::{
-            Error,
-            types::{OrderedMap, Value},
-        };
+    fn test_value_to_sql_borrows_containers() {
+        use crate::types::{OrderedMap, Value};
 
         let cases: &[(&str, Value)] = &[
             ("List", Value::List(vec![Value::Int(1)])),
@@ -255,26 +288,14 @@ mod test {
 
         for (variant, value) in cases {
             match value.to_sql() {
-                Err(Error::ToSqlConversionFailure(e)) => {
-                    let msg = e.to_string();
-                    assert!(
-                        msg.contains(&format!("binding {variant} parameters is not yet supported")),
-                        "{variant}: unexpected message {msg}"
-                    );
-                }
-                Err(other) => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
-                Ok(_) => panic!("{variant}: expected error, got Ok"),
+                Err(other) => panic!("{variant}: {other:?}"),
+                Ok(ToSqlOutput::BorrowedValue(_)) => {}
+                Ok(v) => panic!("{variant}: expected BorrowedValue, got: {v:?}"),
             }
             match ToSqlOutput::Owned(value.clone()).to_sql() {
-                Err(Error::ToSqlConversionFailure(e)) => {
-                    let msg = e.to_string();
-                    assert!(
-                        msg.contains(&format!("binding {variant} parameters is not yet supported")),
-                        "{variant}: unexpected message {msg}"
-                    );
-                }
-                Err(other) => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
-                Ok(_) => panic!("{variant}: expected error, got Ok"),
+                Err(other) => panic!("{variant}: {other:?}"),
+                Ok(ToSqlOutput::BorrowedValue(_)) => {}
+                Ok(v) => panic!("{variant}: expected BorrowedValue, got: {v:?}"),
             }
         }
     }

--- a/crates/duckdb/src/types/value.rs
+++ b/crates/duckdb/src/types/value.rs
@@ -215,6 +215,7 @@ where
 
 impl Value {
     /// Returns DuckDB fundamental datatype.
+    // TODO: make this fallible. Determining type of List is expensive and also might fail.
     #[inline]
     pub fn data_type(&self) -> Type {
         match *self {
@@ -238,8 +239,20 @@ impl Value {
             Self::Date32(_) => Type::Date32,
             Self::Time64(..) => Type::Time64,
             Self::Interval { .. } => Type::Interval,
-            Self::Union(..) | Self::Struct(..) | Self::List(..) | Self::Array(..) | Self::Map(..) => todo!(),
+            Self::Struct(..) | Self::List(..) | Self::Array(..) | Self::Map(..) => todo!(),
+            Self::Union(..) => Type::Union,
             Self::Enum(..) => Type::Enum,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn data_type_name(&self) -> &'static str {
+        match *self {
+            Self::Struct(..) => "Struct",
+            Self::List(..) => "List",
+            Self::Array(..) => "Array",
+            Self::Map(..) => "Map",
+            _ => self.data_type().name(),
         }
     }
 }

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -1,7 +1,7 @@
 use super::{Type, Value};
 use crate::types::{FromSqlError, FromSqlResult, OrderedMap};
 
-use crate::{Error, Result, Row};
+use crate::Row;
 use rust_decimal::prelude::*;
 
 use arrow::{
@@ -343,50 +343,18 @@ impl<'a> From<&'a [u8]> for ValueRef<'a> {
     }
 }
 
-pub(crate) fn value_ref_from_value<'a>(
-    value: &'a Value,
-    unsupported_message: impl FnOnce(&'static str) -> String,
-) -> Result<ValueRef<'a>> {
-    if let Some(variant) = unsupported_value_variant(value) {
-        return Err(Error::ToSqlConversionFailure(unsupported_message(variant).into()));
+pub(crate) fn value_ref_from_value<'a>(value: &'a Value) -> Option<ValueRef<'a>> {
+    if is_unsupported_value_variant(value) {
+        return None;
     }
-
-    Ok(ValueRef::from(value))
+    Some(ValueRef::from(value))
 }
 
-pub(crate) fn binding_unsupported_value(value_type: impl std::fmt::Display) -> String {
-    format!("binding {value_type} parameters is not yet supported")
-}
-
-fn unsupported_value_variant(value: &Value) -> Option<&'static str> {
-    match value {
-        Value::Null
-        | Value::Boolean(_)
-        | Value::TinyInt(_)
-        | Value::SmallInt(_)
-        | Value::Int(_)
-        | Value::BigInt(_)
-        | Value::HugeInt(_)
-        | Value::UTinyInt(_)
-        | Value::USmallInt(_)
-        | Value::UInt(_)
-        | Value::UBigInt(_)
-        | Value::Float(_)
-        | Value::Double(_)
-        | Value::Decimal(_)
-        | Value::Timestamp(_, _)
-        | Value::Text(_)
-        | Value::Blob(_)
-        | Value::Date32(_)
-        | Value::Time64(_, _)
-        | Value::Interval { .. } => None,
-        Value::List(_) => Some("List"),
-        Value::Array(_) => Some("Array"),
-        Value::Struct(_) => Some("Struct"),
-        Value::Map(_) => Some("Map"),
-        Value::Union(_) => Some("Union"),
-        Value::Enum(_) => Some("Enum"),
-    }
+fn is_unsupported_value_variant(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::List(_) | Value::Array(_) | Value::Struct(_) | Value::Map(_) | Value::Union(_) | Value::Enum(_)
+    )
 }
 
 impl<'a> From<&'a Value> for ValueRef<'a> {
@@ -397,6 +365,7 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
     /// Panics for `Value::Enum`, `Value::List`, `Value::Struct`, `Value::Map`,
     /// `Value::Array`, and `Value::Union`. Internal bind and append paths use
     /// `value_ref_from_value` for fallible conversion.
+    // TODO: this should be TryFrom instead. But that's a breaking change.
     #[inline]
     fn from(value: &'a Value) -> Self {
         match *value {
@@ -426,7 +395,7 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
             | Value::Map(..)
             | Value::Array(..)
             | Value::Union(..) => {
-                let variant = unsupported_value_variant(value).expect("unsupported Value variant");
+                let variant = value.data_type_name();
                 panic!("ValueRef::from(&Value::{variant}) is not supported; use value_ref_from_value")
             }
         }


### PR DESCRIPTION
Resolves a part of #680
Susersedes #643

I recomment review commit-by-commit:

- **Add Type::name() and Value::data_type_name()**
- **Add ToSqlOutput::BorrowedValue variant**
- **Bind and append List values**

## Main problem

`Value::List` is not cheaply convertible into `ValueRef::List`.

Before this PR, binding (and appending) converted all values to `ValueRef`,
and then matched on the variant to call appropriate `ffi::duckdb_bind_xxx`.

For container types, we cannot cheaply convert between `Value` and `ValueRef`,
so I've added two binding paths: `value_to_duckdb` and `value_ref_to_duckdb`.

Both convert to `ffi::duckdb_value`, which is then passed to
`ffi::duckdb_bind_value`/`ffi::duckdb_append_value`.

These two helpers do also support converting all other types, but they always
use the faster path of calling specialized ffi functions. 

## Why add `ToSqlOutput::BorrowedValue` variant?

Because we need to call `ToSql(Value)` and return `&Value`, not `ValueRef`.

In essence, the problem is that there are two dimensions in which `Value`
and `ValueRef` differ:
- owned / borrowed,
- statically / dynamically typed.

For most types except container types, both of these distinctions are irrelevant.
But for container types (e.g `List`), there can be 4 possible representations:

- owned dynamic: `Vec<Value>`, (this is `Value`)
- owned static: `arrow::ListArray`,
- borrowed dynamic: `&[Value]`,
- borrowed static: `&arrow::ListArray`.

When binding, `ToSql` needs a path from `owned dynamic` to `borrowed dynamic`.

PR #643 gets around this by adding a new variant to ListType, but I think that
is messy because it mixes static/dynamic distinction with arrow list type impls.
