### PR TITLE
Speed up nightly CI runs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,6 +46,11 @@ jobs:
 
       - name: Test bundled backend
         if: ${{ !cancelled() && steps.upgrade.outcome == 'success' }}
+        # cc crate ignores CMAKE_*_COMPILER_LAUNCHER; wrap CC/CXX for sccache.
+        # Step-scoped so it doesn't reach the bundled-cmake step.
+        env:
+          CC: "sccache cc"
+          CXX: "sccache c++"
         run: cargo test -p duckdb --features bundled
 
       - name: Test bundled-cmake backend

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Test bundled backend
         if: ${{ !cancelled() && steps.upgrade.outcome == 'success' }}
         # cc crate ignores CMAKE_*_COMPILER_LAUNCHER; wrap CC/CXX for sccache.
-        # Step-scoped so it doesn't reach the bundled-cmake step.
+        # Step-scoped so CC/CXX do not leak into cmake backend steps.
         env:
           CC: "sccache cc"
           CXX: "sccache c++"

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -44,11 +44,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       DUCKDB_DOWNLOAD_LIB: "1"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: ${{ matrix.target }}
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - uses: robinraju/release-downloader@v1.4
         name: Download duckdb
@@ -65,6 +68,10 @@ jobs:
       - name: run cargo clippy
         if: matrix.os == 'ubuntu-latest'
         # `bundled-cmake` is checkout-only and covered in the dedicated CMake job below.
+        # extensions-full pulls in the bundled (cc) backend; wrap CC/CXX for sccache.
+        env:
+          CC: "sccache cc"
+          CXX: "sccache c++"
         run: cargo clippy --all-targets --features "buildtime_bindgen extensions-full loadable-extension modern-full vscalar vscalar-arrow vtab-full" --locked -- -D warnings
 
       - name: Dry-run release of crates
@@ -168,11 +175,15 @@ jobs:
   sanitizer:
     name: Address Sanitizer
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2026-03-03
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - name: Tests with asan
         env:
           # PRs use a downloaded libduckdb for speed (no bundled C++ ASAN coverage).
@@ -182,6 +193,10 @@ jobs:
           RUSTFLAGS: -Zsanitizer=address -C debuginfo=0
           RUSTDOCFLAGS: -Zsanitizer=address
           ASAN_OPTIONS: "detect_stack_use_after_return=1:detect_leaks=1:symbolize=1"
+          # extensions-full (main only) compiles the bundled (cc) backend; wrap CC/CXX
+          # for sccache. Not ASAN-instrumented (RUSTFLAGS don't reach cc), so safe.
+          CC: "sccache cc"
+          CXX: "sccache c++"
         # We cannot run "modern-full" with asan as the chrono feature will auto-load release binaries of
         # the ICU-extension, which are not built with ASAN and will cause a crash.
         run: cargo test --lib --tests --features "${ASAN_FEATURES}" --target x86_64-unknown-linux-gnu --package duckdb

--- a/crates/duckdb/src/extension.rs
+++ b/crates/duckdb/src/extension.rs
@@ -50,19 +50,4 @@ mod test {
         assert!(db.query_row::<bool, _, _>("SELECT length(icu_sort_key('Ş', 'ro')) > 0;", [], |r| r.get(0))?);
         Ok(())
     }
-
-    #[cfg(feature = "parquet")]
-    #[test]
-    fn test_extension_remote_parquet() -> Result<()> {
-        let db = Connection::open_in_memory()?;
-        assert_eq!(
-            9i64,
-            db.query_row::<i64, _, _>(
-                r#"SELECT count(*) FROM read_parquet('https://duckdb.org/data/prices.parquet');"#,
-                [],
-                |r| r.get(0)
-            )?
-        );
-        Ok(())
-    }
 }

--- a/crates/libduckdb-sys/upgrade.sh
+++ b/crates/libduckdb-sys/upgrade.sh
@@ -37,24 +37,22 @@ regenerate_bindings() {
     shift
     local FEATURES=$*
     local BINDGEN_RS
+    local TMP_OUTPUT
 
-    rm -f "$OUTPUT"
-    find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -exec rm {} \;
+    find "$WORKSPACE_DIR/target" -type f -name bindgen.rs -exec rm {} \;
     DUCKDB_LIB_DIR="$SCRIPT_DIR/duckdb" \
         DUCKDB_INCLUDE_DIR="$SCRIPT_DIR/duckdb/src/include" \
         cargo check -p libduckdb-sys --no-default-features --features "$FEATURES"
 
-    BINDGEN_RS=$(find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -print -quit)
+    BINDGEN_RS=$(find "$WORKSPACE_DIR/target" -path '*/libduckdb-sys-*/out/bindgen.rs' -print -quit)
     if [ -z "$BINDGEN_RS" ]; then
         echo "ERROR: bindgen.rs was not generated" >&2
         exit 1
     fi
 
-    cp "$BINDGEN_RS" "$OUTPUT"
-    if [ ! -f "$OUTPUT" ]; then
-        echo "ERROR: $OUTPUT was not regenerated" >&2
-        exit 1
-    fi
+    TMP_OUTPUT="${OUTPUT}.tmp"
+    cp "$BINDGEN_RS" "$TMP_OUTPUT"
+    mv "$TMP_OUTPUT" "$OUTPUT"
 }
 
 # Parse args before doing expensive regeneration work.
@@ -82,7 +80,7 @@ if [ -n "$DUCKDB_SHA" ] && ! [[ "$DUCKDB_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
     exit 1
 fi
 
-mkdir -p "$SCRIPT_DIR/../../target"
+mkdir -p "$WORKSPACE_DIR/target"
 
 DUCKDB_VERSION=${POSITIONAL[0]:-$(crate_version_to_duckdb_version "$(current_workspace_version)")}
 DUCKDB_VERSION="v${DUCKDB_VERSION#v}"
@@ -104,7 +102,6 @@ git checkout "$DUCKDB_TARGET"
 cd "$SCRIPT_DIR"
 python3 "$SCRIPT_DIR/update_sources.py"
 
-cd "$SCRIPT_DIR"
 regenerate_bindings "$SCRIPT_DIR/src/bindgen_bundled_version.rs" buildtime_bindgen
 regenerate_bindings "$SCRIPT_DIR/src/bindgen_bundled_version_loadable.rs" buildtime_bindgen loadable-extension
 

--- a/crates/libduckdb-sys/upgrade.sh
+++ b/crates/libduckdb-sys/upgrade.sh
@@ -32,6 +32,31 @@ fetch_duckdb_sha() {
     fi
 }
 
+regenerate_bindings() {
+    local OUTPUT=$1
+    shift
+    local FEATURES=$*
+    local BINDGEN_RS
+
+    rm -f "$OUTPUT"
+    find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -exec rm {} \;
+    DUCKDB_LIB_DIR="$SCRIPT_DIR/duckdb" \
+        DUCKDB_INCLUDE_DIR="$SCRIPT_DIR/duckdb/src/include" \
+        cargo check -p libduckdb-sys --no-default-features --features "$FEATURES"
+
+    BINDGEN_RS=$(find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -print -quit)
+    if [ -z "$BINDGEN_RS" ]; then
+        echo "ERROR: bindgen.rs was not generated" >&2
+        exit 1
+    fi
+
+    cp "$BINDGEN_RS" "$OUTPUT"
+    if [ ! -f "$OUTPUT" ]; then
+        echo "ERROR: $OUTPUT was not regenerated" >&2
+        exit 1
+    fi
+}
+
 # Parse args before doing expensive regeneration work.
 DUCKDB_SHA=""
 POSITIONAL=()
@@ -57,9 +82,7 @@ if [ -n "$DUCKDB_SHA" ] && ! [[ "$DUCKDB_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
     exit 1
 fi
 
-cargo clean
-mkdir -p "$SCRIPT_DIR/../../target" "$SCRIPT_DIR/duckdb"
-export DUCKDB_LIB_DIR="$SCRIPT_DIR/duckdb"
+mkdir -p "$SCRIPT_DIR/../../target"
 
 DUCKDB_VERSION=${POSITIONAL[0]:-$(crate_version_to_duckdb_version "$(current_workspace_version)")}
 DUCKDB_VERSION="v${DUCKDB_VERSION#v}"
@@ -81,26 +104,8 @@ git checkout "$DUCKDB_TARGET"
 cd "$SCRIPT_DIR"
 python3 "$SCRIPT_DIR/update_sources.py"
 
-# Regenerate bindgen file for DUCKDB
 cd "$SCRIPT_DIR"
-rm -f "$SCRIPT_DIR/src/bindgen_bundled_version_loadable.rs"
-find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -exec rm {} \;
-cargo build --features "extensions-full buildtime_bindgen loadable-extension"
-find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -exec cp {} "$SCRIPT_DIR/src/bindgen_bundled_version_loadable.rs" \;
-if [ ! -f "$SCRIPT_DIR/src/bindgen_bundled_version_loadable.rs" ]; then
-    echo "ERROR: bindgen_bundled_version_loadable.rs was not regenerated" >&2
-    exit 1
-fi
+regenerate_bindings "$SCRIPT_DIR/src/bindgen_bundled_version.rs" buildtime_bindgen
+regenerate_bindings "$SCRIPT_DIR/src/bindgen_bundled_version_loadable.rs" buildtime_bindgen loadable-extension
 
-# Regenerate bindgen file for DUCKDB
-rm -f "$SCRIPT_DIR/src/bindgen_bundled_version.rs"
-# Just to make sure there is only one bindgen.rs file in target dir
-find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -exec rm {} \;
-cargo build --features "extensions-full buildtime_bindgen"
-find "$SCRIPT_DIR/../../target" -type f -name bindgen.rs -exec cp {} "$SCRIPT_DIR/src/bindgen_bundled_version.rs" \;
-if [ ! -f "$SCRIPT_DIR/src/bindgen_bundled_version.rs" ]; then
-    echo "ERROR: bindgen_bundled_version.rs was not regenerated" >&2
-    exit 1
-fi
-
-printf '    \e[35;1mFinished\e[0m regenerating bundled DUCKDB sources and bindings (tests not run)\n'
+printf '    \e[35;1mFinished\e[0m regenerating bundled DuckDB sources and bindings (tests not run)\n'

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -187,8 +187,7 @@ echo "Update crate version from $CURRENT_CRATE_VERSION to $TARGET_CRATE_VERSION"
 
 update_crate_versions
 
-sed_inplace "s!$CURRENT_DUCKDB_VERSION_PATTERN!$DUCKDB_VERSION!g" \
-    .github/workflows/rust.yaml
+sed_inplace "s!$CURRENT_DUCKDB_VERSION_PATTERN!$DUCKDB_VERSION!g" .github/workflows/rust.yaml
 
 # Update README download URLs, not prose/history.
 sed_inplace "/releases\/download/s!$CURRENT_DUCKDB_VERSION_PATTERN!$DUCKDB_VERSION!g" README.md


### PR DESCRIPTION
Follow-up to #792

Three changes to make the nightly workflow faster and less flaky:

- regenerate bindings with `cargo check` against headers instead of two full DuckDB builds
- cache bundled (cc) builds with sccache by wrapping `CC`/`CXX`
- drop the remote Parquet test that hit the network and blocked runs

refs https://github.com/duckdblabs/duckdb-internal/issues/7516