### PR TITLE
Stop disabling jemalloc in bundled-cmake builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ You can adjust this behavior in a number of ways:
    - `bundled-cmake` is *experimental* and requires a git/workspace checkout. It is not available from crates.io because the full `duckdb-sources` tree is not packaged there.
    - `bundled-cmake` implies `bundled` (for conditional-compilation gates) but replaces the `cc` build backend with CMake. Enabling any CMake-only extension feature (e.g. `icu`) automatically activates `bundled-cmake`.
    - `bundled-cmake` always links DuckDB's default static extensions (`core_functions` and `parquet`), so it also implies the `parquet` Cargo feature.
+   - The plain `bundled` backend uses DuckDB's standard allocator and does not build jemalloc. On supported 64-bit, non-musl Linux targets, `bundled-cmake` builds DuckDB with upstream's jemalloc allocator enabled; on other targets, DuckDB's CMake platform checks leave jemalloc disabled.
    - Extension autoload/autoinstall are forced on to match the existing `bundled` backend, even though upstream CMake defaults are off. If `DUCKDB_DISABLE_EXTENSION_LOAD=1` is set, both defaults are forced off as well.
    - When `ninja` is on `PATH`, the Ninja generator is preferred automatically. Set `CMAKE_GENERATOR` to override.
    - Builds DuckDB in `Release` mode by default, even in Rust debug builds, to avoid DuckDB's much slower debug/sanitizer profile. Set `DUCKDB_CMAKE_BUILD_TYPE` or `CMAKE_BUILD_TYPE` to override. `DUCKDB_CMAKE_BUILD_TYPE` takes precedence.

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -6,11 +6,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-// Keep this in sync with DuckDB's always-loaded base extension config in
-// duckdb-sources/extension/extension_config.cmake. We intentionally keep
-// upstream's default parquet linkage in the CMake backend.
-const SKIPPED_EXTENSIONS: &[&str] = &["jemalloc"];
-
 struct Generator {
     name: Option<String>,
     out_dir: PathBuf,
@@ -97,7 +92,11 @@ pub fn main(_out_dir: &str, out_path: &Path) {
         config.define("BUILD_EXTENSIONS", enabled_extensions.join(";"));
     }
 
-    config.define("SKIP_EXTENSIONS", SKIPPED_EXTENSIONS.join(";"));
+    // Always set explicitly so old CMake caches that skipped jemalloc do not
+    // keep forcing ENABLE_JEMALLOC=OFF. Upstream still gates jemalloc to
+    // supported 64-bit, non-musl Linux builds, so ON is a no-op elsewhere.
+    config.define("SKIP_EXTENSIONS", "");
+    config.define("ENABLE_JEMALLOC", "ON");
 
     // Upstream CMake defaults these to OFF, but duckdb-rs `bundled` has historically
     // shipped with both enabled. Keep `bundled-cmake` aligned with `bundled` unless
@@ -328,7 +327,7 @@ fn sanitize_path_component(input: &str) -> String {
 fn validate_extension_libraries(lib_dir: &Path, cmake_build_type: &str, enabled_extensions: &[&str]) {
     // Missing extensions are already caught by link_static_library's panic;
     // this check only guards against CMake producing extensions we did not
-    // ask for (e.g. upstream SKIPPED_EXTENSIONS drift).
+    // ask for (e.g. upstream extension-config drift).
     let actual = list_static_extension_libraries(lib_dir, cmake_build_type).unwrap_or_else(|err| {
         panic!(
             "failed to inspect bundled-cmake extension libraries in {}: {err}",


### PR DESCRIPTION
DuckDB v1.5.3 moved jemalloc from a runtime extension into core. It is now controlled by the CMake option `ENABLE_JEMALLOC`, with upstream CMake still gating it to supported platforms.

Our previous `SKIP_EXTENSIONS=jemalloc` define now hits a compat shim that forces `ENABLE_JEMALLOC=OFF`. Clear `SKIP_EXTENSIONS` and set `ENABLE_JEMALLOC=ON` explicitly so reused CMake caches cannot keep the old disabled state.

The ON value is harmless on unsupported targets because DuckDB's CMake only enables jemalloc for supported 64-bit, non-musl Linux builds. Document that bundled-cmake behavior alongside the other CMake build notes.