### PR TITLE
Harden Rust CI cache saves

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,6 +33,7 @@ jobs:
           submodules: recursive
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache-on-failure: false
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: mozilla-actions/sccache-action@v0.0.10
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
 
       - name: publish crates
         uses: katyo/publish-crates@v2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: ${{ matrix.target }}
+          cache-on-failure: false
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: mozilla-actions/sccache-action@v0.0.10
 
@@ -135,6 +136,7 @@ jobs:
           submodules: recursive
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          cache-on-failure: false
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: mozilla-actions/sccache-action@v0.0.10
 
@@ -169,6 +171,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-bin: false
+          cache-on-failure: false
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@cargo-binstall
       - run: cargo binstall --no-confirm cargo-msrv
@@ -187,6 +190,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly-2026-03-03
+          cache-on-failure: false
           cache-save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: mozilla-actions/sccache-action@v0.0.10
       - name: Tests with asan


### PR DESCRIPTION
Rust target caches are now [saved only from main](https://github.com/duckdb/duckdb-rs/pull/794), which makes main the source of truth for PR restores. With setup-rust-toolchain's default `cache-on-failure=true`, a failed main job could persist a partial target cache that PRs restore but cannot replace. Disable cache saves on failed jobs so only successful main runs publish those caches.

The release workflow does not benefit from saving a Rust target cache because it publishes with `--no-verify`. Disable its toolchain cache entirely so tag builds do not compete with CI caches.