### PR TITLE
Add stub nightly CI job for integration testing

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,22 @@
+name: Nightly
+
+on:
+  workflow_dispatch:
+    inputs:
+      duckdb-sha:
+        description: DuckDB commit SHA to test against
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
+jobs:
+  nightly:
+    name: DuckDB nightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show DuckDB commit
+        run: |
+          echo "DuckDB commit: ${{ inputs.duckdb-sha }}"


### PR DESCRIPTION
Will add actual testing later. This will be triggered by https://github.com/duckdb/duckdb/pull/23352

refs https://github.com/duckdblabs/duckdb-internal/issues/7516