### PR TITLE
Add UHUGEINT support

### DIFF
--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -4,7 +4,7 @@ use std::{ffi::c_void, fmt, os::raw::c_char};
 use crate::{
     Error,
     error::result_from_duckdb_appender,
-    types::{ToSql, ToSqlOutput, value_ref_from_value},
+    types::{ToSql, ToSqlOutput, to_duckdb_hugeint, to_duckdb_uhugeint, value_ref_from_value},
 };
 
 /// Appender for fast import data
@@ -186,13 +186,8 @@ impl Appender<'_> {
             ValueRef::USmallInt(i) => unsafe { ffi::duckdb_append_uint16(ptr, i) },
             ValueRef::UInt(i) => unsafe { ffi::duckdb_append_uint32(ptr, i) },
             ValueRef::UBigInt(i) => unsafe { ffi::duckdb_append_uint64(ptr, i) },
-            ValueRef::HugeInt(i) => unsafe {
-                let hi = ffi::duckdb_hugeint {
-                    lower: i as u64,
-                    upper: (i >> 64) as i64,
-                };
-                ffi::duckdb_append_hugeint(ptr, hi)
-            },
+            ValueRef::HugeInt(i) => unsafe { ffi::duckdb_append_hugeint(ptr, to_duckdb_hugeint(i)) },
+            ValueRef::UHugeInt(i) => unsafe { ffi::duckdb_append_uhugeint(ptr, to_duckdb_uhugeint(i)) },
 
             ValueRef::Float(r) => unsafe { ffi::duckdb_append_float(ptr, r) },
             ValueRef::Double(r) => unsafe { ffi::duckdb_append_double(ptr, r) },
@@ -219,13 +214,7 @@ impl Appender<'_> {
             },
             ValueRef::Decimal(d) => unsafe {
                 let decimal = crate::types::to_duckdb_decimal(d);
-                let mut value = ffi::duckdb_create_decimal(decimal);
-                if value.is_null() {
-                    return Err(Error::AppendError);
-                }
-                let res = ffi::duckdb_append_value(ptr, value);
-                ffi::duckdb_destroy_value(&mut value);
-                res
+                append_decimal(ptr, decimal)?
             },
             _ => {
                 return Err(Error::ToSqlConversionFailure(
@@ -299,6 +288,18 @@ fn appending_unsupported_value(value_type: impl fmt::Display) -> String {
     format!("appending {value_type} values is not yet supported")
 }
 
+unsafe fn append_decimal(ptr: ffi::duckdb_appender, decimal: ffi::duckdb_decimal) -> Result<ffi::duckdb_state> {
+    let mut value = unsafe { ffi::duckdb_create_decimal(decimal) };
+    if value.is_null() {
+        return Err(Error::AppendError);
+    }
+    let res = unsafe { ffi::duckdb_append_value(ptr, value) };
+    unsafe {
+        ffi::duckdb_destroy_value(&mut value);
+    }
+    Ok(res)
+}
+
 fn to_value_ref<'value, 'output>(value: &'value ToSqlOutput<'output>) -> Result<ValueRef<'value>>
 where
     'output: 'value,
@@ -318,6 +319,7 @@ fn validate_appender_value_ref(value: ValueRef<'_>) -> Result<()> {
         | ValueRef::Int(_)
         | ValueRef::BigInt(_)
         | ValueRef::HugeInt(_)
+        | ValueRef::UHugeInt(_)
         | ValueRef::UTinyInt(_)
         | ValueRef::USmallInt(_)
         | ValueRef::UInt(_)
@@ -505,6 +507,26 @@ mod test {
 
         let val = db.query_row("SELECT sum(x), sum(y) FROM foo", [], |row| <(i32, i32)>::try_from(row))?;
         assert_eq!(val, (25, 30));
+        Ok(())
+    }
+
+    #[test]
+    fn test_append_u128_as_uhugeint() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute("CREATE TABLE t(v UHUGEINT)", [])?;
+
+        let mut appender = db.appender("t")?;
+        appender.append_row([0u128])?;
+        appender.append_row([u128::MAX])?;
+        drop(appender);
+
+        let values: Vec<u128> = db
+            .prepare("SELECT v FROM t ORDER BY v")?
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<Vec<_>>>()?;
+
+        assert_eq!(values, vec![0, u128::MAX]);
+
         Ok(())
     }
 

--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -22,8 +22,13 @@ pub enum Error {
     /// Error when DuckDB gives us an integral value outside the range of the
     /// requested type (e.g., trying to get the value 1000 into a `u8`).
     /// The associated `usize` is the column index,
-    /// and the associated `i64` is the value returned by SQLite.
+    /// and the associated `i128` is the value returned by DuckDB.
     IntegralValueOutOfRange(usize, i128),
+
+    /// Error when DuckDB gives us an unsigned integral value outside the range
+    /// of the requested type. The associated `usize` is the column index, and
+    /// the associated `u128` is the value returned by DuckDB.
+    UnsignedIntegralValueOutOfRange(usize, u128),
 
     /// Error converting a string to UTF-8.
     Utf8Error(str::Utf8Error),
@@ -99,6 +104,9 @@ impl PartialEq for Error {
         match (self, other) {
             (Self::DuckDBFailure(e1, s1), Self::DuckDBFailure(e2, s2)) => e1 == e2 && s1 == s2,
             (Self::IntegralValueOutOfRange(i1, n1), Self::IntegralValueOutOfRange(i2, n2)) => i1 == i2 && n1 == n2,
+            (Self::UnsignedIntegralValueOutOfRange(i1, n1), Self::UnsignedIntegralValueOutOfRange(i2, n2)) => {
+                i1 == i2 && n1 == n2
+            }
             (Self::Utf8Error(e1), Self::Utf8Error(e2)) => e1 == e2,
             (Self::NulError(e1), Self::NulError(e2)) => e1 == e2,
             (Self::InvalidParameterName(n1), Self::InvalidParameterName(n2)) => n1 == n2,
@@ -144,6 +152,7 @@ impl From<FromSqlError> for Error {
         // context.
         match err {
             FromSqlError::OutOfRange(val) => Self::IntegralValueOutOfRange(UNKNOWN_COLUMN, val),
+            FromSqlError::OutOfRangeUnsigned(val) => Self::UnsignedIntegralValueOutOfRange(UNKNOWN_COLUMN, val),
             #[cfg(feature = "uuid")]
             FromSqlError::InvalidUuidSize(_) => {
                 Self::FromSqlConversionFailure(UNKNOWN_COLUMN, Type::Blob, Box::new(err))
@@ -171,6 +180,13 @@ impl fmt::Display for Error {
                     write!(f, "Integer {val} out of range at index {col}")
                 } else {
                     write!(f, "Integer {val} out of range")
+                }
+            }
+            Self::UnsignedIntegralValueOutOfRange(col, val) => {
+                if col != UNKNOWN_COLUMN {
+                    write!(f, "Unsigned integer {val} out of range at index {col}")
+                } else {
+                    write!(f, "Unsigned integer {val} out of range")
                 }
             }
             Self::Utf8Error(ref err) => err.fmt(f),
@@ -211,6 +227,7 @@ impl error::Error for Error {
             Self::NulError(ref err) => Some(err),
 
             Self::IntegralValueOutOfRange(..)
+            | Self::UnsignedIntegralValueOutOfRange(..)
             | Self::InvalidParameterName(_)
             | Self::ExecuteReturnedResults
             | Self::QueryReturnedNoRows

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -29,6 +29,9 @@ pub struct RawStatement {
     result: Option<ffi::duckdb_arrow>,
     duckdb_result: Option<ffi::duckdb_result>,
     schema: Option<SchemaRef>,
+    // Cached DuckDB logical ids for result columns. Arrow reports HUGEINT,
+    // UHUGEINT, and scale-zero DECIMAL through the same decimal shape.
+    result_column_logical_ids: Option<Box<[LogicalTypeId]>>,
     column_name_cache: OnceCell<HashMap<Box<str>, usize>>,
     // Tracks whether the duckdb_result is truly streaming or materialized.
     // This is needed because some statements (like CALL) return materialized
@@ -54,6 +57,7 @@ impl RawStatement {
             ptr: stmt,
             result: None,
             schema: None,
+            result_column_logical_ids: None,
             column_name_cache: OnceCell::new(),
             duckdb_result: None,
             is_streaming: false,
@@ -233,14 +237,34 @@ impl RawStatement {
 
     #[inline]
     pub fn column_logical_type(&self, idx: usize) -> LogicalTypeHandle {
+        self.try_column_logical_type(idx)
+            .unwrap_or_else(|e| panic!("could not retrieve logical type for result column at index {idx}: {e}"))
+    }
+
+    #[inline]
+    pub(crate) fn try_column_logical_type(&self, idx: usize) -> Result<LogicalTypeHandle> {
         unsafe {
             let ptr = ffi::duckdb_prepared_statement_column_logical_type(self.ptr, idx as u64);
-            assert!(
-                !ptr.is_null(),
-                "could not retrieve logical type for result column at index {idx}"
-            );
-            LogicalTypeHandle::new(ptr)
+            if ptr.is_null() {
+                return Err(Error::DuckDBFailure(
+                    ffi::Error::new(ffi::DuckDBError),
+                    Some(format!(
+                        "Could not retrieve logical type for result column at index {idx}"
+                    )),
+                ));
+            }
+            Ok(LogicalTypeHandle::new(ptr))
         }
+    }
+
+    #[inline]
+    pub(crate) fn result_column_logical_id(&self, idx: usize) -> Option<LogicalTypeId> {
+        let logical_ids = self.result_column_logical_ids.as_ref()?;
+        debug_assert!(
+            idx < logical_ids.len(),
+            "result column logical-id cache is shorter than the result schema"
+        );
+        logical_ids.get(idx).copied()
     }
 
     #[inline]
@@ -276,7 +300,7 @@ impl RawStatement {
     /// NOTE: if execute failed, we shouldn't call any other methods which depends on result
     pub fn execute(&mut self) -> Result<usize> {
         self.reset_result();
-        self.validate_decodable_result_column_types()?;
+        let result_column_logical_ids = self.validate_and_load_result_column_logical_ids()?;
         unsafe {
             let mut out: ffi::duckdb_arrow = ptr::null_mut();
             let rc = ffi::duckdb_execute_prepared_arrow(self.ptr, &mut out);
@@ -293,13 +317,14 @@ impl RawStatement {
             Rc::from_raw(c_schema);
 
             self.result = Some(out);
+            self.result_column_logical_ids = Some(result_column_logical_ids);
             Ok(rows_changed as usize)
         }
     }
 
     pub fn execute_streaming(&mut self) -> Result<()> {
         self.reset_result();
-        self.validate_decodable_result_column_types()?;
+        let result_column_logical_ids = self.validate_and_load_result_column_logical_ids()?;
         unsafe {
             let mut out: ffi::duckdb_result = std::mem::zeroed();
 
@@ -320,7 +345,12 @@ impl RawStatement {
             // Check if the result is truly streaming or materialized
             // Some statements (like CALL) return materialized results even when streaming is requested
             self.is_streaming = ffi::duckdb_result_is_streaming(out);
+
             self.duckdb_result = Some(out);
+            // Row decoding consumes this cache only for the non-streaming path
+            // today. Keep streaming execution state symmetrical for callers
+            // that inspect statement metadata after execution.
+            self.result_column_logical_ids = Some(result_column_logical_ids);
 
             Ok(())
         }
@@ -329,6 +359,7 @@ impl RawStatement {
     #[inline]
     pub fn reset_result(&mut self) {
         self.schema = None;
+        self.result_column_logical_ids = None;
         self.column_name_cache = OnceCell::new();
         self.is_streaming = false;
         if self.result.is_some() {
@@ -373,21 +404,11 @@ impl RawStatement {
         }
     }
 
-    fn validate_decodable_result_column_types(&self) -> Result<()> {
+    fn validate_and_load_result_column_logical_ids(&self) -> Result<Box<[LogicalTypeId]>> {
         let column_count = unsafe { ffi::duckdb_prepared_statement_column_count(self.ptr) as usize };
+        let mut logical_ids = Vec::with_capacity(column_count);
         for idx in 0..column_count {
-            let logical_type = unsafe {
-                let ptr = ffi::duckdb_prepared_statement_column_logical_type(self.ptr, idx as u64);
-                if ptr.is_null() {
-                    return Err(Error::DuckDBFailure(
-                        ffi::Error::new(ffi::DuckDBError),
-                        Some(format!(
-                            "Could not retrieve logical type for result column at index {idx}"
-                        )),
-                    ));
-                }
-                LogicalTypeHandle::new(ptr)
-            };
+            let logical_type = self.try_column_logical_type(idx)?;
             if logical_type.contains_type_id(LogicalTypeId::Variant) {
                 return Err(Error::FromSqlConversionFailure(
                     idx,
@@ -395,11 +416,11 @@ impl RawStatement {
                     "decoding Variant columns is not supported".into(),
                 ));
             }
+            logical_ids.push(logical_type.id());
         }
 
-        Ok(())
+        Ok(logical_ids.into_boxed_slice())
     }
-
     #[inline]
     pub fn sql(&self) -> Option<&CStr> {
         panic!("not supported")

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -1,6 +1,7 @@
 use std::{convert, sync::Arc};
 
 use super::{Error, Result, Statement};
+use crate::core::LogicalTypeId;
 use crate::types::{self, EnumType, FromSql, FromSqlError, ListType, ValueRef};
 
 use arrow::{
@@ -336,6 +337,7 @@ impl<'stmt> Row<'stmt> {
                 Error::InvalidColumnType(idx, self.stmt.column_name_unwrap(idx).into(), value.data_type())
             }
             FromSqlError::OutOfRange(i) => Error::IntegralValueOutOfRange(idx, i),
+            FromSqlError::OutOfRangeUnsigned(i) => Error::UnsignedIntegralValueOutOfRange(idx, i),
             FromSqlError::Other(err) => Error::FromSqlConversionFailure(idx, value.data_type(), err),
             #[cfg(feature = "uuid")]
             FromSqlError::InvalidUuidSize(_) => {
@@ -361,19 +363,31 @@ impl<'stmt> Row<'stmt> {
     /// name for this row.
     pub fn get_ref<I: RowIndex>(&self, idx: I) -> Result<ValueRef<'_>> {
         let idx = idx.idx(self.stmt)?;
-        // Narrowing from `ValueRef<'stmt>` (which `self.stmt.value_ref(idx)`
-        // returns) to `ValueRef<'a>` is needed because it's only valid until
-        // the next call to sqlite3_step.
+        // Narrowing from `ValueRef<'stmt>` (which `self.value_ref(row, idx)`
+        // returns) to `ValueRef<'a>` is needed because it is only valid until
+        // the next row fetch.
         let val_ref = self.value_ref(self.current_row, idx);
         Ok(val_ref)
     }
 
     fn value_ref(&self, row: usize, col: usize) -> ValueRef<'_> {
         let column = self.arr.as_ref().as_ref().unwrap().column(col);
-        Self::value_ref_internal(row, col, column)
+        let value = Self::value_ref_internal(row, column);
+
+        // Arrow decodes HUGEINT, UHUGEINT, and scale-zero DECIMAL through the
+        // signed HugeInt carrier. Promote only when DuckDB's result metadata
+        // explicitly reports UHUGEINT; otherwise preserve the existing HugeInt
+        // fallback for parameter-derived or metadata-less results.
+        if let ValueRef::HugeInt(value) = value {
+            if matches!(self.stmt.result_column_logical_id(col), Some(LogicalTypeId::UHugeint)) {
+                return ValueRef::UHugeInt(value as u128);
+            }
+        }
+
+        value
     }
 
-    pub(crate) fn value_ref_internal(row: usize, col: usize, column: &ArrayRef) -> ValueRef<'_> {
+    pub(crate) fn value_ref_internal<'a>(row: usize, column: &'a ArrayRef) -> ValueRef<'a> {
         if column.is_null(row) {
             return ValueRef::Null;
         }
@@ -448,13 +462,15 @@ impl<'stmt> Row<'stmt> {
                 let array = column.as_any().downcast_ref::<array::Float64Array>().unwrap();
                 ValueRef::Double(array.value(row))
             }
-            DataType::Decimal128(..) => {
+            DataType::Decimal128(_, scale) => {
                 let array = column.as_any().downcast_ref::<array::Decimal128Array>().unwrap();
-                // hugeint: d:38,0
-                if array.scale() == 0 {
-                    return ValueRef::HugeInt(array.value(row));
+                let value = array.value(row);
+                let scale = u32::try_from(*scale).expect("Arrow decimal scale must be non-negative");
+                if scale == 0 {
+                    ValueRef::HugeInt(value)
+                } else {
+                    ValueRef::Decimal(Decimal::from_i128_with_scale(value, scale))
                 }
-                ValueRef::Decimal(Decimal::from_i128_with_scale(array.value(row), array.scale() as u32))
             }
             DataType::Timestamp(unit, _) if *unit == TimeUnit::Second => {
                 let array = column.as_any().downcast_ref::<array::TimestampSecondArray>().unwrap();
@@ -558,7 +574,7 @@ impl<'stmt> Row<'stmt> {
                 ValueRef::Array(arr, row)
             }
             DataType::Union(..) => ValueRef::Union(column, row),
-            _ => unreachable!("invalid value: {}, {}", col, column.data_type()),
+            _ => unreachable!("invalid value: {}", column.data_type()),
         }
     }
 
@@ -669,8 +685,13 @@ tuples_try_from_row!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::redundant_closure)] // false positives due to lifetime issues; clippy issue #5594
-    use crate::{Connection, Result};
+    use crate::{
+        Connection, Error, Result,
+        types::{Type, Value, ValueRef},
+    };
+
+    const U128_MAX_SQL: &str = "340282366920938463463374607431768211455";
+    const I128_MAX_PLUS_ONE_SQL: &str = "170141183460469231731687303715884105728";
 
     #[test]
     fn test_try_from_row_for_tuple_0() -> Result<()> {
@@ -807,6 +828,186 @@ mod tests {
         assert_eq!(val.15, 15);
 
         // We don't test one bigger because it's unimplemented
+        Ok(())
+    }
+
+    #[test]
+    fn uhugeint_arrives_as_uhugeint() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let mut stmt = db.prepare("SELECT (1)::UHUGEINT")?;
+        let mut rows = stmt.query([])?;
+        let row = rows.next()?.unwrap();
+        assert_eq!(row.get_ref(0)?, ValueRef::UHugeInt(1));
+        assert_eq!(row.get_ref(0)?.data_type(), Type::UHugeInt);
+        assert_eq!(row.get::<_, u128>(0)?, 1);
+
+        let mut stmt = db.prepare(&format!("SELECT ({U128_MAX_SQL})::UHUGEINT"))?;
+        let mut rows = stmt.query([])?;
+        let row = rows.next()?.unwrap();
+        assert_eq!(row.get_ref(0)?, ValueRef::UHugeInt(u128::MAX));
+        assert_eq!(row.get_ref(0)?.data_type(), Type::UHugeInt);
+        assert_eq!(row.get::<_, u128>(0)?, u128::MAX);
+
+        let i128_max_plus_one = (i128::MAX as u128) + 1;
+        let mut stmt = db.prepare(&format!("SELECT ({I128_MAX_PLUS_ONE_SQL})::UHUGEINT"))?;
+        let mut rows = stmt.query([])?;
+        let row = rows.next()?.unwrap();
+        assert_eq!(row.get_ref(0)?, ValueRef::UHugeInt(i128_max_plus_one));
+        assert_eq!(row.get::<_, u128>(0)?, i128_max_plus_one);
+
+        Ok(())
+    }
+
+    #[test]
+    fn bound_uhugeint_result_uses_logical_metadata_when_cast() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let max = u128::MAX;
+
+        let value = db.query_row("SELECT ?::UHUGEINT", [&max], |row| {
+            assert_eq!(row.get_ref(0)?, ValueRef::UHugeInt(max));
+            row.get::<_, u128>(0)
+        })?;
+        assert_eq!(value, max);
+
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_arrow_decimal_metadata_keeps_hugeint_fallback() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let byte = 255_i128;
+        let byte_value = db.query_row("SELECT ?", [&byte], |row| {
+            assert_eq!(row.get_ref(0)?, ValueRef::HugeInt(byte));
+            row.get::<_, u8>(0)
+        })?;
+        assert_eq!(byte_value, 255);
+
+        let value = 5_u128;
+        let decimal = db.query_row("SELECT ? + 0::DECIMAL(38,0)", [&value], |row| {
+            row.get_ref(0).map(|value| value.to_owned())
+        })?;
+        assert_eq!(decimal, Value::HugeInt(5));
+
+        Ok(())
+    }
+
+    #[test]
+    fn uhugeint_upper_half_is_out_of_range_for_i128() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let err = db
+            .query_row(&format!("SELECT ({I128_MAX_PLUS_ONE_SQL})::UHUGEINT"), [], |row| {
+                row.get::<_, i128>(0)
+            })
+            .unwrap_err();
+
+        match err {
+            Error::UnsignedIntegralValueOutOfRange(0, value) => {
+                assert_eq!(value, (i128::MAX as u128) + 1)
+            }
+            other => panic!("expected unsigned out-of-range error, got {other:?}"),
+        }
+
+        let err = db
+            .query_row(&format!("SELECT ({U128_MAX_SQL})::UHUGEINT"), [], |row| {
+                row.get::<_, i128>(0)
+            })
+            .unwrap_err();
+
+        match err {
+            Error::UnsignedIntegralValueOutOfRange(0, value) => assert_eq!(value, u128::MAX),
+            other => panic!("expected unsigned out-of-range error, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn nested_uhugeint_uses_metadata_less_hugeint_carrier() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let list = db.query_row(&format!("SELECT [({U128_MAX_SQL})::UHUGEINT]"), [], |row| {
+            let value = row.get_ref(0)?;
+            assert!(matches!(value.data_type(), Type::List(ref inner) if **inner == Type::Decimal));
+            Ok(value.to_owned())
+        })?;
+
+        assert_eq!(list, Value::List(vec![Value::HugeInt(-1)]));
+
+        let structure = db.query_row(
+            &format!("SELECT struct_pack(v := ({U128_MAX_SQL})::UHUGEINT)"),
+            [],
+            |row| {
+                let value = row.get_ref(0)?;
+                assert!(matches!(value.data_type(), Type::Struct(_)));
+                Ok(value.to_owned())
+            },
+        )?;
+
+        match structure {
+            Value::Struct(fields) => {
+                assert_eq!(fields.get(&"v".to_string()), Some(&Value::HugeInt(-1)));
+            }
+            other => panic!("expected struct, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn uhugeint_logical_type_cache_survives_later_batches() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let values = db
+            .prepare(
+                "
+                SELECT
+                    CASE
+                        WHEN i = 2500 THEN NULL::UHUGEINT
+                        ELSE i::UHUGEINT
+                    END AS v
+                FROM range(3000) AS t(i)
+                ORDER BY i
+                ",
+            )?
+            .query_map([], |row| row.get_ref(0).map(|value| value.to_owned()))?
+            .collect::<Result<Vec<_>>>()?;
+
+        assert_eq!(values.len(), 3000);
+        assert_eq!(values[0], Value::UHugeInt(0));
+        assert_eq!(values[2048], Value::UHugeInt(2048));
+        assert_eq!(values[2500], Value::Null);
+        assert_eq!(values[2999], Value::UHugeInt(2999));
+
+        Ok(())
+    }
+
+    #[test]
+    fn uhugeint_nulls_use_cached_logical_type() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let values = db
+            .prepare(&format!(
+                "
+                SELECT v FROM (
+                    VALUES
+                        (0, (0)::UHUGEINT),
+                        (1, NULL::UHUGEINT),
+                        (2, ({U128_MAX_SQL})::UHUGEINT)
+                ) AS t(ord, v)
+                ORDER BY ord
+                "
+            ))?
+            .query_map([], |row| row.get_ref(0).map(|value| value.to_owned()))?
+            .collect::<Result<Vec<_>>>()?;
+
+        assert_eq!(
+            values,
+            vec![Value::UHugeInt(0), Value::Null, Value::UHugeInt(u128::MAX)]
+        );
+
         Ok(())
     }
 

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -860,6 +860,30 @@ mod tests {
     }
 
     #[test]
+    fn uhugeint_promotion_uses_matching_result_column() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let mut stmt = db.prepare(&format!(
+            "
+            SELECT
+                1::HUGEINT AS a,
+                2::UHUGEINT AS b,
+                3::DECIMAL(38,0) AS c,
+                ({U128_MAX_SQL})::UHUGEINT AS d
+            "
+        ))?;
+        let mut rows = stmt.query([])?;
+        let row = rows.next()?.unwrap();
+
+        assert_eq!(row.get_ref(0)?, ValueRef::HugeInt(1));
+        assert_eq!(row.get_ref(1)?, ValueRef::UHugeInt(2));
+        assert_eq!(row.get_ref(2)?, ValueRef::HugeInt(3));
+        assert_eq!(row.get_ref(3)?, ValueRef::UHugeInt(u128::MAX));
+
+        Ok(())
+    }
+
+    #[test]
     fn bound_uhugeint_result_uses_logical_metadata_when_cast() -> Result<()> {
         let db = Connection::open_in_memory()?;
         let max = u128::MAX;

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -3,12 +3,15 @@ use std::{convert, ffi::c_void, fmt, mem, os::raw::c_char, ptr, str};
 use arrow::{array::StructArray, datatypes::SchemaRef};
 
 use super::{AndThenRows, Connection, Error, MappedRows, Params, RawStatement, Result, Row, Rows, ValueRef, ffi};
+use crate::core::LogicalTypeId;
 #[cfg(feature = "polars")]
 use crate::polars_dataframe::Polars;
 use crate::{
     arrow_batch::{Arrow, ArrowStream},
     error::result_from_duckdb_prepare,
-    types::{ToSql, ToSqlOutput, binding_unsupported_value, value_ref_from_value},
+    types::{
+        ToSql, ToSqlOutput, binding_unsupported_value, to_duckdb_hugeint, to_duckdb_uhugeint, value_ref_from_value,
+    },
 };
 #[cfg(feature = "polars")]
 use polars_core::utils::arrow as polars_arrow;
@@ -572,6 +575,11 @@ impl Statement<'_> {
         self.stmt.schema()
     }
 
+    #[inline]
+    pub(crate) fn result_column_logical_id(&self, idx: usize) -> Option<LogicalTypeId> {
+        self.stmt.result_column_logical_id(idx)
+    }
+
     // generic because many of these branches can constant fold away.
     fn bind_parameter<P: ?Sized + ToSql>(&self, param: &P, col: usize) -> Result<()> {
         let value = param.to_sql()?;
@@ -589,13 +597,8 @@ impl Statement<'_> {
             ValueRef::SmallInt(i) => unsafe { ffi::duckdb_bind_int16(ptr, col as u64, i) },
             ValueRef::Int(i) => unsafe { ffi::duckdb_bind_int32(ptr, col as u64, i) },
             ValueRef::BigInt(i) => unsafe { ffi::duckdb_bind_int64(ptr, col as u64, i) },
-            ValueRef::HugeInt(i) => unsafe {
-                let hi = ffi::duckdb_hugeint {
-                    lower: i as u64,
-                    upper: (i >> 64) as i64,
-                };
-                ffi::duckdb_bind_hugeint(ptr, col as u64, hi)
-            },
+            ValueRef::HugeInt(i) => unsafe { ffi::duckdb_bind_hugeint(ptr, col as u64, to_duckdb_hugeint(i)) },
+            ValueRef::UHugeInt(i) => unsafe { ffi::duckdb_bind_uhugeint(ptr, col as u64, to_duckdb_uhugeint(i)) },
             ValueRef::UTinyInt(i) => unsafe { ffi::duckdb_bind_uint8(ptr, col as u64, i) },
             ValueRef::USmallInt(i) => unsafe { ffi::duckdb_bind_uint16(ptr, col as u64, i) },
             ValueRef::UInt(i) => unsafe { ffi::duckdb_bind_uint32(ptr, col as u64, i) },
@@ -773,6 +776,24 @@ mod test {
             let id: i32 = stmt.query_one([&"one"], |r| r.get(0))?;
             assert_eq!(id, 1);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_u128_as_uhugeint() -> Result<()> {
+        const U128_MAX_SQL: &str = "340282366920938463463374607431768211455";
+
+        let db = Connection::open_in_memory()?;
+        let max = u128::MAX;
+
+        let typ: String = db.query_row("SELECT typeof(?)", [&max], |row| row.get(0))?;
+        assert_eq!(typ, "UHUGEINT");
+
+        let equals_max: bool = db.query_row(&format!("SELECT ? = ({U128_MAX_SQL})::UHUGEINT"), [&max], |row| {
+            row.get(0)
+        })?;
+        assert!(equals_max);
+
         Ok(())
     }
 

--- a/crates/duckdb/src/test_all_types.rs
+++ b/crates/duckdb/src/test_all_types.rs
@@ -20,7 +20,7 @@ fn test_large_arrow_types() -> crate::Result<()> {
 }
 
 fn test_with_database(database: &Connection) -> crate::Result<()> {
-    let excluded = ["uhugeint", "time_tz", "time_ns", "dec38_10", "bignum", "geometry"];
+    let excluded = ["time_tz", "time_ns", "dec38_10", "bignum", "geometry"];
 
     let mut binding = database.prepare(&format!(
         "SELECT * EXCLUDE ({}) FROM test_all_types()",
@@ -100,8 +100,8 @@ fn test_single(idx: &mut i32, column: String, value: ValueRef<'_>) {
             _ => assert_eq!(value, ValueRef::Null),
         },
         "uhugeint" => match idx {
-            0 => assert_eq!(value, ValueRef::UBigInt(0)),
-            1 => assert_eq!(value, ValueRef::UBigInt(18446744073709551615)),
+            0 => assert_eq!(value, ValueRef::UHugeInt(0)),
+            1 => assert_eq!(value, ValueRef::UHugeInt(u128::MAX)),
             _ => assert_eq!(value, ValueRef::Null),
         },
         "float" => match idx {

--- a/crates/duckdb/src/types/decimal.rs
+++ b/crates/duckdb/src/types/decimal.rs
@@ -57,6 +57,7 @@ impl FromSql for rust_decimal::Decimal {
             ValueRef::Int(i) => rust_decimal::Decimal::from_i32(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::BigInt(i) => rust_decimal::Decimal::from_i64(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::HugeInt(i) => rust_decimal::Decimal::from_i128(i).ok_or(FromSqlError::OutOfRange(i)),
+            ValueRef::UHugeInt(i) => rust_decimal::Decimal::from_u128(i).ok_or(FromSqlError::OutOfRangeUnsigned(i)),
             ValueRef::UTinyInt(i) => rust_decimal::Decimal::from_u8(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::USmallInt(i) => rust_decimal::Decimal::from_u16(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::UInt(i) => rust_decimal::Decimal::from_u32(i).ok_or(FromSqlError::OutOfRange(i as i128)),
@@ -89,6 +90,7 @@ mod test {
     use rust_decimal::Decimal;
 
     use super::*;
+    use crate::{Connection, Error, Result};
 
     #[test]
     fn test_to_duckdb_decimal_large_negative_upper_bits() {
@@ -123,6 +125,38 @@ mod test {
             FromSqlError::OutOfRange(value) => assert_eq!(value, i128::MAX),
             _ => panic!("expected OutOfRange, got {err}"),
         }
+    }
+
+    #[test]
+    fn test_from_sql_uhugeint_overflow_is_out_of_range() {
+        let err = Decimal::column_result(ValueRef::UHugeInt(u128::MAX)).unwrap_err();
+        match err {
+            FromSqlError::OutOfRangeUnsigned(value) => assert_eq!(value, u128::MAX),
+            _ => panic!("expected OutOfRange, got {err}"),
+        }
+    }
+
+    #[test]
+    fn test_read_uhugeint_as_decimal() -> Result<()> {
+        const U128_MAX_SQL: &str = "340282366920938463463374607431768211455";
+
+        let db = Connection::open_in_memory()?;
+
+        let value: Decimal = db.query_row("SELECT (5)::UHUGEINT", [], |row| row.get(0))?;
+        assert_eq!(value, Decimal::from(5));
+
+        let err = db
+            .query_row(&format!("SELECT ({U128_MAX_SQL})::UHUGEINT"), [], |row| {
+                row.get::<_, Decimal>(0)
+            })
+            .unwrap_err();
+
+        match err {
+            Error::UnsignedIntegralValueOutOfRange(0, value) => assert_eq!(value, u128::MAX),
+            other => panic!("expected unsigned out-of-range error, got {other:?}"),
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/crates/duckdb/src/types/from_sql.rs
+++ b/crates/duckdb/src/types/from_sql.rs
@@ -17,6 +17,11 @@ pub enum FromSqlError {
     /// requested type.
     OutOfRange(i128),
 
+    /// Error when an unsigned 128-bit value returned by DuckDB cannot be
+    /// stored into the requested type. This is reported for `UHUGEINT` sources;
+    /// same-magnitude signed sources use [`Self::OutOfRange`].
+    OutOfRangeUnsigned(u128),
+
     /// `feature = "uuid"` Error returned when reading a `uuid` from a blob with
     /// a size other than 16. Only available when the `uuid` feature is enabled.
     #[cfg(feature = "uuid")]
@@ -31,6 +36,7 @@ impl PartialEq for FromSqlError {
         match (self, other) {
             (Self::InvalidType, Self::InvalidType) => true,
             (Self::OutOfRange(n1), Self::OutOfRange(n2)) => n1 == n2,
+            (Self::OutOfRangeUnsigned(n1), Self::OutOfRangeUnsigned(n2)) => n1 == n2,
             #[cfg(feature = "uuid")]
             (Self::InvalidUuidSize(s1), Self::InvalidUuidSize(s2)) => s1 == s2,
             (..) => false,
@@ -43,6 +49,7 @@ impl fmt::Display for FromSqlError {
         match *self {
             Self::InvalidType => write!(f, "Invalid type"),
             Self::OutOfRange(i) => write!(f, "Value {i} out of range"),
+            Self::OutOfRangeUnsigned(i) => write!(f, "Unsigned value {i} out of range"),
             #[cfg(feature = "uuid")]
             Self::InvalidUuidSize(s) => {
                 write!(f, "Cannot read UUID value out of {s} byte blob")
@@ -82,6 +89,8 @@ macro_rules! from_sql_integral(
                     ValueRef::Int(i) => <$t as cast::From<i32>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
                     ValueRef::BigInt(i) => <$t as cast::From<i64>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
                     ValueRef::HugeInt(i) => <$t as cast::From<i128>>::cast(i).into_result(FromSqlError::OutOfRange(i)),
+                    ValueRef::UHugeInt(i) => <$t as cast::From<u128>>::cast(i)
+                        .into_result(FromSqlError::OutOfRangeUnsigned(i)),
 
                     ValueRef::UTinyInt(i) => <$t as cast::From<u8>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
                     ValueRef::USmallInt(i) => <$t as cast::From<u16>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
@@ -146,6 +155,7 @@ into_result_integral!(u8);
 into_result_integral!(u16);
 into_result_integral!(u32);
 into_result_integral!(u64);
+into_result_integral!(u128);
 into_result_integral!(usize);
 into_result_integral!(f32);
 into_result_integral!(f64);
@@ -169,6 +179,7 @@ from_sql_integral!(u8);
 from_sql_integral!(u16);
 from_sql_integral!(u32);
 from_sql_integral!(u64);
+from_sql_integral!(u128);
 from_sql_integral!(usize);
 from_sql_integral!(f32);
 from_sql_integral!(f64);
@@ -266,7 +277,7 @@ impl FromSql for Value {
 
 #[cfg(test)]
 mod test {
-    use super::FromSql;
+    use super::{FromSql, FromSqlError};
     use crate::{Connection, Error, Result};
 
     #[test]
@@ -373,6 +384,32 @@ mod test {
         check_ranges::<u8>(&db, &[-2, -1, 256], &[0, 1, 255]);
         check_ranges::<u16>(&db, &[-2, -1, 65536], &[0, 1, 65535]);
         check_ranges::<u32>(&db, &[-2, -1, 4_294_967_296], &[0, 1, 4_294_967_295]);
+
+        let err = db
+            .query_row("SELECT (-1)::HUGEINT", [], |r| r.get::<_, u128>(0))
+            .unwrap_err();
+        match err {
+            Error::IntegralValueOutOfRange(_, value) => assert_eq!(value, -1),
+            _ => panic!("unexpected error: {err}"),
+        }
+
+        let ubigint_max = u128::from(u64::MAX);
+        let value = db.query_row("SELECT (18446744073709551615)::UBIGINT", [], |r| r.get::<_, u128>(0))?;
+        assert_eq!(value, ubigint_max);
+
+        let u64_overflow = ubigint_max + 1;
+        let err = db
+            .query_row("SELECT (18446744073709551616)::UHUGEINT", [], |r| r.get::<_, u64>(0))
+            .unwrap_err();
+        match err {
+            Error::UnsignedIntegralValueOutOfRange(_, value) => assert_eq!(value, u64_overflow),
+            _ => panic!("unexpected error: {err}"),
+        }
+
+        assert_eq!(
+            FromSqlError::OutOfRangeUnsigned(u64_overflow).to_string(),
+            "Unsigned value 18446744073709551616 out of range"
+        );
         Ok(())
     }
 
@@ -554,6 +591,15 @@ mod test {
         );
         assert_eq!(
             db.query_row("SELECT -0.51::DECIMAL(10,2)", [], |row| row.get::<_, i32>(0))?,
+            -1
+        );
+
+        assert_eq!(
+            db.query_row("SELECT 0.50::DECIMAL(38,2)", [], |row| row.get::<_, i32>(0))?,
+            1
+        );
+        assert_eq!(
+            db.query_row("SELECT -0.50::DECIMAL(38,2)", [], |row| row.get::<_, i32>(0))?,
             -1
         );
 

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -1,6 +1,31 @@
 //! [`ToSql`] and [`FromSql`] are also implemented for `Option<T>` where `T`
 //! implements [`ToSql`] or [`FromSql`] for the cases where you want to know if
 //! a value was NULL (which gets translated to `None`).
+//!
+//! # Dynamic value compatibility notes
+//!
+//! [`Type`], [`Value`], and [`ValueRef`] are non-exhaustive. Downstream code
+//! matching these enums should include a wildcard arm so new DuckDB types can
+//! be added without another source break.
+//!
+//! Top-level `UHUGEINT` result values use [`Value::UHugeInt`] and
+//! [`ValueRef::UHugeInt`] when DuckDB reports `UHUGEINT` logical metadata for
+//! the result column. Nested `UHUGEINT` values inside lists, structs, maps,
+//! arrays, and unions do not currently carry DuckDB child logical type metadata
+//! through the borrowed container API, so values above `i128::MAX` cannot
+//! recover their `u128` value from those metadata-less carriers.
+//!
+//! Parameter-derived scale-zero Arrow decimal result columns are intentionally
+//! not guessed. DuckDB can report `Invalid` logical metadata for a bare bound
+//! parameter (`SELECT ?`) even when the bound value is `u128`. In that case
+//! `duckdb-rs` preserves the existing signed [`Value::HugeInt`] fallback instead
+//! of inferring `UHUGEINT`, `HUGEINT`, or `DECIMAL` from parameter names,
+//! aliases, or expression text. Cast the result expression so DuckDB reports
+//! stable logical metadata when a dynamic `UHUGEINT` carrier is required.
+//!
+//! DuckDB `DECIMAL(38, s)` values that do not fit `rust_decimal::Decimal`
+//! remain a separate limitation; a full-width decimal carrier can be added in a
+//! follow-up without changing the `UHUGEINT` binding support added here.
 
 pub use self::{
     from_sql::{FromSql, FromSqlError, FromSqlResult},
@@ -16,6 +41,8 @@ pub(crate) use value_ref::{binding_unsupported_value, value_ref_from_value};
 use arrow::datatypes::DataType;
 use std::fmt;
 
+use crate::ffi;
+
 #[cfg(feature = "chrono")]
 mod chrono;
 mod from_sql;
@@ -30,6 +57,20 @@ mod value_ref;
 mod decimal;
 mod ordered_map;
 mod string;
+
+pub(crate) fn to_duckdb_hugeint(i: i128) -> ffi::duckdb_hugeint {
+    ffi::duckdb_hugeint {
+        lower: i as u64,
+        upper: (i >> 64) as i64,
+    }
+}
+
+pub(crate) fn to_duckdb_uhugeint(i: u128) -> ffi::duckdb_uhugeint {
+    ffi::duckdb_uhugeint {
+        lower: i as u64,
+        upper: (i >> 64) as u64,
+    }
+}
 
 /// Empty struct that can be used to fill in a query parameter as `NULL`.
 ///
@@ -49,6 +90,7 @@ pub struct Null;
 /// DuckDB data types.
 /// See [Fundamental Datatypes](https://duckdb.org/docs/sql/data_types/overview).
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Type {
     /// NULL
     Null,
@@ -64,6 +106,8 @@ pub enum Type {
     BigInt,
     /// HUGEINT
     HugeInt,
+    /// UHUGEINT
+    UHugeInt,
     /// UTINYINT
     UTinyInt,
     /// USMALLINT
@@ -136,9 +180,12 @@ impl From<&DataType> for Type {
             // DataType::LargeBinary => Self::LargeBinary,
             DataType::LargeUtf8 | DataType::Utf8 => Self::Text,
             DataType::List(inner) => Self::List(Box::new(Self::from(inner.data_type()))),
-            DataType::FixedSizeList(field, size) => {
-                Self::Array(Box::new(Self::from(field.data_type())), (*size).try_into().unwrap())
-            }
+            DataType::FixedSizeList(field, size) => Self::Array(
+                Box::new(Self::from(field.data_type())),
+                (*size)
+                    .try_into()
+                    .expect("Arrow FixedSizeList size must be non-negative"),
+            ),
             // DataType::LargeList(_) => Self::LargeList,
             DataType::Struct(inner) => {
                 let capacity = inner.len();
@@ -153,11 +200,17 @@ impl From<&DataType> for Type {
             DataType::Map(field, ..) => {
                 let data_type = field.data_type();
                 match data_type {
-                    DataType::Struct(fields) => Self::Map(
+                    DataType::Struct(fields) if fields.len() == 2 => Self::Map(
                         Box::new(Self::from(fields[0].data_type())),
                         Box::new(Self::from(fields[1].data_type())),
                     ),
-                    _ => unreachable!(),
+                    DataType::Struct(fields) => {
+                        panic!(
+                            "Arrow Map child struct must have exactly two fields, got {}",
+                            fields.len()
+                        )
+                    }
+                    _ => panic!("Arrow Map child type must be Struct(key, value), got {data_type}"),
                 }
             }
             res => unimplemented!("{}", res),
@@ -175,6 +228,7 @@ impl fmt::Display for Type {
             Self::Int => f.pad("Int"),
             Self::BigInt => f.pad("BigInt"),
             Self::HugeInt => f.pad("HugeInt"),
+            Self::UHugeInt => f.pad("UHugeInt"),
             Self::UTinyInt => f.pad("UTinyInt"),
             Self::USmallInt => f.pad("USmallInt"),
             Self::UInt => f.pad("UInt"),

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -7,10 +7,10 @@ use std::borrow::Cow;
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum ToSqlOutput<'a> {
-    /// A borrowed SQLite-representable value.
+    /// A borrowed DuckDB-representable value.
     Borrowed(ValueRef<'a>),
 
-    /// An owned SQLite-representable value.
+    /// An owned DuckDB-representable value.
     Owned(Value),
 }
 
@@ -47,6 +47,7 @@ from_value!(i16);
 from_value!(i32);
 from_value!(i64);
 from_value!(i128);
+from_value!(u128);
 from_value!(isize);
 from_value!(u8);
 from_value!(u16);
@@ -135,6 +136,7 @@ to_sql_self!(i16);
 to_sql_self!(i32);
 to_sql_self!(i64);
 to_sql_self!(i128);
+to_sql_self!(u128);
 to_sql_self!(isize);
 to_sql_self!(u8);
 to_sql_self!(u16);
@@ -226,9 +228,14 @@ mod test {
         is_to_sql::<i16>();
         is_to_sql::<i32>();
         is_to_sql::<i64>();
+        is_to_sql::<i128>();
+        is_to_sql::<isize>();
         is_to_sql::<u8>();
         is_to_sql::<u16>();
         is_to_sql::<u32>();
+        is_to_sql::<u64>();
+        is_to_sql::<u128>();
+        is_to_sql::<usize>();
     }
 
     #[test]

--- a/crates/duckdb/src/types/value.rs
+++ b/crates/duckdb/src/types/value.rs
@@ -4,9 +4,14 @@ use rust_decimal::prelude::*;
 /// Owning [dynamic type value](https://duckdb.org/docs/stable/sql/data_types/overview.html).
 /// Value's type is typically dictated by DuckDB (not by the caller).
 ///
+/// Container variants decode child values without DuckDB child logical type
+/// metadata. See the [`crate::types`] compatibility notes for `UHUGEINT`
+/// behavior inside containers.
+///
 /// See [`ValueRef`](crate::types::ValueRef) for a non-owning dynamic type
 /// value.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Value {
     /// The value is a `NULL` value.
     Null,
@@ -22,6 +27,13 @@ pub enum Value {
     BigInt(i64),
     /// The value is a signed huge integer.
     HugeInt(i128),
+    /// The value is an unsigned huge integer.
+    ///
+    /// Top-level `UHUGEINT` result values materialize as this variant. Nested
+    /// `UHUGEINT` values inside lists, structs, maps, arrays, and unions do
+    /// not currently carry DuckDB child logical metadata and cannot recover
+    /// values above `i128::MAX`.
+    UHugeInt(u128),
     /// The value is a unsigned tiny integer.
     UTinyInt(u8),
     /// The value is a unsigned small integer.
@@ -59,17 +71,17 @@ pub enum Value {
         /// nanos
         nanos: i64,
     },
-    /// The value is a list
+    /// The value is a list.
     List(Vec<Value>),
     /// The value is an enum
     Enum(String),
-    /// The value is a struct
+    /// The value is a struct.
     Struct(OrderedMap<String, Value>),
-    /// The value is an array
+    /// The value is an array.
     Array(Vec<Value>),
-    /// The value is a map
+    /// The value is a map.
     Map(OrderedMap<Value, Value>),
-    /// The value is a union
+    /// The value is a union.
     Union(Box<Value>),
 }
 
@@ -172,6 +184,13 @@ impl From<i128> for Value {
     }
 }
 
+impl From<u128> for Value {
+    #[inline]
+    fn from(i: u128) -> Self {
+        Self::UHugeInt(i)
+    }
+}
+
 impl From<f32> for Value {
     #[inline]
     fn from(f: f32) -> Self {
@@ -225,6 +244,7 @@ impl Value {
             Self::Int(_) => Type::Int,
             Self::BigInt(_) => Type::BigInt,
             Self::HugeInt(_) => Type::HugeInt,
+            Self::UHugeInt(_) => Type::UHugeInt,
             Self::UTinyInt(_) => Type::UTinyInt,
             Self::USmallInt(_) => Type::USmallInt,
             Self::UInt(_) => Type::UInt,

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -39,10 +39,15 @@ impl TimeUnit {
 }
 
 /// A non-owning [static type value](https://duckdb.org/docs/sql/data_types/overview). Typically the
-/// memory backing this value is owned by SQLite.
+/// memory backing this value is owned by DuckDB.
+///
+/// Container variants decode child values without DuckDB child logical type
+/// metadata. See the [`crate::types`] compatibility notes for `UHUGEINT`
+/// behavior inside containers.
 ///
 /// See [`Value`](Value) for an owning dynamic type value.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ValueRef<'a> {
     /// The value is a `NULL` value.
     Null,
@@ -58,6 +63,13 @@ pub enum ValueRef<'a> {
     BigInt(i64),
     /// The value is a signed huge integer.
     HugeInt(i128),
+    /// The value is an unsigned huge integer.
+    ///
+    /// Top-level `UHUGEINT` result values decode to this variant because row
+    /// decoding uses DuckDB logical type metadata. Borrowed container values do
+    /// not carry that metadata and cannot recover nested `UHUGEINT` values
+    /// above `i128::MAX`.
+    UHugeInt(u128),
     /// The value is a unsigned tiny integer.
     UTinyInt(u8),
     /// The value is a unsigned small integer.
@@ -70,7 +82,7 @@ pub enum ValueRef<'a> {
     Float(f32),
     /// The value is a f64.
     Double(f64),
-    /// The value is a decimal
+    /// The value is a Decimal.
     Decimal(Decimal),
     /// The value is a timestamp.
     Timestamp(TimeUnit, i64),
@@ -91,17 +103,17 @@ pub enum ValueRef<'a> {
         /// nanos
         nanos: i64,
     },
-    /// The value is a list
+    /// The value is a list.
     List(ListType<'a>, usize),
     /// The value is an enum
     Enum(EnumType<'a>, usize),
-    /// The value is a struct
+    /// The value is a struct.
     Struct(&'a StructArray, usize),
-    /// The value is an array
+    /// The value is an array.
     Array(&'a FixedSizeListArray, usize),
-    /// The value is a map
+    /// The value is a map.
     Map(&'a MapArray, usize),
-    /// The value is a union
+    /// The value is a union.
     Union(&'a ArrayRef, usize),
 }
 
@@ -137,6 +149,7 @@ impl ValueRef<'_> {
             ValueRef::Int(_) => Type::Int,
             ValueRef::BigInt(_) => Type::BigInt,
             ValueRef::HugeInt(_) => Type::HugeInt,
+            ValueRef::UHugeInt(_) => Type::UHugeInt,
             ValueRef::UTinyInt(_) => Type::UTinyInt,
             ValueRef::USmallInt(_) => Type::USmallInt,
             ValueRef::UInt(_) => Type::UInt,
@@ -220,6 +233,7 @@ impl From<ValueRef<'_>> for Value {
             ValueRef::Int(i) => Self::Int(i),
             ValueRef::BigInt(i) => Self::BigInt(i),
             ValueRef::HugeInt(i) => Self::HugeInt(i),
+            ValueRef::UHugeInt(i) => Self::UHugeInt(i),
             ValueRef::UTinyInt(i) => Self::UTinyInt(i),
             ValueRef::USmallInt(i) => Self::USmallInt(i),
             ValueRef::UInt(i) => Self::UInt(i),
@@ -236,26 +250,7 @@ impl From<ValueRef<'_>> for Value {
             ValueRef::Date32(d) => Self::Date32(d),
             ValueRef::Time64(t, d) => Self::Time64(t, d),
             ValueRef::Interval { months, days, nanos } => Self::Interval { months, days, nanos },
-            ValueRef::List(items, idx) => match items {
-                ListType::Regular(items) => {
-                    let offsets = items.offsets();
-                    from_list(
-                        offsets[idx].try_into().unwrap(),
-                        offsets[idx + 1].try_into().unwrap(),
-                        idx,
-                        items.values(),
-                    )
-                }
-                ListType::Large(items) => {
-                    let offsets = items.offsets();
-                    from_list(
-                        offsets[idx].try_into().unwrap(),
-                        offsets[idx + 1].try_into().unwrap(),
-                        idx,
-                        items.values(),
-                    )
-                }
-            },
+            ValueRef::List(items, idx) => from_list_value(items, idx),
             ValueRef::Enum(items, idx) => {
                 let dict_values = match items {
                     EnumType::UInt8(res) => res.values(),
@@ -273,60 +268,88 @@ impl From<ValueRef<'_>> for Value {
                 .unwrap();
                 Self::Enum(dict_values.value(dict_key).to_string())
             }
-            ValueRef::Struct(items, idx) => {
-                let capacity = items.columns().len();
-                let mut value = Vec::with_capacity(capacity);
-                value.extend(
-                    items
-                        .columns()
-                        .iter()
-                        .zip(items.fields().iter().map(|f| f.name().to_owned()))
-                        .map(|(column, name)| -> (String, Self) {
-                            (name, Row::value_ref_internal(idx, 0, column).to_owned())
-                        }),
-                );
-                Self::Struct(OrderedMap::from(value))
-            }
-            ValueRef::Map(arr, idx) => {
-                let keys = arr.keys();
-                let values = arr.values();
-                let offsets = arr.offsets();
-                let range = offsets[idx]..offsets[idx + 1];
-                let capacity = range.len();
-                let mut map_vec = Vec::with_capacity(capacity);
-                map_vec.extend(range.map(|row| {
-                    let row = row.try_into().unwrap();
-                    let key = Row::value_ref_internal(row, idx, keys).to_owned();
-                    let value = Row::value_ref_internal(row, idx, values).to_owned();
-                    (key, value)
-                }));
-                Self::Map(OrderedMap::from(map_vec))
-            }
-            ValueRef::Array(items, idx) => {
-                let value_length = usize::try_from(items.value_length()).unwrap();
-                let range = (idx * value_length)..((idx + 1) * value_length);
-                let capacity = value_length;
-                let mut array_vec = Vec::with_capacity(capacity);
-                array_vec.extend(range.map(|row| Row::value_ref_internal(row, idx, items.values()).to_owned()));
-                Self::Array(array_vec)
-            }
-            ValueRef::Union(column, idx) => {
-                let column = column.as_any().downcast_ref::<UnionArray>().unwrap();
-                let type_id = column.type_id(idx);
-                let value_offset = column.value_offset(idx);
-
-                let tag = Row::value_ref_internal(idx, value_offset, column.child(type_id));
-                Self::Union(Box::new(tag.to_owned()))
-            }
+            ValueRef::Struct(items, idx) => from_struct(items, idx),
+            ValueRef::Map(arr, idx) => from_map(arr, idx),
+            ValueRef::Array(items, idx) => from_array(items, idx),
+            ValueRef::Union(column, idx) => from_union(column, idx),
         }
     }
 }
 
-fn from_list(start: usize, end: usize, idx: usize, values: &ArrayRef) -> Value {
+fn from_list_value(items: ListType<'_>, idx: usize) -> Value {
+    match items {
+        ListType::Regular(items) => {
+            let offsets = items.offsets();
+            from_list(
+                offsets[idx].try_into().unwrap(),
+                offsets[idx + 1].try_into().unwrap(),
+                items.values(),
+            )
+        }
+        ListType::Large(items) => {
+            let offsets = items.offsets();
+            from_list(
+                offsets[idx].try_into().unwrap(),
+                offsets[idx + 1].try_into().unwrap(),
+                items.values(),
+            )
+        }
+    }
+}
+
+fn from_list(start: usize, end: usize, values: &ArrayRef) -> Value {
     let capacity = end - start;
     let mut list_vec = Vec::with_capacity(capacity);
-    list_vec.extend((start..end).map(|row| Row::value_ref_internal(row, idx, values).to_owned()));
+    list_vec.extend((start..end).map(|row| Row::value_ref_internal(row, values).to_owned()));
     Value::List(list_vec)
+}
+
+fn from_struct(items: &StructArray, idx: usize) -> Value {
+    let capacity = items.columns().len();
+    let mut value = Vec::with_capacity(capacity);
+    value.extend(
+        items
+            .columns()
+            .iter()
+            .zip(items.fields().iter().map(|f| f.name().to_owned()))
+            .map(|(column, name)| -> (String, Value) { (name, Row::value_ref_internal(idx, column).to_owned()) }),
+    );
+    Value::Struct(OrderedMap::from(value))
+}
+
+fn from_map(arr: &MapArray, idx: usize) -> Value {
+    let keys = arr.keys();
+    let values = arr.values();
+    let offsets = arr.offsets();
+    let range = offsets[idx]..offsets[idx + 1];
+    let capacity = range.len();
+    let mut map_vec = Vec::with_capacity(capacity);
+    map_vec.extend(range.map(|row| {
+        let row = row.try_into().unwrap();
+        let key = Row::value_ref_internal(row, keys).to_owned();
+        let value = Row::value_ref_internal(row, values).to_owned();
+        (key, value)
+    }));
+    Value::Map(OrderedMap::from(map_vec))
+}
+
+fn from_array(items: &FixedSizeListArray, idx: usize) -> Value {
+    let value_length = usize::try_from(items.value_length()).unwrap();
+    let range = (idx * value_length)..((idx + 1) * value_length);
+    let mut array_vec = Vec::with_capacity(value_length);
+    array_vec.extend(range.map(|row| Row::value_ref_internal(row, items.values()).to_owned()));
+    Value::Array(array_vec)
+}
+
+fn from_union(column: &ArrayRef, idx: usize) -> Value {
+    let column = column.as_any().downcast_ref::<UnionArray>().unwrap();
+    let type_id = column.type_id(idx);
+    // Arrow's value offset is the row in the active child array. DuckDB
+    // currently emits sparse unions where this equals `idx`, but using the
+    // offset keeps the decoder correct for dense unions too.
+    let value_offset = column.value_offset(idx);
+    let tag = Row::value_ref_internal(value_offset, column.child(type_id));
+    Value::Union(Box::new(tag.to_owned()))
 }
 
 impl<'a> From<&'a str> for ValueRef<'a> {
@@ -367,6 +390,7 @@ fn unsupported_value_variant(value: &Value) -> Option<&'static str> {
         | Value::Int(_)
         | Value::BigInt(_)
         | Value::HugeInt(_)
+        | Value::UHugeInt(_)
         | Value::UTinyInt(_)
         | Value::USmallInt(_)
         | Value::UInt(_)
@@ -407,6 +431,7 @@ impl<'a> From<&'a Value> for ValueRef<'a> {
             Value::Int(i) => ValueRef::Int(i),
             Value::BigInt(i) => ValueRef::BigInt(i),
             Value::HugeInt(i) => ValueRef::HugeInt(i),
+            Value::UHugeInt(i) => ValueRef::UHugeInt(i),
             Value::UTinyInt(i) => ValueRef::UTinyInt(i),
             Value::USmallInt(i) => ValueRef::USmallInt(i),
             Value::UInt(i) => ValueRef::UInt(i),


### PR DESCRIPTION
Introduce a `u128` carrier for DuckDB `UHUGEINT`: bind, append, and read top-level `UHUGEINT` columns via `Value::UHugeInt` / `ValueRef::UHugeInt`, with `FromSql` / `ToSql` for `u128`.

DuckDB's Arrow result path gives `HUGEINT`, `UHUGEINT`, and scale-zero `DECIMAL` the same Arrow decimal shape. This PR caches DuckDB's reported result-column logical IDs so top-level `UHUGEINT` reads reinterpret the raw 128-bit pattern instead of using a checked signed cast, allowing `u128::MAX` to round-trip.

The implementation deliberately does not use parameter names, aliases, or expression text to recover missing logical metadata. Parameter-derived scale-zero Arrow decimal results with `Invalid` logical metadata, such as bare `SELECT ?` with a `u128` value, preserve the existing signed `HugeInt` fallback. Cast the expression, e.g. `SELECT ?::UHUGEINT`, when a dynamic `UHUGEINT` carrier is required; otherwise upper-half `u128` values cannot be recovered through that metadata-less path.

## Compatibility notes

- **Breaking:** `Type`, `Value`, and `ValueRef` are now `#[non_exhaustive]`, and each gains a `UHugeInt` variant. Exhaustive matches over these enums must add a wildcard arm.
- Top-level `UHUGEINT` result columns decode as `Value::UHugeInt` / `ValueRef::UHugeInt` when DuckDB reports `UHUGEINT` logical metadata.
- Parameter-derived scale-zero Arrow decimal results with `Invalid` logical metadata preserve the existing signed `HugeInt` fallback. No alias/parameter-name/expression-text heuristics are used to promote them to `UHUGEINT`. Cast the expression, e.g. `SELECT ?::UHUGEINT`, when a dynamic `UHUGEINT` carrier is required.
- Nested containers still do not carry DuckDB child logical type metadata through the current borrowed `ValueRef` container API. Nested `UHUGEINT` values above `i128::MAX` remain unrecoverable through the Arrow-backed row path.
- Full-width `DECIMAL(38, s)` values outside `rust_decimal`'s range remain future work.

Closes #273