### PR TITLE
Make VScalar::invoke safe to align with VTab

### DIFF
--- a/crates/duckdb/examples/vscalar.rs
+++ b/crates/duckdb/examples/vscalar.rs
@@ -20,7 +20,7 @@ impl VScalar for AddOne {
 
     /// Called once per data chunk. DuckDB passes a batch of input rows and
     /// expects the corresponding output values to be written back.
-    unsafe fn invoke(
+    fn invoke(
         _: &Self::State,
         input: &mut DataChunkHandle,
         output: &mut dyn WritableVector,

--- a/crates/duckdb/src/vscalar/arrow.rs
+++ b/crates/duckdb/src/vscalar/arrow.rs
@@ -107,7 +107,7 @@ where
 {
     type State = T::State;
 
-    unsafe fn invoke(
+    fn invoke(
         state: &Self::State,
         input: &mut DataChunkHandle,
         out: &mut dyn WritableVector,

--- a/crates/duckdb/src/vscalar/mod.rs
+++ b/crates/duckdb/src/vscalar/mod.rs
@@ -33,20 +33,25 @@ pub trait VScalar: Sized {
     /// of this call. Implementations must populate `output` for rows
     /// `0..input.len()` and must not read or write beyond that range.
     ///
-    /// # Safety
+    /// This mirrors [`VTab::func`](crate::vtab::VTab::func): the method itself
+    /// is safe, but `input` and `output` are accessed through the vector
+    /// wrappers in [`crate::core`], several of whose accessors are `unsafe`.
     ///
-    /// Called by the DuckDB trampoline with wrappers over borrowed DuckDB
-    /// storage. Implementations must:
+    /// # Working with vectors
+    ///
+    /// When reaching for those `unsafe` accessors, implementations must uphold
+    /// their contracts:
     ///
     /// - only read and write within the rows and column types DuckDB provided
     ///   for this invocation;
     /// - not retain `input`, `output`, or any vector/slice derived from them
     ///   past return;
     /// - not hold two writable wrappers over the same column at the same
-    ///   time. The wrapper types do not currently prevent this: calling e.g.
-    ///   `input.flat_vector(0)` twice and then `as_mut_slice` on each yields
-    ///   overlapping `&mut [T]`, which is undefined behavior.
-    unsafe fn invoke(
+    ///   time. The column accessors (`flat_vector`, `list_vector`, ...) take
+    ///   `&self`, so safe code can obtain two wrappers over one column and
+    ///   call `as_mut_slice` on each, yielding overlapping `&mut [T]` —
+    ///   undefined behavior.
+    fn invoke(
         state: &Self::State,
         input: &mut DataChunkHandle,
         output: &mut dyn WritableVector,
@@ -232,7 +237,7 @@ mod test {
     impl VScalar for ErrorScalar {
         type State = ();
 
-        unsafe fn invoke(
+        fn invoke(
             _: &Self::State,
             input: &mut DataChunkHandle,
             _: &mut dyn WritableVector,
@@ -271,7 +276,7 @@ mod test {
     impl VScalar for EchoScalar {
         type State = TestState;
 
-        unsafe fn invoke(
+        fn invoke(
             state: &Self::State,
             input: &mut DataChunkHandle,
             output: &mut dyn WritableVector,
@@ -304,7 +309,7 @@ mod test {
     impl VScalar for Repeat {
         type State = ();
 
-        unsafe fn invoke(
+        fn invoke(
             _: &Self::State,
             input: &mut DataChunkHandle,
             output: &mut dyn WritableVector,
@@ -420,7 +425,7 @@ mod test {
     impl VScalar for CounterScalar {
         type State = ();
 
-        unsafe fn invoke(
+        fn invoke(
             _: &Self::State,
             input: &mut DataChunkHandle,
             output: &mut dyn WritableVector,
@@ -448,7 +453,7 @@ mod test {
     impl VScalar for VolatileCounterScalar {
         type State = ();
 
-        unsafe fn invoke(
+        fn invoke(
             _: &Self::State,
             input: &mut DataChunkHandle,
             output: &mut dyn WritableVector,


### PR DESCRIPTION
`VTab`'s bind/init/func are safe fns (#414), but `VScalar::invoke` was still an `unsafe fn`, pushing the proof obligation onto every implementor. The genuine unsafety lives in the vector accessors, which are already `unsafe`, so the method itself can be safe just like `VTab::func` -- impls keep their inner `unsafe {}` blocks where they touch raw vector storage.