### PR TITLE
Avoid Windows mtime restore in bundled builds

### DIFF
--- a/crates/libduckdb-sys/build_bundled_cc.rs
+++ b/crates/libduckdb-sys/build_bundled_cc.rs
@@ -46,6 +46,10 @@ fn untar_archive(out_dir: &str) {
     let tar_gz = std::fs::File::open(path).expect("archive file");
     let tar = flate2::read::GzDecoder::new(tar_gz);
     let mut archive = tar::Archive::new(tar);
+    // These archives are generated for reproducibility, not source mtimes.
+    // Skipping mtime restoration also avoids Windows SetFileTime failures on
+    // filesystems such as FAT32, which cannot represent Unix epoch mtimes.
+    archive.set_preserve_mtime(false);
     archive.unpack(out_dir).expect("archive");
 }
 

--- a/crates/libduckdb-sys/update_sources.py
+++ b/crates/libduckdb-sys/update_sources.py
@@ -22,6 +22,11 @@ PACKAGE_BUILD_LOADER_PATH = (
 )
 SRC_DIR = SCRIPT_DIR / "src"
 
+# Keep the timestamp reproducible while staying within the FAT/FAT32 date
+# range used by some Windows target directories. Unix epoch mtimes can fail
+# when archive tools restore them through SetFileTime.
+ARCHIVE_MTIME = 946684800  # 2000-01-01T00:00:00Z
+
 # List of extensions' sources to grab. Technically, these sources will be compiled
 # but not included in the final build unless they're explicitly enabled.
 EXTENSIONS = ["core_functions", "parquet", "json"]
@@ -109,7 +114,7 @@ def normalized_tarinfo(path):
     tarinfo.gid = 0
     tarinfo.uname = ""
     tarinfo.gname = ""
-    tarinfo.mtime = 0
+    tarinfo.mtime = ARCHIVE_MTIME
     tarinfo.pax_headers = {}
 
     if path.is_symlink():


### PR DESCRIPTION
The reproducible source archive previously used Unix epoch mtimes. On Windows targets backed by FAT/FAT32, restoring that timestamp can fail because those filesystems cannot represent Unix epoch times.

Fixes #764 

Tested with and without the fix in CI: https://github.com/duckdb/duckdb-rs/actions/runs/26278548238
