### PR TITLE
Expose Arrow C Data ABI structs in libduckdb-sys

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -611,6 +611,9 @@ mod bindings {
             .header(header.clone())
             .allowlist_item(r#"(\w*duckdb\w*)"#)
             .allowlist_type("idx_t")
+            // Use the concrete ABI layouts from src/arrow_c_data.rs.
+            .blocklist_type("ArrowArray")
+            .blocklist_type("ArrowSchema")
             .layout_tests(false) // causes problems on WASM builds
             .clang_arg("-DDUCKDB_EXTENSION_API_VERSION_UNSTABLE")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))

--- a/crates/libduckdb-sys/src/arrow_c_data.rs
+++ b/crates/libduckdb-sys/src/arrow_c_data.rs
@@ -1,0 +1,132 @@
+//! Arrow C Data Interface layouts used by DuckDB's Arrow conversion APIs.
+//!
+//! DuckDB's public C header forward-declares these structs. The conversion
+//! APIs need concrete caller-allocated layouts, so `libduckdb-sys` defines the
+//! ABI records directly without taking a dependency on arrow-rs.
+
+use std::{
+    ffi::{c_char, c_void},
+    ptr,
+};
+
+/// Arrow C Data Interface array.
+#[repr(C)]
+#[derive(Debug)]
+pub struct ArrowArray {
+    pub length: i64,
+    pub null_count: i64,
+    pub offset: i64,
+    pub n_buffers: i64,
+    pub n_children: i64,
+    pub buffers: *mut *const c_void,
+    pub children: *mut *mut ArrowArray,
+    pub dictionary: *mut ArrowArray,
+    pub release: Option<unsafe extern "C" fn(*mut ArrowArray)>,
+    pub private_data: *mut c_void,
+}
+
+impl ArrowArray {
+    /// Creates a null-release placeholder for a producer to fill.
+    pub const fn empty() -> Self {
+        Self {
+            length: 0,
+            null_count: 0,
+            offset: 0,
+            n_buffers: 0,
+            n_children: 0,
+            buffers: ptr::null_mut(),
+            children: ptr::null_mut(),
+            dictionary: ptr::null_mut(),
+            release: None,
+            private_data: ptr::null_mut(),
+        }
+    }
+}
+
+/// Arrow C Data Interface schema.
+#[repr(C)]
+#[derive(Debug)]
+pub struct ArrowSchema {
+    pub format: *const c_char,
+    pub name: *const c_char,
+    pub metadata: *const c_char,
+    pub flags: i64,
+    pub n_children: i64,
+    pub children: *mut *mut ArrowSchema,
+    pub dictionary: *mut ArrowSchema,
+    pub release: Option<unsafe extern "C" fn(*mut ArrowSchema)>,
+    pub private_data: *mut c_void,
+}
+
+impl ArrowSchema {
+    /// Creates a null-release placeholder for a producer to fill.
+    pub const fn empty() -> Self {
+        Self {
+            format: ptr::null(),
+            name: ptr::null(),
+            metadata: ptr::null(),
+            flags: 0,
+            n_children: 0,
+            children: ptr::null_mut(),
+            dictionary: ptr::null_mut(),
+            release: None,
+            private_data: ptr::null_mut(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{align_of, offset_of, size_of};
+
+    use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+
+    macro_rules! assert_offsets {
+        ($left:ty, $right:ty, $($field:ident),+ $(,)?) => {
+            $(
+                assert_eq!(
+                    offset_of!($left, $field),
+                    offset_of!($right, $field),
+                    concat!("field offset differs for ", stringify!($field))
+                );
+            )+
+        };
+    }
+
+    #[test]
+    fn matches_arrow_rs_layouts() {
+        assert_eq!(size_of::<ArrowArray>(), size_of::<FFI_ArrowArray>());
+        assert_eq!(align_of::<ArrowArray>(), align_of::<FFI_ArrowArray>());
+        assert_offsets!(
+            ArrowArray,
+            FFI_ArrowArray,
+            length,
+            null_count,
+            offset,
+            n_buffers,
+            n_children,
+            buffers,
+            children,
+            dictionary,
+            release,
+            private_data,
+        );
+
+        assert_eq!(size_of::<ArrowSchema>(), size_of::<FFI_ArrowSchema>());
+        assert_eq!(align_of::<ArrowSchema>(), align_of::<FFI_ArrowSchema>());
+        assert_offsets!(
+            ArrowSchema,
+            FFI_ArrowSchema,
+            format,
+            name,
+            metadata,
+            flags,
+            n_children,
+            children,
+            dictionary,
+            release,
+            private_data,
+        );
+    }
+}

--- a/crates/libduckdb-sys/src/arrow_c_data.rs
+++ b/crates/libduckdb-sys/src/arrow_c_data.rs
@@ -3,6 +3,8 @@
 //! DuckDB's public C header forward-declares these structs. The conversion
 //! APIs need concrete caller-allocated layouts, so `libduckdb-sys` defines the
 //! ABI records directly without taking a dependency on arrow-rs.
+//!
+//! Specification: <https://arrow.apache.org/docs/format/CDataInterface.html>
 
 use std::{
     ffi::{c_char, c_void},

--- a/crates/libduckdb-sys/src/bindgen_bundled_version.rs
+++ b/crates/libduckdb-sys/src/bindgen_bundled_version.rs
@@ -738,17 +738,6 @@ pub type duckdb_replacement_callback_t = ::std::option::Option<
         data: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = "! Forward declare Arrow structs\n! It is important to notice that these structs are not defined by DuckDB but are actually Arrow external objects.\n! They're defined by the C Data Interface Arrow spec: https://arrow.apache.org/docs/format/CDataInterface.html"]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ArrowArray {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ArrowSchema {
-    _unused: [u8; 0],
-}
 #[doc = "! Holds an arrow query result. Must be destroyed with `duckdb_destroy_arrow`."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/crates/libduckdb-sys/src/bindgen_bundled_version_loadable.rs
+++ b/crates/libduckdb-sys/src/bindgen_bundled_version_loadable.rs
@@ -738,17 +738,6 @@ pub type duckdb_replacement_callback_t = ::std::option::Option<
         data: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = "! Forward declare Arrow structs\n! It is important to notice that these structs are not defined by DuckDB but are actually Arrow external objects.\n! They're defined by the C Data Interface Arrow spec: https://arrow.apache.org/docs/format/CDataInterface.html"]
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ArrowArray {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ArrowSchema {
-    _unused: [u8; 0],
-}
 #[doc = "! Holds an arrow query result. Must be destroyed with `duckdb_destroy_arrow`."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -14126,4 +14115,3 @@ pub unsafe fn duckdb_rs_extension_api_init(
     }
     Ok(true)
 }
-

--- a/crates/libduckdb-sys/src/lib.rs
+++ b/crates/libduckdb-sys/src/lib.rs
@@ -4,8 +4,15 @@
 #![allow(deref_nullptr)]
 #![allow(improper_ctypes)]
 
+/// Dependency-free Arrow C Data Interface structs used by DuckDB Arrow APIs.
+mod arrow_c_data;
+pub use arrow_c_data::{ArrowArray, ArrowSchema};
+
 #[allow(clippy::all, unsafe_op_in_unsafe_fn)]
 mod bindings {
+    // Bindgen references these blocklisted forward declarations unqualified.
+    use crate::arrow_c_data::{ArrowArray, ArrowSchema};
+
     include!(concat!(env!("OUT_DIR"), "/bindgen.rs"));
 }
 #[allow(clippy::all)]


### PR DESCRIPTION
Define dependency-free `ArrowArray` and `ArrowSchema` layouts for DuckDB's Arrow conversion APIs, and block bindgen's opaque forward-declared versions so generated bindings use the concrete crate-local structs.

Lets downstream crates call DuckDB's new Arrow C APIs without redefining `ArrowArray` / `ArrowSchema` or depending on arrow-rs. Prepares duckdb-rs to adopt the new Arrow conversion APIs later.