### PR TITLE
Test DuckDB nightly commits

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Upgrade bundled DuckDB to nightly commit
+        id: upgrade
         env:
           DUCKDB_SHA: ${{ inputs.duckdb-sha }}
         run: ./upgrade.sh --sha "$DUCKDB_SHA"
@@ -47,4 +48,5 @@ jobs:
         run: cargo test -p duckdb --features bundled
 
       - name: Test bundled-cmake backend
+        if: ${{ !cancelled() && steps.upgrade.outcome == 'success' }}
         run: cargo test -p duckdb --features bundled-cmake

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,11 +12,39 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.duckdb-sha }}
+  cancel-in-progress: true
+
 jobs:
   nightly:
     name: DuckDB nightly
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
     steps:
-      - name: Show DuckDB commit
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Upgrade bundled DuckDB to nightly commit
+        env:
+          DUCKDB_SHA: ${{ inputs.duckdb-sha }}
+        run: ./upgrade.sh --sha "$DUCKDB_SHA"
+
+      - name: Show generated upgrade diff
+        if: always()
         run: |
-          echo "DuckDB commit: ${{ inputs.duckdb-sha }}"
+          git status --short
+          git diff --stat
+
+      - name: Test bundled backend
+        run: cargo test -p duckdb --features bundled
+
+      - name: Test bundled-cmake backend
+        run: cargo test -p duckdb --features bundled-cmake

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           submodules: recursive
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Upgrade bundled DuckDB to nightly commit
         env:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -45,6 +45,7 @@ jobs:
           git diff --stat
 
       - name: Test bundled backend
+        if: ${{ !cancelled() && steps.upgrade.outcome == 'success' }}
         run: cargo test -p duckdb --features bundled
 
       - name: Test bundled-cmake backend

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -126,7 +126,7 @@ jobs:
         with:
           submodules: recursive
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Verify static linking with extension loading disabled
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,16 +172,18 @@ submodule, generated bindings, or DuckDB download tags.
 
 #### Testing a pre-tag DuckDB commit
 
-To integrate a DuckDB version before it is tagged, pass `--sha` to pin the
-bundled sources to an upstream commit (e.g. a release-branch commit). The
-`bundled` build compiles from source, so no published release binaries are
-needed.
+To integrate a DuckDB version before it is tagged, pass a commit SHA to `--sha`
+(e.g. a release-branch commit). The `bundled` build compiles from source, so no
+published release binaries are needed.
 
 ```shell
-./upgrade.sh --sha <COMMIT_SHA>          # test a commit, no version bump
+./upgrade.sh --sha <COMMIT_SHA>          # pin a commit, no version bump
 ./upgrade.sh v1.5.4 --sha <COMMIT_SHA>   # planned release, sources pinned to commit
 ```
 
-Both regenerate bindings and run the bundled tests. Download-based CI jobs
-(`DUCKDB_DOWNLOAD_LIB`, the Windows release zip) stay red until DuckDB publishes
-the release binaries; re-run `./upgrade.sh v1.5.4` to finalize once tagged.
+Both regenerate bundled sources and bindings, but do not run tests. Validate
+locally, or rely on the nightly workflow and CI to cover the bundled backends.
+Download-based CI jobs (`DUCKDB_DOWNLOAD_LIB`, the Windows release zip) stay red
+until DuckDB publishes the release binaries. If the planned release command
+above already bumped versions and download URLs, finalize the bundled sources
+and bindings from the tag with `./crates/libduckdb-sys/upgrade.sh v1.5.4`.

--- a/crates/libduckdb-sys/upgrade.sh
+++ b/crates/libduckdb-sys/upgrade.sh
@@ -23,6 +23,15 @@ crate_version_to_duckdb_version() {
     printf 'v%s.%s.%s' "$DUCKDB_MAJOR" "$DUCKDB_MINOR" "$DUCKDB_PATCH"
 }
 
+fetch_duckdb_sha() {
+    local SHA=$1
+    if ! git fetch origin "$SHA"; then
+        echo "Failed to fetch DuckDB commit $SHA from origin." >&2
+        echo "Ensure the commit is reachable from an advertised remote ref." >&2
+        exit 1
+    fi
+}
+
 # Parse args before doing expensive regeneration work.
 DUCKDB_SHA=""
 POSITIONAL=()
@@ -43,8 +52,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -n "$DUCKDB_SHA" ] && ! [[ "$DUCKDB_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
-    echo "Invalid commit SHA: $DUCKDB_SHA" >&2
+if [ -n "$DUCKDB_SHA" ] && ! [[ "$DUCKDB_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "Invalid commit SHA: $DUCKDB_SHA (expected 40 hex characters)" >&2
     exit 1
 fi
 
@@ -61,8 +70,14 @@ fi
 
 git submodule update --init --checkout
 cd "$SCRIPT_DIR/duckdb-sources"
-git fetch
-git checkout "${DUCKDB_SHA:-$DUCKDB_VERSION}"
+if [ -n "$DUCKDB_SHA" ]; then
+    fetch_duckdb_sha "$DUCKDB_SHA"
+    DUCKDB_TARGET=$DUCKDB_SHA
+else
+    git fetch --all --tags
+    DUCKDB_TARGET=$DUCKDB_VERSION
+fi
+git checkout "$DUCKDB_TARGET"
 cd "$SCRIPT_DIR"
 python3 "$SCRIPT_DIR/update_sources.py"
 
@@ -77,9 +92,6 @@ if [ ! -f "$SCRIPT_DIR/src/bindgen_bundled_version_loadable.rs" ]; then
     exit 1
 fi
 
-# Sanity checks
-# FIXME: how to test this here?
-
 # Regenerate bindgen file for DUCKDB
 rm -f "$SCRIPT_DIR/src/bindgen_bundled_version.rs"
 # Just to make sure there is only one bindgen.rs file in target dir
@@ -91,4 +103,4 @@ if [ ! -f "$SCRIPT_DIR/src/bindgen_bundled_version.rs" ]; then
     exit 1
 fi
 
-printf '    \e[35;1mFinished\e[0m regenerating bundled DUCKDB sources\n'
+printf '    \e[35;1mFinished\e[0m regenerating bundled DUCKDB sources and bindings (tests not run)\n'

--- a/crates/libduckdb-sys/upgrade.sh
+++ b/crates/libduckdb-sys/upgrade.sh
@@ -91,8 +91,4 @@ if [ ! -f "$SCRIPT_DIR/src/bindgen_bundled_version.rs" ]; then
     exit 1
 fi
 
-# Sanity checks
-cd "$SCRIPT_DIR/.."
-cargo test --features "extensions-full buildtime_bindgen"
-
-printf '    \e[35;1mFinished\e[0m bundled DUCKDB tests\n'
+printf '    \e[35;1mFinished\e[0m regenerating bundled DUCKDB sources\n'

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -28,8 +28,7 @@ With DUCKDB_VERSION, upgrade bundled DuckDB and reset the crate patch to 0.
 With DUCKDB_VERSION and --sha, pin the bundled DuckDB sources to COMMIT_SHA
 (e.g. a pre-tag release-branch commit) while still bumping to the planned
 DUCKDB_VERSION. With --sha alone, pin sources to COMMIT_SHA and regenerate for
-the current crate version without bumping versions or download URLs (for
-testing arbitrary upstream commits).
+the current crate version without bumping versions or download URLs.
 Full upgrades also update workflow and README download URLs and regenerate
 bindings. With --patch, increment only the duckdb-rs crate patch version and
 leave DuckDB sources, generated bindings, and DuckDB download tags unchanged.
@@ -136,8 +135,8 @@ if [ "$PATCH_MODE" -eq 1 ] && { [ -n "$DUCKDB_SHA" ] || [ ${#POSITIONAL[@]} -ne 
     exit 1
 fi
 
-if [ -n "$DUCKDB_SHA" ] && ! [[ "$DUCKDB_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
-    echo "Invalid commit SHA: $DUCKDB_SHA" >&2
+if [ -n "$DUCKDB_SHA" ] && ! [[ "$DUCKDB_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "Invalid commit SHA: $DUCKDB_SHA (expected 40 hex characters)" >&2
     exit 1
 fi
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -27,7 +27,7 @@ Without arguments, upgrade to the latest DuckDB release.
 With DUCKDB_VERSION, upgrade bundled DuckDB and reset the crate patch to 0.
 With DUCKDB_VERSION and --sha, pin the bundled DuckDB sources to COMMIT_SHA
 (e.g. a pre-tag release-branch commit) while still bumping to the planned
-DUCKDB_VERSION. With --sha alone, pin sources to COMMIT_SHA and test against
+DUCKDB_VERSION. With --sha alone, pin sources to COMMIT_SHA and regenerate for
 the current crate version without bumping versions or download URLs (for
 testing arbitrary upstream commits).
 Full upgrades also update workflow and README download URLs and regenerate
@@ -160,10 +160,10 @@ if [ "$PATCH_MODE" -eq 1 ]; then
     exit 0
 fi
 
-# Test an arbitrary upstream commit: pin sources to the SHA and validate it
-# against the current crate version, without bumping versions or download URLs.
+# Pin an arbitrary upstream commit against the current crate version, without
+# bumping versions or download URLs.
 if [ -n "$DUCKDB_SHA" ] && [ ${#POSITIONAL[@]} -eq 0 ]; then
-    echo "Test DuckDB commit $DUCKDB_SHA against current crate version $CURRENT_CRATE_VERSION (no version bump)"
+    echo "Pin DuckDB commit $DUCKDB_SHA against current crate version $CURRENT_CRATE_VERSION (no version bump)"
     exec ./crates/libduckdb-sys/upgrade.sh --sha "$DUCKDB_SHA"
 fi
 


### PR DESCRIPTION
Expands https://github.com/duckdb/duckdb-rs/pull/791 to run real tests for nightly `v1.5-variegata` commits, using `bundled` and `bundled-cmake`.

refs https://github.com/duckdblabs/duckdb-internal/issues/7516