### PR TITLE
Fix bundled builds on Windows/MSVC

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -56,12 +56,10 @@ pub(crate) fn write_bindings(header_dir: &Path, out_path: &Path) {
     }
 }
 
-/// Link the Windows system libraries DuckDB needs but that neither `cc` nor a static
-/// CMake link adds automatically. Mirrors DuckDB's `DUCKDB_SYSTEM_LIBS`
-/// (duckdb-sources/src/CMakeLists.txt): `ws2_32` + `rstrtmgr` under `if(MSVC OR MINGW)`
-/// and `bcrypt` under `if(MSVC)`; the MinGW path also needs `stdc++`. Single canonical
-/// copy shared by both bundled backends — keep in sync with that upstream list on
-/// submodule bumps. Callers apply their own `win_target()` gate.
+/// Link the Windows system libraries DuckDB needs but that neither `cc` nor a
+/// static CMake link adds automatically. Mirrors DuckDB's `DUCKDB_SYSTEM_LIBS`
+/// (duckdb-sources/src/CMakeLists.txt) — keep in sync on submodule bumps.
+/// Callers apply their own `win_target()` gate.
 #[cfg(feature = "bundled")]
 pub(crate) fn link_windows_system_libs() {
     println!("cargo:rustc-link-lib=dylib=ws2_32");

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -17,7 +17,6 @@ fn win_target() -> bool {
 /// the content of `CARGO_CFG_TARGET_ENV` (and is always lowercase)
 ///
 /// See [`win_target`]
-#[cfg(any(not(feature = "bundled"), feature = "bundled-cmake"))]
 fn is_compiler(compiler_name: &str) -> bool {
     std::env::var("CARGO_CFG_TARGET_ENV").is_ok_and(|v| v == compiler_name)
 }
@@ -54,6 +53,23 @@ pub(crate) fn write_bindings(header_dir: &Path, out_path: &Path) {
     {
         let _ = header_dir;
         copy_pregenerated_bindings(out_path);
+    }
+}
+
+/// Link the Windows system libraries DuckDB needs but that neither `cc` nor a static
+/// CMake link adds automatically. Mirrors DuckDB's `DUCKDB_SYSTEM_LIBS`
+/// (duckdb-sources/src/CMakeLists.txt): `ws2_32` + `rstrtmgr` under `if(MSVC OR MINGW)`
+/// and `bcrypt` under `if(MSVC)`; the MinGW path also needs `stdc++`. Single canonical
+/// copy shared by both bundled backends — keep in sync with that upstream list on
+/// submodule bumps. Callers apply their own `win_target()` gate.
+#[cfg(feature = "bundled")]
+pub(crate) fn link_windows_system_libs() {
+    println!("cargo:rustc-link-lib=dylib=ws2_32");
+    println!("cargo:rustc-link-lib=dylib=rstrtmgr");
+    if is_compiler("msvc") {
+        println!("cargo:rustc-link-lib=dylib=bcrypt");
+    } else {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
     }
 }
 

--- a/crates/libduckdb-sys/build_bundled_cc.rs
+++ b/crates/libduckdb-sys/build_bundled_cc.rs
@@ -1,4 +1,4 @@
-use crate::{link_windows_system_libs, win_target, write_bindings};
+use crate::{is_compiler, link_windows_system_libs, win_target, write_bindings};
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
@@ -113,6 +113,20 @@ pub fn main(out_dir: &str, out_path: &Path) {
         .flag_if_supported("/bigobj")
         .warnings(false)
         .flag_if_supported("-w");
+
+    // Enable C++ exceptions on MSVC. CMake-built DuckDB gets /EHsc from CMake's default
+    // MSVC flags, but the cc build must add it explicitly: without it MSVC leaves
+    // exception handling off, the C API's try/catch blocks are inert, and a thrown
+    // exception (e.g. an invalid-UTF-8 CSV read) aborts the process with
+    // STATUS_STACK_BUFFER_OVERRUN (https://github.com/duckdb/duckdb-rs/issues/774).
+    // Apply it as a hard, gated flag rather than flag_if_supported: /EHsc is always
+    // accepted by MSVC/clang-cl, so the probe can only ever pass — but a *spurious*
+    // probe failure would silently drop /EHsc, yielding a clean build that crashes at
+    // runtime with no signal. gcc/clang (incl. MinGW) enable exceptions by default and
+    // reject /EHsc, so gate on MSVC. Mirrors the gate in build_bundled_cmake.rs.
+    if win_target() && is_compiler("msvc") {
+        cfg.flag("/EHsc");
+    }
 
     let is_debug = match std::env::var("DEBUG") {
         Ok(v) => v != "false" && v != "0",

--- a/crates/libduckdb-sys/build_bundled_cc.rs
+++ b/crates/libduckdb-sys/build_bundled_cc.rs
@@ -114,16 +114,12 @@ pub fn main(out_dir: &str, out_path: &Path) {
         .warnings(false)
         .flag_if_supported("-w");
 
-    // Enable C++ exceptions on MSVC. CMake-built DuckDB gets /EHsc from CMake's default
-    // MSVC flags, but the cc build must add it explicitly: without it MSVC leaves
-    // exception handling off, the C API's try/catch blocks are inert, and a thrown
-    // exception (e.g. an invalid-UTF-8 CSV read) aborts the process with
-    // STATUS_STACK_BUFFER_OVERRUN (https://github.com/duckdb/duckdb-rs/issues/774).
-    // Apply it as a hard, gated flag rather than flag_if_supported: /EHsc is always
-    // accepted by MSVC/clang-cl, so the probe can only ever pass — but a *spurious*
-    // probe failure would silently drop /EHsc, yielding a clean build that crashes at
-    // runtime with no signal. gcc/clang (incl. MinGW) enable exceptions by default and
-    // reject /EHsc, so gate on MSVC. Mirrors the gate in build_bundled_cmake.rs.
+    // Enable C++ exceptions on MSVC: without /EHsc, exception handling is off, the
+    // C API's try/catch blocks are inert, and a thrown exception (e.g. invalid-UTF-8
+    // CSV read) aborts with STATUS_STACK_BUFFER_OVERRUN (#774). Hard flag, not
+    // flag_if_supported, so a spurious probe miss can't silently drop it. gcc/clang
+    // enable exceptions by default and reject /EHsc, so gate on MSVC. Mirrors
+    // build_bundled_cmake.rs.
     if win_target() && is_compiler("msvc") {
         cfg.flag("/EHsc");
     }
@@ -141,9 +137,8 @@ pub fn main(out_dir: &str, out_path: &Path) {
     }
     cfg.compile("duckdb");
 
-    // DuckDB references Windows system libraries that `cc` does not link automatically
-    // (e.g. unresolved `RmStartSession` pulled in by `duckdb::AdditionalLockInfo`, the
-    // Restart Manager). See link_windows_system_libs for the list and upstream mapping.
+    // `cc` does not link DuckDB's Windows system libs automatically (e.g. unresolved
+    // `RmStartSession` from the Restart Manager). See link_windows_system_libs.
     if win_target() {
         link_windows_system_libs();
     }

--- a/crates/libduckdb-sys/build_bundled_cc.rs
+++ b/crates/libduckdb-sys/build_bundled_cc.rs
@@ -1,4 +1,4 @@
-use crate::{win_target, write_bindings};
+use crate::{link_windows_system_libs, win_target, write_bindings};
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
@@ -126,6 +126,13 @@ pub fn main(out_dir: &str, out_path: &Path) {
         cfg.define("DUCKDB_BUILD_LIBRARY", None);
     }
     cfg.compile("duckdb");
+
+    // DuckDB references Windows system libraries that `cc` does not link automatically
+    // (e.g. unresolved `RmStartSession` pulled in by `duckdb::AdditionalLockInfo`, the
+    // Restart Manager). See link_windows_system_libs for the list and upstream mapping.
+    if win_target() {
+        link_windows_system_libs();
+    }
 
     println!("cargo:lib_dir={out_dir}");
 }

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -1,4 +1,4 @@
-use crate::{is_compiler, win_target, write_bindings};
+use crate::{is_compiler, link_windows_system_libs, win_target, write_bindings};
 use std::{
     collections::BTreeSet,
     env::{self, VarError},
@@ -469,15 +469,7 @@ fn link_system_libs() {
         "macos" => {
             println!("cargo:rustc-link-lib=dylib=c++");
         }
-        "windows" => {
-            println!("cargo:rustc-link-lib=dylib=ws2_32");
-            println!("cargo:rustc-link-lib=dylib=rstrtmgr");
-            if is_compiler("msvc") {
-                println!("cargo:rustc-link-lib=dylib=bcrypt");
-            } else {
-                println!("cargo:rustc-link-lib=dylib=stdc++");
-            }
-        }
+        "windows" => link_windows_system_libs(),
         other => {
             panic!(
                 "bundled-cmake is currently supported only on Linux, macOS, and Windows; unsupported target OS `{other}`"

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -134,6 +134,12 @@ pub fn main(out_dir: &str, out_path: &Path) {
             if disable_extension_load { "0" } else { "1" },
         );
 
+    // Windows MAX_PATH caveat: this build emits very deep object paths (the
+    // compressed_materialization unity object runs ~150 chars below the build dir) and
+    // Ninja does not shorten them to CMAKE_OBJECT_PATH_MAX, so a deep OUT_DIR can exceed
+    // 260 chars and fail late with `C1083: Cannot open compiler generated file: ''`. The
+    // build script can't raise the limit or move OUT_DIR — shorten the path instead
+    // (short CARGO_TARGET_DIR, drop `--target`, or check out nearer the drive root).
     let dst = config.build();
     let lib_dir = dst.join("lib");
     validate_extension_libraries(&lib_dir, &cmake_build_type, &enabled_extensions);

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -70,22 +70,14 @@ pub fn main(out_dir: &str, out_path: &Path) {
         .define("CMAKE_C_FLAGS_INIT", warning_suppression_flag())
         .define("CMAKE_CXX_FLAGS_INIT", warning_suppression_flag());
 
-    // Re-enable C++ exceptions on MSVC. CMake's platform default would add /EHsc to
-    // CMAKE_CXX_FLAGS, but the cmake crate makes its own `cxxflag`s the *source* of
-    // -DCMAKE_CXX_FLAGS, replacing CMake's default, so /EHsc is otherwise dropped and
-    // DuckDB compiles with exception handling effectively off. A single-threaded error
-    // still unwinds via x64's table-based mechanism, but an exception thrown across the
-    // parallel CSV reader's worker threads (e.g. invalid UTF-8) is then mishandled at
-    // the C API boundary: it aborts with STATUS_STACK_BUFFER_OVERRUN (0xC0000409) under
-    // a CRT mismatch, or deadlocks when the CRT is aligned, instead of returning an
-    // error (https://github.com/duckdb/duckdb-rs/issues/774).
+    // Re-enable C++ exceptions on MSVC. The cmake crate makes its `cxxflag`s the
+    // source of -DCMAKE_CXX_FLAGS, replacing CMake's default (which includes /EHsc),
+    // so exception handling ends up effectively off: a thrown exception (e.g.
+    // invalid-UTF-8 CSV read) then aborts with STATUS_STACK_BUFFER_OVERRUN (#774).
     //
-    // INVARIANT: cxxflag("/EHsc") only reaches the compiler because we never call
-    // `config.define("CMAKE_CXX_FLAGS", ..)` — the cmake crate sources -DCMAKE_CXX_FLAGS
-    // from its `cxxflags` *only when* that var is not already in `defines`. Defining
-    // CMAKE_CXX_FLAGS anywhere here would silently discard /EHsc and reintroduce #774.
-    // (CMAKE_CXX_FLAGS_INIT, which we set to "/w", is a different variable and is safe.)
-    // Mirrors the gate in build_bundled_cc.rs; gcc/clang enable exceptions by default.
+    // Don't `config.define("CMAKE_CXX_FLAGS", ..)` here: it overrides the cxxflag
+    // above and silently drops /EHsc, reintroducing #774.
+    // Mirrors build_bundled_cc.rs; gcc/clang enable exceptions by default.
     if win_target() && is_compiler("msvc") {
         config.cxxflag("/EHsc");
     }
@@ -134,12 +126,11 @@ pub fn main(out_dir: &str, out_path: &Path) {
             if disable_extension_load { "0" } else { "1" },
         );
 
-    // Windows MAX_PATH caveat: this build emits very deep object paths (the
-    // compressed_materialization unity object runs ~150 chars below the build dir) and
-    // Ninja does not shorten them to CMAKE_OBJECT_PATH_MAX, so a deep OUT_DIR can exceed
-    // 260 chars and fail late with `C1083: Cannot open compiler generated file: ''`. The
-    // build script can't raise the limit or move OUT_DIR — shorten the path instead
-    // (short CARGO_TARGET_DIR, drop `--target`, or check out nearer the drive root).
+    // Windows MAX_PATH caveat: this build emits very deep object paths (Ninja ignores
+    // CMAKE_OBJECT_PATH_MAX), so a deep OUT_DIR can exceed 260 chars and fail late with
+    // `C1083: Cannot open compiler generated file: ''`. The build script can't move
+    // OUT_DIR — shorten the path (short CARGO_TARGET_DIR, drop `--target`, or check out
+    // nearer the drive root).
     let dst = config.build();
     let lib_dir = dst.join("lib");
     validate_extension_libraries(&lib_dir, &cmake_build_type, &enabled_extensions);

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -70,6 +70,26 @@ pub fn main(out_dir: &str, out_path: &Path) {
         .define("CMAKE_C_FLAGS_INIT", warning_suppression_flag())
         .define("CMAKE_CXX_FLAGS_INIT", warning_suppression_flag());
 
+    // Re-enable C++ exceptions on MSVC. CMake's platform default would add /EHsc to
+    // CMAKE_CXX_FLAGS, but the cmake crate makes its own `cxxflag`s the *source* of
+    // -DCMAKE_CXX_FLAGS, replacing CMake's default, so /EHsc is otherwise dropped and
+    // DuckDB compiles with exception handling effectively off. A single-threaded error
+    // still unwinds via x64's table-based mechanism, but an exception thrown across the
+    // parallel CSV reader's worker threads (e.g. invalid UTF-8) is then mishandled at
+    // the C API boundary: it aborts with STATUS_STACK_BUFFER_OVERRUN (0xC0000409) under
+    // a CRT mismatch, or deadlocks when the CRT is aligned, instead of returning an
+    // error (https://github.com/duckdb/duckdb-rs/issues/774).
+    //
+    // INVARIANT: cxxflag("/EHsc") only reaches the compiler because we never call
+    // `config.define("CMAKE_CXX_FLAGS", ..)` — the cmake crate sources -DCMAKE_CXX_FLAGS
+    // from its `cxxflags` *only when* that var is not already in `defines`. Defining
+    // CMAKE_CXX_FLAGS anywhere here would silently discard /EHsc and reintroduce #774.
+    // (CMAKE_CXX_FLAGS_INIT, which we set to "/w", is a different variable and is safe.)
+    // Mirrors the gate in build_bundled_cc.rs; gcc/clang enable exceptions by default.
+    if win_target() && is_compiler("msvc") {
+        config.cxxflag("/EHsc");
+    }
+
     // Unity builds (DuckDB's default) combine .cpp files into fewer translation
     // units and compile significantly faster. Allow opting out for debugging.
     // Always set explicitly so the CMake cache doesn't keep a stale value.


### PR DESCRIPTION
Makes both bundled backends build and run correctly on Windows/MSVC.

- Link missing system libs (`ws2_32`, `rstrtmgr`, etc.) - fixes #544
- Compile with `/EHsc` to enable proper exception handling - fixes #774
- Document `MAX_PATH` caveat