### PR TITLE
Change LogicalTypeHandle::set_alias to take &mut self

### DIFF
--- a/crates/duckdb/src/core/logical_type.rs
+++ b/crates/duckdb/src/core/logical_type.rs
@@ -365,7 +365,7 @@ impl LogicalTypeHandle {
     }
 
     /// Set the alias of the logical type.
-    pub fn set_alias(&self, alias: &str) {
+    pub fn set_alias(&mut self, alias: &str) {
         unsafe {
             let alias = CString::new(alias).unwrap();
             duckdb_logical_type_set_alias(self.ptr, alias.as_ptr());


### PR DESCRIPTION
Since it mutates the underlying data, no? Leaving the signature with an immutable `&self` borrow means the compiler will let multiple threads / calls write to the data at the same time, which is not great. Requiring a mutable borrow guarantees exclusivity, avoiding data races (assuming manual `unsafe` guarantees are maintained).

This may be a (minor) breaking change; e.g. someone may have to make a change like the following:

```diff
-let handle = ...;
+let mut handle = ...;
 handle.set_alias(...);
 ...
```

However IMO it's worth it for more accurate contract description.