### PR TITLE
feat(arrow): zero-copy Arrow registration with projection + filter pushdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+checksum = "3ac95125e1d71c4a252b5a9c729aef111e80418f08aaa6dbabd1ba66918247fc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+checksum = "0c60c79628e9a97cb90d7a0dc3e944f216a902f837d4ecabc14d524bddbbc137"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+checksum = "6026f638c400e9878c1b1cc05c3cfd46fbf381285916ab408678701c1df46c1a"
 dependencies = [
  "bytes",
  "half",
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+checksum = "c82c236c3caf8df5664284f3f1fbe89938852163998c3fdbf37e84ac220445e9"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+checksum = "7bd568aa70c4ec5947027b0d5caee94877433b661a0bb9e8ddceeeb5f0c9b1ab"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+checksum = "a79cf73ad2eba8686ec2aa9bbf8671208e509025f166afc040cedbd94ffe4983"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+checksum = "cea0f7d8ed6182f14952761e2c0f989852d5aa334fcbc49f73a9f2247c25b879"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -233,18 +233,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+checksum = "80b3e786a0dd9103acd583a6fb486dbf2f3268466cc0bd571dcf34cef231c1f1"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+checksum = "067a67e0361f6c31f4a7248759f36ca4ca71b187a941ed4d49da1c7d3d4db624"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.3.0"
+version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+checksum = "99bc95847f3ff62a2b03d6f8ce2e3e78f01362060549a2a311898dd442f6256d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ duckdb = { version = "=1.10504.0", path = "crates/duckdb" }
 duckdb-loadable-macros = { version = "=1.10504.0", path = "crates/duckdb-loadable-macros" }
 libduckdb-sys = { version = "=1.10504.0", path = "crates/libduckdb-sys" }
 
-arrow = { version = "58", default-features = false }
+arrow = { version = "59", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cast = "0.3"
 cc = "1.0"

--- a/crates/duckdb/CHANGELOG.md
+++ b/crates/duckdb/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to the `duckdb` crate are documented here.
+
+## [Unreleased]
+
+- `Connection::register_arrow` filter pushdown now covers every filter kind DuckDB v1.5.4
+  pushes to an arrow scan: STRUCT_EXTRACT (struct-field) predicates via column paths, plus
+  scalar breadth (Date/Time/Timestamp/Decimal128/Blob + float NaN total-order) on top of the
+  existing constant-comparison / IS [NOT] NULL / AND·OR / IN coverage. OPTIONAL/DYNAMIC/BLOOM
+  are safely skipped; any unhandled required filter fails loud.

--- a/crates/duckdb/examples/arrow_zerocopy_bench.rs
+++ b/crates/duckdb/examples/arrow_zerocopy_bench.rs
@@ -1,0 +1,131 @@
+//! Benchmark: zero-copy `register_arrow` vs the Appender (copy), cold per-task
+//! (open connection + ingest + query). Two queries are measured:
+//!   1. Unfiltered projection: `SELECT sum(c0) FROM …`
+//!   2. Filtered + projected:  `SELECT sum(c0) FROM … WHERE c0 > n/2`
+//!
+//! The table is wide (8 int64 columns) with light compute and single-column projection,
+//! so both the skipped ingest copy AND projection+filter pushdown show clearly.
+//!
+//! Run:
+//!   cargo run -p duckdb --features "bundled appender-arrow" --release --example arrow_zerocopy_bench
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use duckdb::Connection;
+use duckdb::arrow::array::Int64Array;
+use duckdb::arrow::datatypes::{DataType, Field, Schema};
+use duckdb::arrow::record_batch::RecordBatch;
+
+const COLS: usize = 8;
+
+fn make_batch(n: i64) -> RecordBatch {
+    let fields: Vec<Field> = (0..COLS)
+        .map(|c| Field::new(format!("c{c}"), DataType::Int64, false))
+        .collect();
+    let schema = Arc::new(Schema::new(fields));
+    let cols: Vec<Arc<dyn duckdb::arrow::array::Array>> = (0..COLS)
+        .map(|c| Arc::new(Int64Array::from_iter_values((0..n).map(|i| i + c as i64))) as _)
+        .collect();
+    RecordBatch::try_new(schema, cols).unwrap()
+}
+
+fn ddl() -> String {
+    let cols: Vec<String> = (0..COLS).map(|c| format!("c{c} BIGINT")).collect();
+    format!("CREATE TABLE t ({})", cols.join(", "))
+}
+
+fn appender_cold(batch: &RecordBatch, query: &str) -> i64 {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(&ddl()).unwrap();
+    {
+        let mut app = conn.appender("t").unwrap();
+        app.append_record_batch(batch.clone()).unwrap();
+    }
+    conn.query_row(query, [], |r| r.get(0)).unwrap()
+}
+
+fn zerocopy_cold(batch: &RecordBatch, query: &str) -> i64 {
+    let conn = Connection::open_in_memory().unwrap();
+    let reg = conn.register_arrow("v", vec![batch.clone()]).unwrap();
+    let out: i64 = conn.query_row(query, [], |r| r.get(0)).unwrap();
+    drop(reg);
+    out
+}
+
+fn main() {
+    let sizes = [100_000i64, 1_000_000, 10_000_000];
+    let k = 5;
+
+    // Warm up (first connection + first arrow_scan pay one-time inits).
+    let warm = make_batch(1000);
+    assert_eq!(
+        appender_cold(&warm, "SELECT sum(c0) FROM t"),
+        zerocopy_cold(&warm, "SELECT sum(c0) FROM v"),
+        "warm-up results must agree (unfiltered)"
+    );
+
+    println!("Copy-dominated cold per-task: zero-copy arrow_scan vs Appender (wide table, {COLS} cols)");
+
+    // ── Unfiltered query ────────────────────────────────────────────────────────
+    println!("\n[Unfiltered] SELECT sum(c0) FROM …");
+    println!(
+        "{:>12} {:>14} {:>15} {:>9}",
+        "rows", "appender ms", "zero-copy ms", "speedup"
+    );
+    for &n in &sizes {
+        let batch = make_batch(n);
+        let q_app = "SELECT sum(c0) FROM t";
+        let q_zc = "SELECT sum(c0) FROM v";
+        assert_eq!(
+            appender_cold(&batch, q_app),
+            zerocopy_cold(&batch, q_zc),
+            "results must agree (unfiltered) at n={n}"
+        );
+
+        let t0 = Instant::now();
+        for _ in 0..k {
+            let _ = appender_cold(&batch, q_app);
+        }
+        let app_ms = t0.elapsed().as_secs_f64() * 1000.0 / k as f64;
+
+        let t1 = Instant::now();
+        for _ in 0..k {
+            let _ = zerocopy_cold(&batch, q_zc);
+        }
+        let zc_ms = t1.elapsed().as_secs_f64() * 1000.0 / k as f64;
+
+        println!("{:>12} {:>14.1} {:>15.1} {:>8.2}x", n, app_ms, zc_ms, app_ms / zc_ms);
+    }
+
+    // ── Filtered + projected query ──────────────────────────────────────────────
+    println!("\n[Filtered] SELECT sum(c0) FROM … WHERE c0 > n/2");
+    println!(
+        "{:>12} {:>14} {:>15} {:>9}",
+        "rows", "appender ms", "zero-copy ms", "speedup"
+    );
+    for &n in &sizes {
+        let batch = make_batch(n);
+        let q_app = format!("SELECT sum(c0) FROM t WHERE c0 > {}", n / 2);
+        let q_zc = format!("SELECT sum(c0) FROM v WHERE c0 > {}", n / 2);
+        assert_eq!(
+            appender_cold(&batch, &q_app),
+            zerocopy_cold(&batch, &q_zc),
+            "results must agree (filtered) at n={n}"
+        );
+
+        let t0 = Instant::now();
+        for _ in 0..k {
+            let _ = appender_cold(&batch, &q_app);
+        }
+        let app_ms = t0.elapsed().as_secs_f64() * 1000.0 / k as f64;
+
+        let t1 = Instant::now();
+        for _ in 0..k {
+            let _ = zerocopy_cold(&batch, &q_zc);
+        }
+        let zc_ms = t1.elapsed().as_secs_f64() * 1000.0 / k as f64;
+
+        println!("{:>12} {:>14.1} {:>15.1} {:>8.2}x", n, app_ms, zc_ms, app_ms / zc_ms);
+    }
+}

--- a/crates/duckdb/src/arrow_zerocopy/filter.rs
+++ b/crates/duckdb/src/arrow_zerocopy/filter.rs
@@ -6,7 +6,7 @@
 
 use arrow::array::{
     Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
-    LargeStringArray, RecordBatch, Scalar, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+    LargeStringArray, RecordBatch, Scalar, StringArray, StructArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::compute::kernels::{boolean, cmp};
 use arrow::compute::{is_not_null, is_null};
@@ -52,12 +52,12 @@ pub(crate) enum CmpOp {
 
 #[derive(Debug)]
 pub(crate) enum FilterNode {
-    Compare { col: usize, op: CmpOp, val: ScalarVal },
-    IsNull { col: usize },
-    IsNotNull { col: usize },
+    Compare { path: Vec<usize>, op: CmpOp, val: ScalarVal },
+    IsNull { path: Vec<usize> },
+    IsNotNull { path: Vec<usize> },
     And(Vec<FilterNode>),
     Or(Vec<FilterNode>),
-    In { col: usize, vals: Vec<ScalarVal> },
+    In { path: Vec<usize>, vals: Vec<ScalarVal> },
     Unhandled(u32),
 }
 
@@ -110,6 +110,11 @@ impl<'a> Cursor<'a> {
         f64::from_bits(bits)
     }
 
+    fn read_path(&mut self) -> Vec<usize> {
+        let depth = self.read_u32() as usize;
+        (0..depth).map(|_| self.read_u32() as usize).collect()
+    }
+
     fn remaining(&self) -> usize {
         self.buf.len().saturating_sub(self.pos)
     }
@@ -150,7 +155,7 @@ impl<'a> Cursor<'a> {
         }
         match self.read_u8() {
             0 => {
-                let col = self.read_u32() as usize;
+                let path = self.read_path();
                 let op_byte = self.read_u8();
                 let op = match op_byte {
                     0 => CmpOp::Eq,
@@ -166,14 +171,10 @@ impl<'a> Cursor<'a> {
                     }
                 };
                 let val = self.read_scalar();
-                FilterNode::Compare { col, op, val }
+                FilterNode::Compare { path, op, val }
             }
-            1 => FilterNode::IsNull {
-                col: self.read_u32() as usize,
-            },
-            2 => FilterNode::IsNotNull {
-                col: self.read_u32() as usize,
-            },
+            1 => FilterNode::IsNull { path: self.read_path() },
+            2 => FilterNode::IsNotNull { path: self.read_path() },
             3 => {
                 let n = self.read_u32() as usize;
                 let children = (0..n).map(|_| self.read_node_inner(depth + 1)).collect();
@@ -185,10 +186,10 @@ impl<'a> Cursor<'a> {
                 FilterNode::Or(children)
             }
             5 => {
-                let col = self.read_u32() as usize;
+                let path = self.read_path();
                 let n = self.read_u32() as usize;
                 let vals = (0..n).map(|_| self.read_scalar()).collect();
-                FilterNode::In { col, vals }
+                FilterNode::In { path, vals }
             }
             255 => FilterNode::Unhandled(self.read_u32()),
             tag => FilterNode::Unhandled(tag as u32),
@@ -210,8 +211,47 @@ pub(crate) fn decode(buf: &[u8]) -> FilterNode {
 // Evaluator
 // ──────────────────────────────────────────────────────────────────────────────
 
+/// Resolve a column path to its leaf array plus an optional "ancestor-valid" mask.
+/// `path[0]` selects the projected column; each subsequent index descends into a
+/// `StructArray` child. The returned mask (when `Some`) is `true` where every ancestor
+/// struct is non-null at that row; `None` means no ancestor struct carried nulls.
+fn resolve_path(
+    batch: &RecordBatch,
+    path: &[usize],
+) -> Result<(ArrayRef, Option<BooleanArray>), FilterError> {
+    let root = *path
+        .first()
+        .ok_or_else(|| FilterError::Unhandled("empty column path".into()))?;
+    if root >= batch.num_columns() {
+        return Err(FilterError::Unhandled(format!("column index {root} out of range")));
+    }
+    let mut arr: ArrayRef = batch.column(root).clone();
+    let mut ancestor_valid: Option<BooleanArray> = None;
+    for &idx in &path[1..] {
+        let sa = arr.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
+            FilterError::Unhandled(format!("path descends into non-struct: {:?}", arr.data_type()))
+        })?;
+        if let Some(nulls) = sa.nulls() {
+            // Collect per-logical-element validity (true = non-null). `iter()` applies the
+            // NullBuffer's offset/len, so this is correct even for a sliced StructArray
+            // (a user may register a sliced batch) — unlike cloning the raw inner buffer.
+            let this_valid: BooleanArray = nulls.iter().collect();
+            ancestor_valid = Some(match ancestor_valid {
+                Some(prev) => boolean::and(&prev, &this_valid).map_err(|e| FilterError::Unhandled(e.to_string()))?,
+                None => this_valid,
+            });
+        }
+        let child = sa
+            .columns()
+            .get(idx)
+            .ok_or_else(|| FilterError::Unhandled(format!("struct child index {idx} out of range")))?;
+        arr = child.clone();
+    }
+    Ok((arr, ancestor_valid))
+}
+
 /// Evaluate a filter node against a projected `RecordBatch`, returning a boolean mask.
-/// Column indices in the `FilterNode` refer to positions in the projected batch.
+/// Column paths in the `FilterNode` refer to positions in the projected batch.
 pub(crate) fn evaluate(node: &FilterNode, batch: &RecordBatch) -> Result<BooleanArray, FilterError> {
     match node {
         FilterNode::Unhandled(k) => Err(FilterError::Unhandled(format!("TableFilterType {k}"))),
@@ -234,20 +274,31 @@ pub(crate) fn evaluate(node: &FilterNode, batch: &RecordBatch) -> Result<Boolean
             Ok(acc)
         }
 
-        FilterNode::IsNull { col } => {
-            is_null(batch.column(*col).as_ref()).map_err(|e| FilterError::Unhandled(e.to_string()))
+        FilterNode::IsNull { path } => {
+            let (col, valid) = resolve_path(batch, path)?;
+            let mut m = is_null(col.as_ref()).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            if let Some(v) = valid {
+                let not_v = boolean::not(&v).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+                m = boolean::or(&m, &not_v).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            }
+            Ok(m)
         }
 
-        FilterNode::IsNotNull { col } => {
-            is_not_null(batch.column(*col).as_ref()).map_err(|e| FilterError::Unhandled(e.to_string()))
+        FilterNode::IsNotNull { path } => {
+            let (col, valid) = resolve_path(batch, path)?;
+            let mut m = is_not_null(col.as_ref()).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            if let Some(v) = valid {
+                m = boolean::and(&m, &v).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            }
+            Ok(m)
         }
 
-        FilterNode::In { col, vals } => {
+        FilterNode::In { path, vals } => {
             // OR of equality comparisons; NULLs in the column are never matched (DuckDB semantics).
-            let col_arr = batch.column(*col);
+            let (col_arr, valid) = resolve_path(batch, path)?;
             let mut acc = BooleanArray::from(vec![false; batch.num_rows()]);
             for val in vals {
-                let eq_mask = compare(col_arr, &CmpOp::Eq, val)?;
+                let eq_mask = compare(&col_arr, &CmpOp::Eq, val)?;
                 // `compare` with a non-null scalar returns a BooleanArray where null column
                 // entries produce null in the mask — coerce them to false so they don't match.
                 let n = eq_mask.len();
@@ -258,10 +309,20 @@ pub(crate) fn evaluate(node: &FilterNode, batch: &RecordBatch) -> Result<Boolean
                 );
                 acc = boolean::or(&acc, &eq_no_null).map_err(|e| FilterError::Unhandled(e.to_string()))?;
             }
+            if let Some(v) = valid {
+                acc = boolean::and(&acc, &v).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            }
             Ok(acc)
         }
 
-        FilterNode::Compare { col, op, val } => compare(batch.column(*col), op, val),
+        FilterNode::Compare { path, op, val } => {
+            let (col, valid) = resolve_path(batch, path)?;
+            let mask = compare(&col, op, val)?;
+            match valid {
+                Some(v) => boolean::and(&mask, &v).map_err(|e| FilterError::Unhandled(e.to_string())),
+                None => Ok(mask),
+            }
+        }
     }
 }
 

--- a/crates/duckdb/src/arrow_zerocopy/filter.rs
+++ b/crates/duckdb/src/arrow_zerocopy/filter.rs
@@ -5,12 +5,14 @@
 //! a projected `RecordBatch`, producing a `BooleanArray` mask for `filter_record_batch`.
 
 use arrow::array::{
-    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
-    LargeStringArray, RecordBatch, Scalar, StringArray, StructArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+    Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
+    Int8Array, Int16Array, Int32Array, Int64Array, LargeBinaryArray, LargeStringArray, RecordBatch, Scalar,
+    StringArray, StructArray, Time64MicrosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+    TimestampNanosecondArray, TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::compute::kernels::{boolean, cmp};
 use arrow::compute::{is_not_null, is_null};
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, TimeUnit};
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Public types
@@ -36,6 +38,11 @@ pub(crate) enum ScalarVal {
     F64(f64),
     Bool(bool),
     Utf8(String),
+    Date32(i32),
+    Time { unit: u8, v: i64 },
+    Timestamp { unit: u8, v: i64 },
+    Blob(Vec<u8>),
+    Decimal128 { v: i128, scale: u8 },
     Null,
     Unsupported,
 }
@@ -89,6 +96,10 @@ impl<'a> Cursor<'a> {
         b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
     }
 
+    fn read_i32(&mut self) -> i32 {
+        self.read_u32() as i32
+    }
+
     fn read_i64(&mut self) -> i64 {
         let mut v: u64 = 0;
         for i in 0..8u64 {
@@ -108,6 +119,14 @@ impl<'a> Cursor<'a> {
     fn read_f64(&mut self) -> f64 {
         let bits = self.read_u64();
         f64::from_bits(bits)
+    }
+
+    fn read_i128(&mut self) -> i128 {
+        let mut bytes = [0u8; 16];
+        for b in bytes.iter_mut() {
+            *b = self.read_u8();
+        }
+        i128::from_le_bytes(bytes)
     }
 
     fn read_path(&mut self) -> Vec<usize> {
@@ -138,6 +157,16 @@ impl<'a> Cursor<'a> {
                 }
             }
             5 => ScalarVal::Null,
+            6 => ScalarVal::Date32(self.read_i32()),
+            7 => { let unit = self.read_u8(); let v = self.read_i64(); ScalarVal::Time { unit, v } }
+            8 => { let unit = self.read_u8(); let v = self.read_i64(); ScalarVal::Timestamp { unit, v } }
+            9 => { let v = self.read_i128(); let scale = self.read_u8(); ScalarVal::Decimal128 { v, scale } }
+            10 => {
+                let len = self.read_u32() as usize;
+                let bytes = self.buf.get(self.pos..self.pos + len).unwrap_or(&[]).to_vec();
+                self.pos += len;
+                ScalarVal::Blob(bytes)
+            }
             _ => ScalarVal::Unsupported,
         }
     }
@@ -326,6 +355,82 @@ pub(crate) fn evaluate(node: &FilterNode, batch: &RecordBatch) -> Result<Boolean
     }
 }
 
+fn time_unit_tag(u: &TimeUnit) -> u8 {
+    match u {
+        TimeUnit::Second => 0,
+        TimeUnit::Millisecond => 1,
+        TimeUnit::Microsecond => 2,
+        TimeUnit::Nanosecond => 3,
+    }
+}
+
+/// Convert an integer timestamp/time `v` from `from` unit to `to` unit.
+/// Exact (multiply) when going finer-or-equal; fail loud if a coarser target would lose precision.
+fn convert_time_unit(v: i64, from: u8, to: u8) -> Result<i64, FilterError> {
+    const FACTORS: [i128; 4] = [1, 1_000, 1_000_000, 1_000_000_000]; // s, ms, µs, ns per second
+    // `from` comes from the (untrusted) wire buffer; an out-of-range unit byte must fail loud,
+    // not panic on an out-of-bounds index. (`to` comes from time_unit_tag and is always 0..=3.)
+    if from as usize >= FACTORS.len() || to as usize >= FACTORS.len() {
+        return Err(FilterError::Unhandled(format!("unknown time unit byte: from={from} to={to}")));
+    }
+    let (f, t) = (FACTORS[from as usize], FACTORS[to as usize]);
+    let vi = v as i128;
+    let out = if t >= f {
+        vi * (t / f)
+    } else {
+        let div = f / t;
+        if vi % div != 0 {
+            return Err(FilterError::Unhandled(format!(
+                "timestamp constant {v} (unit {from}) not representable in column unit {to}"
+            )));
+        }
+        vi / div
+    };
+    i64::try_from(out).map_err(|_| FilterError::Unhandled(format!("timestamp constant overflow converting unit {from}->{to}")))
+}
+
+/// Comparison of a float column against a NaN constant, using DuckDB's float total order
+/// (NaN sorts highest; NaN == NaN). `col` is Float32 or Float64.
+/// Result is non-null: positions that are SQL-null in `col` yield false.
+///
+/// Note: arrow-rs 58 uses total-order semantics for cmp kernels (NaN == NaN is true), so
+/// we cannot use `cmp::neq(col, col)` to detect NaN (it returns false for NaN positions).
+/// Instead, we inspect the raw float bits directly via downcast.
+fn nan_compare(col: &ArrayRef, op: &CmpOp) -> Result<BooleanArray, FilterError> {
+    let n = col.len();
+    let not_null: Vec<bool> = (0..n).map(|i| col.is_valid(i)).collect();
+
+    // Detect NaN by inspecting raw values (works for both Float32 and Float64 columns).
+    let is_nan: Vec<bool> = if let Some(arr) = col.as_any().downcast_ref::<Float64Array>() {
+        (0..n).map(|i| col.is_valid(i) && arr.value(i).is_nan()).collect()
+    } else if let Some(arr) = col.as_any().downcast_ref::<Float32Array>() {
+        (0..n).map(|i| col.is_valid(i) && arr.value(i).is_nan()).collect()
+    } else {
+        return Err(FilterError::Unhandled(format!(
+            "nan_compare: expected Float32 or Float64 column, got {:?}",
+            col.data_type()
+        )));
+    };
+
+    let out: Vec<bool> = (0..n)
+        .map(|i| {
+            if !not_null[i] {
+                return false; // NULL never satisfies a comparison
+            }
+            let nan = is_nan[i];
+            match op {
+                CmpOp::Eq => nan,        // = NaN  → only NaN
+                CmpOp::Ne => !nan,       // <> NaN → everything that is not NaN
+                CmpOp::Lt => !nan,       // < NaN  → everything below NaN
+                CmpOp::Le => true,       // <= NaN → all (NaN is the max)
+                CmpOp::Gt => false,      // > NaN  → nothing exceeds NaN
+                CmpOp::Ge => nan,        // >= NaN → only NaN
+            }
+        })
+        .collect();
+    Ok(BooleanArray::from(out))
+}
+
 /// Build a one-element typed scalar matching the column's DataType from the incoming `val`,
 /// then dispatch the comparison kernel.
 ///
@@ -384,9 +489,19 @@ fn compare(col: &ArrayRef, op: &CmpOp, val: &ScalarVal) -> Result<BooleanArray, 
         }
 
         // ── Floats (DuckDB pushes as F64) ──────────────────────────────────────
-        (DataType::Float64, ScalarVal::F64(v)) => dispatch(op, col, &Scalar::new(Float64Array::from(vec![*v]))),
+        (DataType::Float64, ScalarVal::F64(v)) => {
+            if v.is_nan() {
+                return nan_compare(col, op);
+            }
+            dispatch(op, col, &Scalar::new(Float64Array::from(vec![*v])))
+        }
         // Float32: f64 → f32 cast is a deliberate precision round, not a correctness issue
-        (DataType::Float32, ScalarVal::F64(v)) => dispatch(op, col, &Scalar::new(Float32Array::from(vec![*v as f32]))),
+        (DataType::Float32, ScalarVal::F64(v)) => {
+            if v.is_nan() {
+                return nan_compare(col, op);
+            }
+            dispatch(op, col, &Scalar::new(Float32Array::from(vec![*v as f32])))
+        }
 
         // ── Boolean ────────────────────────────────────────────────────────────
         (DataType::Boolean, ScalarVal::Bool(v)) => dispatch(op, col, &Scalar::new(BooleanArray::from(vec![*v]))),
@@ -396,6 +511,42 @@ fn compare(col: &ArrayRef, op: &CmpOp, val: &ScalarVal) -> Result<BooleanArray, 
         // LargeUtf8: present for completeness; DuckDB's arrow_scan rarely emits it
         (DataType::LargeUtf8, ScalarVal::Utf8(v)) => {
             dispatch(op, col, &Scalar::new(LargeStringArray::from(vec![v.as_str()])))
+        }
+
+        // ── Date / Time ────────────────────────────────────────────────────────
+        (DataType::Date32, ScalarVal::Date32(v)) => dispatch(op, col, &Scalar::new(Date32Array::from(vec![*v]))),
+        (DataType::Time64(TimeUnit::Microsecond), ScalarVal::Time { unit: 2, v }) => {
+            dispatch(op, col, &Scalar::new(Time64MicrosecondArray::from(vec![*v])))
+        }
+
+        // ── Blob ────────────────────────────────────────────────────────────────
+        (DataType::Binary, ScalarVal::Blob(b)) => dispatch(op, col, &Scalar::new(BinaryArray::from(vec![b.as_slice()]))),
+        (DataType::LargeBinary, ScalarVal::Blob(b)) => {
+            dispatch(op, col, &Scalar::new(LargeBinaryArray::from(vec![b.as_slice()])))
+        }
+
+        // ── Timestamps (convert wire unit → column unit, lossless or fail loud) ──
+        (DataType::Timestamp(col_unit, tz), ScalarVal::Timestamp { unit, v }) => {
+            let v_col = convert_time_unit(*v, *unit, time_unit_tag(col_unit))?;
+            match col_unit {
+                TimeUnit::Second => dispatch(op, col, &Scalar::new(TimestampSecondArray::from(vec![v_col]).with_timezone_opt(tz.clone()))),
+                TimeUnit::Millisecond => dispatch(op, col, &Scalar::new(TimestampMillisecondArray::from(vec![v_col]).with_timezone_opt(tz.clone()))),
+                TimeUnit::Microsecond => dispatch(op, col, &Scalar::new(TimestampMicrosecondArray::from(vec![v_col]).with_timezone_opt(tz.clone()))),
+                TimeUnit::Nanosecond => dispatch(op, col, &Scalar::new(TimestampNanosecondArray::from(vec![v_col]).with_timezone_opt(tz.clone()))),
+            }
+        }
+
+        // ── Decimal128 (column precision/scale drive the scalar; scale must match) ──
+        (DataType::Decimal128(p, s), ScalarVal::Decimal128 { v, scale }) => {
+            if *scale != *s as u8 {
+                return Err(FilterError::Unhandled(format!(
+                    "decimal scale mismatch: constant scale {scale} vs column scale {s}"
+                )));
+            }
+            let arr = Decimal128Array::from(vec![*v])
+                .with_precision_and_scale(*p, *s)
+                .map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            dispatch(op, col, &Scalar::new(arr))
         }
 
         // ── Anything else → clean error (never silently wrong) ─────────────────

--- a/crates/duckdb/src/arrow_zerocopy/filter.rs
+++ b/crates/duckdb/src/arrow_zerocopy/filter.rs
@@ -355,12 +355,18 @@ pub(crate) fn evaluate(node: &FilterNode, batch: &RecordBatch) -> Result<Boolean
     }
 }
 
+// Wire unit-byte tags for Time/Timestamp scalars; must match the C++ emit_scalar unit byte.
+const UNIT_SEC: u8 = 0;
+const UNIT_MS: u8 = 1;
+const UNIT_US: u8 = 2;
+const UNIT_NS: u8 = 3;
+
 fn time_unit_tag(u: &TimeUnit) -> u8 {
     match u {
-        TimeUnit::Second => 0,
-        TimeUnit::Millisecond => 1,
-        TimeUnit::Microsecond => 2,
-        TimeUnit::Nanosecond => 3,
+        TimeUnit::Second => UNIT_SEC,
+        TimeUnit::Millisecond => UNIT_MS,
+        TimeUnit::Microsecond => UNIT_US,
+        TimeUnit::Nanosecond => UNIT_NS,
     }
 }
 
@@ -515,7 +521,7 @@ fn compare(col: &ArrayRef, op: &CmpOp, val: &ScalarVal) -> Result<BooleanArray, 
 
         // ── Date / Time ────────────────────────────────────────────────────────
         (DataType::Date32, ScalarVal::Date32(v)) => dispatch(op, col, &Scalar::new(Date32Array::from(vec![*v]))),
-        (DataType::Time64(TimeUnit::Microsecond), ScalarVal::Time { unit: 2, v }) => {
+        (DataType::Time64(TimeUnit::Microsecond), ScalarVal::Time { unit: UNIT_US, v }) => {
             dispatch(op, col, &Scalar::new(Time64MicrosecondArray::from(vec![*v])))
         }
 

--- a/crates/duckdb/src/arrow_zerocopy/filter.rs
+++ b/crates/duckdb/src/arrow_zerocopy/filter.rs
@@ -1,0 +1,358 @@
+//! Filter buffer decoder and evaluator for the zero-copy Arrow registration.
+//!
+//! The C++ shim serialises DuckDB's `TableFilterSet` into a little-endian byte buffer (the
+//! "wire format"); this module decodes it into a `FilterNode` tree and evaluates it against
+//! a projected `RecordBatch`, producing a `BooleanArray` mask for `filter_record_batch`.
+
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
+    LargeStringArray, RecordBatch, Scalar, StringArray, UInt8Array, UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::compute::kernels::{boolean, cmp};
+use arrow::compute::{is_not_null, is_null};
+use arrow::datatypes::DataType;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub(crate) enum FilterError {
+    Unhandled(String),
+}
+
+impl std::fmt::Display for FilterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterError::Unhandled(s) => write!(f, "unhandled filter: {s}"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ScalarVal {
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    Bool(bool),
+    Utf8(String),
+    Null,
+    Unsupported,
+}
+
+#[derive(Debug)]
+pub(crate) enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+}
+
+#[derive(Debug)]
+pub(crate) enum FilterNode {
+    Compare { col: usize, op: CmpOp, val: ScalarVal },
+    IsNull { col: usize },
+    IsNotNull { col: usize },
+    And(Vec<FilterNode>),
+    Or(Vec<FilterNode>),
+    In { col: usize, vals: Vec<ScalarVal> },
+    Unhandled(u32),
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Decoder
+// ──────────────────────────────────────────────────────────────────────────────
+
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn read_u8(&mut self) -> u8 {
+        let v = self.buf.get(self.pos).copied().unwrap_or(0);
+        self.pos += 1;
+        v
+    }
+
+    fn read_u32(&mut self) -> u32 {
+        let b0 = self.read_u8() as u32;
+        let b1 = self.read_u8() as u32;
+        let b2 = self.read_u8() as u32;
+        let b3 = self.read_u8() as u32;
+        b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+    }
+
+    fn read_i64(&mut self) -> i64 {
+        let mut v: u64 = 0;
+        for i in 0..8u64 {
+            v |= (self.read_u8() as u64) << (i * 8);
+        }
+        v as i64
+    }
+
+    fn read_u64(&mut self) -> u64 {
+        let mut v: u64 = 0;
+        for i in 0..8u64 {
+            v |= (self.read_u8() as u64) << (i * 8);
+        }
+        v
+    }
+
+    fn read_f64(&mut self) -> f64 {
+        let bits = self.read_u64();
+        f64::from_bits(bits)
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    fn read_scalar(&mut self) -> ScalarVal {
+        if self.remaining() == 0 {
+            return ScalarVal::Unsupported;
+        }
+        match self.read_u8() {
+            0 => ScalarVal::I64(self.read_i64()),
+            1 => ScalarVal::U64(self.read_u64()),
+            2 => ScalarVal::F64(self.read_f64()),
+            3 => ScalarVal::Bool(self.read_u8() != 0),
+            4 => {
+                let len = self.read_u32() as usize;
+                let bytes = self.buf.get(self.pos..self.pos + len).unwrap_or(&[]).to_vec();
+                self.pos += len;
+                match String::from_utf8(bytes) {
+                    Ok(s) => ScalarVal::Utf8(s),
+                    Err(_) => ScalarVal::Unsupported,
+                }
+            }
+            5 => ScalarVal::Null,
+            _ => ScalarVal::Unsupported,
+        }
+    }
+
+    fn read_node(&mut self) -> FilterNode {
+        self.read_node_inner(0)
+    }
+
+    fn read_node_inner(&mut self, depth: usize) -> FilterNode {
+        if depth > 64 {
+            return FilterNode::Unhandled(255);
+        }
+        if self.remaining() == 0 {
+            return FilterNode::Unhandled(255);
+        }
+        match self.read_u8() {
+            0 => {
+                let col = self.read_u32() as usize;
+                let op_byte = self.read_u8();
+                let op = match op_byte {
+                    0 => CmpOp::Eq,
+                    1 => CmpOp::Ne,
+                    2 => CmpOp::Lt,
+                    3 => CmpOp::Gt,
+                    4 => CmpOp::Le,
+                    5 => CmpOp::Ge,
+                    _ => {
+                        // op is unknown, still read the scalar to advance the cursor
+                        let _val = self.read_scalar();
+                        return FilterNode::Unhandled(255);
+                    }
+                };
+                let val = self.read_scalar();
+                FilterNode::Compare { col, op, val }
+            }
+            1 => FilterNode::IsNull {
+                col: self.read_u32() as usize,
+            },
+            2 => FilterNode::IsNotNull {
+                col: self.read_u32() as usize,
+            },
+            3 => {
+                let n = self.read_u32() as usize;
+                let children = (0..n).map(|_| self.read_node_inner(depth + 1)).collect();
+                FilterNode::And(children)
+            }
+            4 => {
+                let n = self.read_u32() as usize;
+                let children = (0..n).map(|_| self.read_node_inner(depth + 1)).collect();
+                FilterNode::Or(children)
+            }
+            5 => {
+                let col = self.read_u32() as usize;
+                let n = self.read_u32() as usize;
+                let vals = (0..n).map(|_| self.read_scalar()).collect();
+                FilterNode::In { col, vals }
+            }
+            255 => FilterNode::Unhandled(self.read_u32()),
+            tag => FilterNode::Unhandled(tag as u32),
+        }
+    }
+}
+
+/// Decode the wire-format filter buffer into a `FilterNode` tree.
+/// An empty buffer means "keep all rows" → returns `And([])`.
+pub(crate) fn decode(buf: &[u8]) -> FilterNode {
+    if buf.is_empty() {
+        return FilterNode::And(vec![]);
+    }
+    let mut cursor = Cursor::new(buf);
+    cursor.read_node()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Evaluator
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Evaluate a filter node against a projected `RecordBatch`, returning a boolean mask.
+/// Column indices in the `FilterNode` refer to positions in the projected batch.
+pub(crate) fn evaluate(node: &FilterNode, batch: &RecordBatch) -> Result<BooleanArray, FilterError> {
+    match node {
+        FilterNode::Unhandled(k) => Err(FilterError::Unhandled(format!("TableFilterType {k}"))),
+
+        FilterNode::And(children) => {
+            let mut acc = BooleanArray::from(vec![true; batch.num_rows()]);
+            for c in children {
+                let child_mask = evaluate(c, batch)?;
+                acc = boolean::and(&acc, &child_mask).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            }
+            Ok(acc)
+        }
+
+        FilterNode::Or(children) => {
+            let mut acc = BooleanArray::from(vec![false; batch.num_rows()]);
+            for c in children {
+                let child_mask = evaluate(c, batch)?;
+                acc = boolean::or(&acc, &child_mask).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            }
+            Ok(acc)
+        }
+
+        FilterNode::IsNull { col } => {
+            is_null(batch.column(*col).as_ref()).map_err(|e| FilterError::Unhandled(e.to_string()))
+        }
+
+        FilterNode::IsNotNull { col } => {
+            is_not_null(batch.column(*col).as_ref()).map_err(|e| FilterError::Unhandled(e.to_string()))
+        }
+
+        FilterNode::In { col, vals } => {
+            // OR of equality comparisons; NULLs in the column are never matched (DuckDB semantics).
+            let col_arr = batch.column(*col);
+            let mut acc = BooleanArray::from(vec![false; batch.num_rows()]);
+            for val in vals {
+                let eq_mask = compare(col_arr, &CmpOp::Eq, val)?;
+                // `compare` with a non-null scalar returns a BooleanArray where null column
+                // entries produce null in the mask — coerce them to false so they don't match.
+                let n = eq_mask.len();
+                let eq_no_null = BooleanArray::from(
+                    (0..n)
+                        .map(|i| eq_mask.is_valid(i) && eq_mask.value(i))
+                        .collect::<Vec<bool>>(),
+                );
+                acc = boolean::or(&acc, &eq_no_null).map_err(|e| FilterError::Unhandled(e.to_string()))?;
+            }
+            Ok(acc)
+        }
+
+        FilterNode::Compare { col, op, val } => compare(batch.column(*col), op, val),
+    }
+}
+
+/// Build a one-element typed scalar matching the column's DataType from the incoming `val`,
+/// then dispatch the comparison kernel.
+///
+/// The column DataType drives the cast so that the arrow-compute kernel sees matching types
+/// on both sides (e.g. `Int32Array` column + `Int32Array` scalar, not Int32 vs Int64).
+/// DuckDB pushes scalars as i64/u64/f64/bool/utf8; we widen/narrow to the column type.
+/// Any scalar/column-type combo we haven't explicitly mapped → `FilterError` (never silently wrong).
+fn compare(col: &ArrayRef, op: &CmpOp, val: &ScalarVal) -> Result<BooleanArray, FilterError> {
+    if matches!(val, ScalarVal::Null) {
+        // NULL comparison always yields false (SQL semantics).
+        return Ok(BooleanArray::from(vec![false; col.len()]));
+    }
+    if matches!(val, ScalarVal::Unsupported) {
+        return Err(FilterError::Unhandled("unsupported scalar type: Unsupported".into()));
+    }
+
+    let col_type = col.data_type();
+
+    match (col_type, val) {
+        // ── Signed integers (DuckDB pushes as I64) ─────────────────────────────
+        (DataType::Int64, ScalarVal::I64(v)) => dispatch(op, col, &Scalar::new(Int64Array::from(vec![*v]))),
+        // Narrowing uses checked `try_from`: an out-of-range pushed constant must fail loud
+        // (→ error_stream), never silently wrap and produce a wrong row set.
+        (DataType::Int32, ScalarVal::I64(v)) => {
+            let n = i32::try_from(*v)
+                .map_err(|_| FilterError::Unhandled(format!("i64 value {v} out of range for Int32 column")))?;
+            dispatch(op, col, &Scalar::new(Int32Array::from(vec![n])))
+        }
+        (DataType::Int16, ScalarVal::I64(v)) => {
+            let n = i16::try_from(*v)
+                .map_err(|_| FilterError::Unhandled(format!("i64 value {v} out of range for Int16 column")))?;
+            dispatch(op, col, &Scalar::new(Int16Array::from(vec![n])))
+        }
+        (DataType::Int8, ScalarVal::I64(v)) => {
+            let n = i8::try_from(*v)
+                .map_err(|_| FilterError::Unhandled(format!("i64 value {v} out of range for Int8 column")))?;
+            dispatch(op, col, &Scalar::new(Int8Array::from(vec![n])))
+        }
+
+        // ── Unsigned integers (DuckDB pushes as U64) ───────────────────────────
+        (DataType::UInt64, ScalarVal::U64(v)) => dispatch(op, col, &Scalar::new(UInt64Array::from(vec![*v]))),
+        (DataType::UInt32, ScalarVal::U64(v)) => {
+            let n = u32::try_from(*v)
+                .map_err(|_| FilterError::Unhandled(format!("u64 value {v} out of range for UInt32 column")))?;
+            dispatch(op, col, &Scalar::new(UInt32Array::from(vec![n])))
+        }
+        (DataType::UInt16, ScalarVal::U64(v)) => {
+            let n = u16::try_from(*v)
+                .map_err(|_| FilterError::Unhandled(format!("u64 value {v} out of range for UInt16 column")))?;
+            dispatch(op, col, &Scalar::new(UInt16Array::from(vec![n])))
+        }
+        (DataType::UInt8, ScalarVal::U64(v)) => {
+            let n = u8::try_from(*v)
+                .map_err(|_| FilterError::Unhandled(format!("u64 value {v} out of range for UInt8 column")))?;
+            dispatch(op, col, &Scalar::new(UInt8Array::from(vec![n])))
+        }
+
+        // ── Floats (DuckDB pushes as F64) ──────────────────────────────────────
+        (DataType::Float64, ScalarVal::F64(v)) => dispatch(op, col, &Scalar::new(Float64Array::from(vec![*v]))),
+        // Float32: f64 → f32 cast is a deliberate precision round, not a correctness issue
+        (DataType::Float32, ScalarVal::F64(v)) => dispatch(op, col, &Scalar::new(Float32Array::from(vec![*v as f32]))),
+
+        // ── Boolean ────────────────────────────────────────────────────────────
+        (DataType::Boolean, ScalarVal::Bool(v)) => dispatch(op, col, &Scalar::new(BooleanArray::from(vec![*v]))),
+
+        // ── Strings ────────────────────────────────────────────────────────────
+        (DataType::Utf8, ScalarVal::Utf8(v)) => dispatch(op, col, &Scalar::new(StringArray::from(vec![v.as_str()]))),
+        // LargeUtf8: present for completeness; DuckDB's arrow_scan rarely emits it
+        (DataType::LargeUtf8, ScalarVal::Utf8(v)) => {
+            dispatch(op, col, &Scalar::new(LargeStringArray::from(vec![v.as_str()])))
+        }
+
+        // ── Anything else → clean error (never silently wrong) ─────────────────
+        _ => Err(FilterError::Unhandled(format!(
+            "unsupported column/scalar combination: {:?} / {:?}",
+            col_type, val
+        ))),
+    }
+}
+
+fn dispatch(op: &CmpOp, l: &dyn arrow::array::Datum, r: &dyn arrow::array::Datum) -> Result<BooleanArray, FilterError> {
+    let out = match op {
+        CmpOp::Eq => cmp::eq(l, r),
+        CmpOp::Ne => cmp::neq(l, r),
+        CmpOp::Lt => cmp::lt(l, r),
+        CmpOp::Gt => cmp::gt(l, r),
+        CmpOp::Le => cmp::lt_eq(l, r),
+        CmpOp::Ge => cmp::gt_eq(l, r),
+    };
+    out.map_err(|e| FilterError::Unhandled(e.to_string()))
+}

--- a/crates/duckdb/src/arrow_zerocopy/mod.rs
+++ b/crates/duckdb/src/arrow_zerocopy/mod.rs
@@ -414,12 +414,12 @@ mod test {
         use super::filter::{FilterNode, evaluate};
         // sample(): region (col 1) = [us, eu, NULL, us]
         let batch = sample();
-        let null_mask = evaluate(&FilterNode::IsNull { col: 1 }, &batch).unwrap();
+        let null_mask = evaluate(&FilterNode::IsNull { path: vec![1] }, &batch).unwrap();
         assert_eq!(
             null_mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
             vec![false, false, true, false]
         );
-        let not_null_mask = evaluate(&FilterNode::IsNotNull { col: 1 }, &batch).unwrap();
+        let not_null_mask = evaluate(&FilterNode::IsNotNull { path: vec![1] }, &batch).unwrap();
         assert_eq!(
             not_null_mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
             vec![true, true, false, true]
@@ -433,12 +433,12 @@ mod test {
         let batch = sample();
         let node = FilterNode::Or(vec![
             FilterNode::Compare {
-                col: 0,
+                path: vec![0],
                 op: CmpOp::Eq,
                 val: ScalarVal::I64(1),
             },
             FilterNode::Compare {
-                col: 0,
+                path: vec![0],
                 op: CmpOp::Eq,
                 val: ScalarVal::I64(4),
             },
@@ -456,7 +456,7 @@ mod test {
         // sample(): region (col 1) = [us, eu, NULL, us]; region IN ('us') must NOT match the NULL row
         let batch = sample();
         let node = FilterNode::In {
-            col: 1,
+            path: vec![1],
             vals: vec![ScalarVal::Utf8("us".into())],
         };
         let mask = evaluate(&node, &batch).unwrap();
@@ -549,7 +549,7 @@ mod test {
         // sample_types(): i32 (col 0) = [-1, 0, 1, 2, 3]; i32 >= 0 → [false, true, true, true, true]
         let batch = sample_types();
         let node = FilterNode::Compare {
-            col: 0,
+            path: vec![0],
             op: CmpOp::Ge,
             val: ScalarVal::I64(0),
         };
@@ -566,7 +566,7 @@ mod test {
         // sample_types(): u32 (col 1) = [10, 50, 99, 100, 200]; u32 < 100 → [true, true, true, false, false]
         let batch = sample_types();
         let node = FilterNode::Compare {
-            col: 1,
+            path: vec![1],
             op: CmpOp::Lt,
             val: ScalarVal::U64(100),
         };
@@ -583,7 +583,7 @@ mod test {
         // sample_types(): f64 (col 2) = [0.5, 1.0, 1.5, 2.0, 2.5]; f64 > 1.5 → [false, false, false, true, true]
         let batch = sample_types();
         let node = FilterNode::Compare {
-            col: 2,
+            path: vec![2],
             op: CmpOp::Gt,
             val: ScalarVal::F64(1.5),
         };
@@ -600,7 +600,7 @@ mod test {
         // sample_types(): b (col 3) = [true, false, true, false, true]; b = true → [true, false, true, false, true]
         let batch = sample_types();
         let node = FilterNode::Compare {
-            col: 3,
+            path: vec![3],
             op: CmpOp::Eq,
             val: ScalarVal::Bool(true),
         };
@@ -616,7 +616,7 @@ mod test {
         use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
         // Int32 column (col 0) with an F64 scalar — no arm covers this combo; must fail loud.
         let node = FilterNode::Compare {
-            col: 0,
+            path: vec![0],
             op: CmpOp::Eq,
             val: ScalarVal::F64(1.0),
         };
@@ -635,7 +635,7 @@ mod test {
         let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int8, false)]));
         let batch = RecordBatch::try_new(schema, vec![Arc::new(Int8Array::from(vec![1i8, 2, 3]))]).unwrap();
         let node = FilterNode::Compare {
-            col: 0,
+            path: vec![0],
             op: CmpOp::Ge,
             val: ScalarVal::I64(300),
         };
@@ -672,6 +672,82 @@ mod test {
         let conn = Connection::open_in_memory().unwrap();
         let result = conn.register_arrow("v", vec![batch1, batch2]);
         assert!(result.is_err(), "mismatched schemas must return Err");
+    }
+
+    #[test]
+    fn struct_extract_filter_matches_appender() {
+        use arrow::array::{ArrayRef, Int64Array, StructArray};
+        use arrow::datatypes::{DataType, Field, Fields};
+        // Column `s STRUCT(id BIGINT, score BIGINT)` with all-valid structs. (A null-struct row is
+        // deliberately NOT used here: DuckDB's native Appender ingestion and its Arrow-scan path
+        // diverge on struct-null propagation — extracting a field from a NULL struct is NULL in the
+        // Arrow path but the Appender stores the child value — so a null-struct row is not a sound
+        // oracle comparison. The null-struct masking semantics are asserted directly in
+        // `struct_path_null_struct_masking_direct`.)
+        let id = Arc::new(Int64Array::from(vec![1i64, 2, 3, 4])) as ArrayRef;
+        let score = Arc::new(Int64Array::from(vec![10i64, 20, 30, 40])) as ArrayRef;
+        let fields: Fields = vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("score", DataType::Int64, false),
+        ]
+        .into();
+        let s = Arc::new(StructArray::new(fields.clone(), vec![id, score], None)) as ArrayRef;
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Struct(fields), true)]));
+        let batch = RecordBatch::try_new(schema, vec![s]).unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (s STRUCT(id BIGINT, score BIGINT))").unwrap();
+        {
+            let mut app = conn.appender("t").unwrap();
+            app.append_record_batch(batch.clone()).unwrap();
+        }
+        let reg = conn.register_arrow("v", vec![batch]).unwrap();
+
+        let q = |sql: String| conn.query_row::<i64, _, _>(&sql, [], |r| r.get(0)).unwrap();
+        for where_clause in ["WHERE s.id > 2", "WHERE s.score = 20", "WHERE s.id IS NOT NULL"] {
+            assert_eq!(
+                q(format!("SELECT count(*) FROM v {where_clause}")),
+                q(format!("SELECT count(*) FROM t {where_clause}")),
+                "struct-field filter must match the Appender oracle: {where_clause}"
+            );
+        }
+        drop(reg);
+    }
+
+    #[test]
+    fn struct_path_null_struct_masking_direct() {
+        // Directly asserts the SQL-correct semantics for a NULL struct: extracting a field from a
+        // null struct yields NULL, so `s.id > 2` must EXCLUDE a null-struct row (even when the
+        // child slot holds a value), and `s.id IS NULL` must be TRUE for it. This is what
+        // resolve_path's ancestor-valid masking provides; it cannot be checked against the Appender
+        // oracle because DuckDB's native ingestion mishandles null-struct child values.
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        use arrow::array::{Array, ArrayRef, Int64Array, StructArray};
+        use arrow::buffer::NullBuffer;
+        use arrow::datatypes::{DataType, Field, Fields};
+        let id = Arc::new(Int64Array::from(vec![1i64, 2, 3, 4])) as ArrayRef;
+        let fields: Fields = vec![Field::new("id", DataType::Int64, false)].into();
+        let nulls = NullBuffer::from(vec![true, true, false, true]); // row 2 = NULL struct
+        let s = Arc::new(StructArray::new(fields.clone(), vec![id], Some(nulls))) as ArrayRef;
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Struct(fields), true)]));
+        let batch = RecordBatch::try_new(schema, vec![s]).unwrap();
+
+        let bits = |node: FilterNode| -> Vec<bool> {
+            let m = evaluate(&node, &batch).unwrap();
+            (0..m.len()).map(|i| m.is_valid(i) && m.value(i)).collect()
+        };
+        // s.id > 2 : row 2 (null struct) excluded despite child id=3; only row 3 (id=4) kept.
+        assert_eq!(
+            bits(FilterNode::Compare { path: vec![0, 0], op: CmpOp::Gt, val: ScalarVal::I64(2) }),
+            vec![false, false, false, true],
+            "null-struct row must be excluded from s.id > 2"
+        );
+        // s.id IS NULL : only the null-struct row (row 2) reads as NULL.
+        assert_eq!(
+            bits(FilterNode::IsNull { path: vec![0, 0] }),
+            vec![false, false, true, false],
+            "field of a null struct must read as NULL"
+        );
     }
 
     #[test]

--- a/crates/duckdb/src/arrow_zerocopy/mod.rs
+++ b/crates/duckdb/src/arrow_zerocopy/mod.rs
@@ -11,17 +11,23 @@
 //! buffer that is decoded and evaluated in Rust before returning each stream. The following filter
 //! kinds are handled end-to-end:
 //!
-//! * `CONSTANT_COMPARISON` (eq / ne / lt / gt / le / ge)
+//! * `CONSTANT_COMPARISON` (eq / ne / lt / gt / le / ge) over all pushable scalar types: ints,
+//!   unsigned, float/double (incl. NaN total-order), bool, Utf8, Blob, Date, Time (µs),
+//!   Timestamp (all four DuckDB units incl. TZ), Decimal128.
 //! * `IS_NULL` / `IS_NOT_NULL`
 //! * `CONJUNCTION_AND` / `CONJUNCTION_OR` (nested trees)
 //! * `IN_FILTER`
+//! * `STRUCT_EXTRACT` — struct-field (column-path) predicates via recursive descent.
 //!
 //! The following are safely skipped (the outer query re-checks):
 //!
 //! * `OPTIONAL_FILTER` — a hint; correctness is guaranteed by the join.
 //! * `DYNAMIC_FILTER` / `BLOOM_FILTER` — join-reduction filters; re-checked by the join.
 //!
-//! Any other filter kind causes an error stream (fail-loud, never silently wrong).
+//! On DuckDB v1.5.4 the optimizer routes every pushable arrow-scan filter to one of these
+//! structured kinds (it constant-folds expressions and keeps genuinely-complex predicates above
+//! the scan). The catch-all `EXPRESSION_FILTER` kind is not emitted; should one ever appear it
+//! produces a clean error stream (fail-loud, never silently wrong).
 
 pub(crate) mod filter;
 
@@ -219,10 +225,15 @@ impl Connection {
     ///
     /// Scans reference the held Arrow buffers in place — no copy into DuckDB storage. The
     /// factory is replayable (a fresh stream per scan, so self-joins work) and honors both
-    /// **projection pushdown** (DuckDB selects only needed columns) and **filter pushdown**
-    /// (CONSTANT_COMPARISON, IS_NULL/IS_NOT_NULL, CONJUNCTION_AND/OR, IN_FILTER are evaluated
-    /// in Rust; OPTIONAL/DYNAMIC/BLOOM filters are safely skipped; any other kind causes an
-    /// error stream).
+    /// **projection pushdown** (DuckDB selects only needed columns) and **filter pushdown**:
+    /// constant comparisons, IS [NOT] NULL, IN, AND/OR, and STRUCT_EXTRACT
+    /// (struct-field) predicates are evaluated in Rust over scalars of all pushable types (ints,
+    /// unsigned, float/double incl. NaN total-order, bool, Utf8, Blob, Date, Time (µs), Timestamp,
+    /// Decimal128). OPTIONAL/DYNAMIC/BLOOM filters are safely skipped. On DuckDB v1.5.4 the
+    /// optimizer routes every pushable arrow-scan filter to one of these structured kinds (it
+    /// constant-folds expressions and keeps genuinely-complex predicates above the scan), so the
+    /// catch-all EXPRESSION_FILTER kind is not emitted here; should one ever appear it produces a
+    /// clean error stream (fail-loud, never silently wrong).
     ///
     /// Dropping the returned [`ArrowView`] automatically unregisters the view from DuckDB
     /// (via `DROP VIEW IF EXISTS`) before freeing the factory memory, so a late scan errors

--- a/crates/duckdb/src/arrow_zerocopy/mod.rs
+++ b/crates/duckdb/src/arrow_zerocopy/mod.rs
@@ -1,0 +1,717 @@
+//! Zero-copy Arrow registration via DuckDB's native `arrow_scan` table function.
+//!
+//! Registers a set of held Arrow `RecordBatch`es as a DuckDB view whose scans reference the Arrow
+//! buffers in place (no copy into DuckDB native storage), unlike the `Appender`. The factory is
+//! replayable (a fresh stream per scan, so self-joins work) and honors both projection and filter
+//! pushdown.
+//!
+//! # Filter pushdown
+//!
+//! The C++ shim serialises DuckDB's `TableFilterSet` into a compact little-endian wire-format
+//! buffer that is decoded and evaluated in Rust before returning each stream. The following filter
+//! kinds are handled end-to-end:
+//!
+//! * `CONSTANT_COMPARISON` (eq / ne / lt / gt / le / ge)
+//! * `IS_NULL` / `IS_NOT_NULL`
+//! * `CONJUNCTION_AND` / `CONJUNCTION_OR` (nested trees)
+//! * `IN_FILTER`
+//!
+//! The following are safely skipped (the outer query re-checks):
+//!
+//! * `OPTIONAL_FILTER` — a hint; correctness is guaranteed by the join.
+//! * `DYNAMIC_FILTER` / `BLOOM_FILTER` — join-reduction filters; re-checked by the join.
+//!
+//! Any other filter kind causes an error stream (fail-loud, never silently wrong).
+
+pub(crate) mod filter;
+
+use std::ffi::{CString, c_char, c_void};
+use std::os::raw::c_int;
+
+use arrow::datatypes::SchemaRef;
+use arrow::ffi::FFI_ArrowSchema;
+use arrow::ffi_stream::FFI_ArrowArrayStream;
+use arrow::record_batch::{RecordBatch, RecordBatchIterator};
+
+use crate::error::Error;
+use crate::inner_connection::InnerConnection;
+use crate::{Connection, Result};
+
+type ProduceFn = extern "C" fn(*mut c_void, *const *const c_char, usize, *const u8, usize, *mut FFI_ArrowArrayStream);
+type GetSchemaFn = extern "C" fn(*mut c_void, *mut FFI_ArrowSchema);
+
+// SAFETY: layout matched by the C++ `RustCallbacks` prefix; the two fn pointers MUST stay first.
+#[repr(C)]
+struct ArrowFactory {
+    produce: ProduceFn,
+    get_schema: GetSchemaFn,
+    batches: Vec<RecordBatch>,
+    schema: SchemaRef,
+}
+
+unsafe extern "C" {
+    fn ddb_rs_arrow_register(conn: crate::ffi::duckdb_connection, name: *const c_char, factory: *mut c_void) -> c_int;
+}
+
+/// Handle to a live zero-copy Arrow registration created by [`Connection::register_arrow`].
+///
+/// Dropping this handle automatically unregisters the view from DuckDB (via `DROP VIEW IF EXISTS`)
+/// **before** freeing the factory memory it points at, so a late scan errors cleanly ("view not
+/// found") rather than dereferencing freed memory.
+///
+/// The `'conn` lifetime borrow guarantees the connection outlives the view.
+///
+/// # Thread safety
+///
+/// `ArrowView` is `!Send` and `!Sync`: it holds a raw pointer to the factory and is tied to the
+/// single-threaded [`Connection`] model of this crate.
+pub struct ArrowView<'conn> {
+    conn: &'conn Connection,
+    name: String,
+    factory: *mut ArrowFactory,
+}
+
+impl Drop for ArrowView<'_> {
+    fn drop(&mut self) {
+        // Unregister the view BEFORE freeing the factory it points at, so a later scan can't
+        // dereference freed memory (it errors cleanly with "view not found" instead).
+        let escaped = self.name.replace('"', "\"\"");
+        let _ = self.conn.execute_batch(&format!("DROP VIEW IF EXISTS \"{escaped}\""));
+        // SAFETY: factory came from Box::into_raw in register_arrow; freed exactly once.
+        unsafe { drop(Box::from_raw(self.factory)) };
+    }
+}
+
+/// Build a non-null-callback error stream so that DuckDB's `get_next` call returns an Arrow error
+/// rather than dereferencing a null function pointer. A null `get_next` (from `empty()`) would
+/// segfault inside `ArrowArrayStreamWrapper::GetNextChunk`, which has no null guard.
+fn error_stream(schema: SchemaRef, msg: String) -> FFI_ArrowArrayStream {
+    let iter = std::iter::once::<arrow::error::Result<RecordBatch>>(Err(arrow::error::ArrowError::ComputeError(msg)));
+    FFI_ArrowArrayStream::new(Box::new(RecordBatchIterator::new(iter, schema)))
+}
+
+/// Resolve column name pointers to schema indices.
+fn resolve_indices(f: &ArrowFactory, names: *const *const c_char, n: usize) -> Result<Vec<usize>, String> {
+    if n == 0 {
+        return Ok((0..f.schema.fields().len()).collect());
+    }
+    let name_ptrs = unsafe { std::slice::from_raw_parts(names, n) };
+    name_ptrs
+        .iter()
+        .map(|&p| {
+            let name = unsafe { std::ffi::CStr::from_ptr(p) }
+                .to_str()
+                .map_err(|e| format!("column name is not valid UTF-8: {e}"))?;
+            f.schema
+                .index_of(name)
+                .map_err(|_| format!("projected column '{name}' not found in schema"))
+        })
+        .collect::<Result<Vec<usize>, String>>()
+}
+
+/// Build the projected and filter-applied [`FFI_ArrowArrayStream`], returning an error message on failure.
+/// Also returns the projected [`SchemaRef`] so callers can use it for error streams.
+fn build_stream_filtered(
+    f: &ArrowFactory,
+    names: *const *const c_char,
+    n: usize,
+    filter_ptr: *const u8,
+    filter_len: usize,
+) -> Result<(FFI_ArrowArrayStream, SchemaRef), String> {
+    // Resolve projected indices and build the projected schema ONCE up front.
+    let indices = resolve_indices(f, names, n)?;
+    let proj_schema: SchemaRef =
+        std::sync::Arc::new(f.schema.project(&indices).map_err(|e| format!("project schema: {e}"))?);
+
+    // Project batches using the already-resolved indices.
+    let projected: Vec<RecordBatch> = f
+        .batches
+        .iter()
+        .map(|b| b.project(&indices).map_err(|e| e.to_string()))
+        .collect::<Result<Vec<RecordBatch>, String>>()?;
+
+    // Decode + apply filter
+    let filter_buf = if filter_ptr.is_null() || filter_len == 0 {
+        &[][..]
+    } else {
+        unsafe { std::slice::from_raw_parts(filter_ptr, filter_len) }
+    };
+    let node = filter::decode(filter_buf);
+
+    let filtered: Vec<RecordBatch> = projected
+        .into_iter()
+        .map(|b| {
+            let mask = filter::evaluate(&node, &b).map_err(|e| e.to_string())?;
+            arrow::compute::filter_record_batch(&b, &mask).map_err(|e| e.to_string())
+        })
+        .collect::<Result<Vec<RecordBatch>, String>>()?;
+
+    // `proj_schema` already computed above — no second resolve_indices call needed even when
+    // all rows are filtered out or batches are empty.
+    let reader = RecordBatchIterator::new(
+        filtered.into_iter().map(Ok::<RecordBatch, arrow::error::ArrowError>),
+        proj_schema.clone(),
+    );
+    Ok((FFI_ArrowArrayStream::new(Box::new(reader)), proj_schema))
+}
+
+extern "C" fn rust_produce(
+    factory: *mut c_void,
+    names: *const *const c_char,
+    n: usize,
+    filter_ptr: *const u8,
+    filter_len: usize,
+    out: *mut FFI_ArrowArrayStream,
+) {
+    // Read the factory pointer BEFORE the fallible work so it is available on the recovery path.
+    // SAFETY: factory is valid for the lifetime of the ArrowView, which must outlive
+    // any scan callback (documented on ArrowView).
+    let f = unsafe { &*(factory as *const ArrowFactory) };
+
+    // Compute the projected schema up front so error streams carry the right schema.
+    // Fall back to the full schema only when projection itself fails (e.g. unknown column name).
+    let projected_schema: SchemaRef = resolve_indices(f, names, n)
+        .and_then(|indices| {
+            f.schema
+                .project(&indices)
+                .map(std::sync::Arc::new)
+                .map_err(|e| e.to_string())
+        })
+        .unwrap_or_else(|_| f.schema.clone());
+
+    let stream = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        build_stream_filtered(f, names, n, filter_ptr, filter_len)
+    })) {
+        Ok(Ok((s, _proj_schema))) => s,
+        Ok(Err(msg)) => error_stream(projected_schema, msg),
+        Err(_) => error_stream(
+            projected_schema,
+            "arrow zero-copy factory panicked in produce".to_string(),
+        ),
+    };
+    // SAFETY: `out` is a valid, uninitialized output slot provided by DuckDB's shim.
+    unsafe { std::ptr::write(out, stream) };
+}
+
+extern "C" fn rust_get_schema(factory: *mut c_void, out: *mut FFI_ArrowSchema) {
+    let result = std::panic::catch_unwind(|| unsafe {
+        let f = &*(factory as *const ArrowFactory);
+        let schema = FFI_ArrowSchema::try_from(f.schema.as_ref()).expect("export schema");
+        std::ptr::write(out, schema);
+    });
+    if result.is_err() {
+        // empty() yields a less-actionable downstream error than the produce-path error stream; acceptable at bind time.
+        unsafe { std::ptr::write(out, FFI_ArrowSchema::empty()) };
+    }
+}
+
+/// Build a generic DuckDB-failure error with a message (the crate's `Error` has no plain
+/// string variant; this mirrors `error.rs`'s `Error::DuckDBFailure(ffi::Error::new(code), msg)`).
+fn duckdb_err(msg: impl Into<String>) -> Error {
+    Error::DuckDBFailure(
+        crate::ffi::Error::new(crate::ffi::duckdb_state_DuckDBError),
+        Some(msg.into()),
+    )
+}
+
+impl Connection {
+    /// Register `batches` as a zero-copy Arrow view named `name` on this connection.
+    ///
+    /// Scans reference the held Arrow buffers in place — no copy into DuckDB storage. The
+    /// factory is replayable (a fresh stream per scan, so self-joins work) and honors both
+    /// **projection pushdown** (DuckDB selects only needed columns) and **filter pushdown**
+    /// (CONSTANT_COMPARISON, IS_NULL/IS_NOT_NULL, CONJUNCTION_AND/OR, IN_FILTER are evaluated
+    /// in Rust; OPTIONAL/DYNAMIC/BLOOM filters are safely skipped; any other kind causes an
+    /// error stream).
+    ///
+    /// Dropping the returned [`ArrowView`] automatically unregisters the view from DuckDB
+    /// (via `DROP VIEW IF EXISTS`) before freeing the factory memory, so a late scan errors
+    /// cleanly rather than dereferencing freed memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `batches` is empty, if any batch has a schema that does not match
+    /// the first batch's schema, or if DuckDB fails to create the view.
+    ///
+    /// # Thread safety
+    ///
+    /// [`ArrowView`] is `!Send` and `!Sync` — it is tied to the single-threaded [`Connection`]
+    /// model of this crate.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use duckdb::Connection;
+    /// # use duckdb::arrow::array::Int64Array;
+    /// # use duckdb::arrow::datatypes::{DataType, Field, Schema};
+    /// # use duckdb::arrow::record_batch::RecordBatch;
+    /// # use std::sync::Arc;
+    /// let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+    /// let arr = Arc::new(Int64Array::from(vec![1i64, 2, 3, 4, 5]));
+    /// let batch = RecordBatch::try_new(schema, vec![arr]).unwrap();
+    ///
+    /// let conn = Connection::open_in_memory().unwrap();
+    /// let _view = conn.register_arrow("nums", vec![batch]).unwrap();
+    ///
+    /// // Filtered + projected query — filter is pushed into the Rust evaluator:
+    /// let sum: i64 = conn
+    ///     .query_row("SELECT sum(v) FROM nums WHERE v > 2", [], |r| r.get(0))
+    ///     .unwrap();
+    /// assert_eq!(sum, 12); // 3 + 4 + 5
+    /// ```
+    pub fn register_arrow(&self, name: &str, batches: Vec<RecordBatch>) -> Result<ArrowView<'_>> {
+        // Fail (without allocating the factory) before Box::into_raw so nothing can leak.
+        let cname = CString::new(name).map_err(Error::NulError)?;
+        let schema = batches
+            .first()
+            .map(|b| b.schema())
+            .ok_or_else(|| duckdb_err("register_arrow: empty batches"))?;
+        for b in &batches {
+            if b.schema() != schema {
+                return Err(duckdb_err("register_arrow: all batches must share the same schema"));
+            }
+        }
+        let factory_ptr = Box::into_raw(Box::new(ArrowFactory {
+            produce: rust_produce,
+            get_schema: rust_get_schema,
+            batches,
+            schema,
+        }));
+        match self
+            .db
+            .borrow_mut()
+            .register_arrow_inner(cname.as_ptr(), factory_ptr.cast::<c_void>())
+        {
+            Ok(()) => Ok(ArrowView {
+                conn: self,
+                name: name.to_owned(),
+                factory: factory_ptr,
+            }),
+            Err(e) => {
+                // SAFETY: registration failed, reclaim the box we just leaked.
+                unsafe { drop(Box::from_raw(factory_ptr)) };
+                Err(e)
+            }
+        }
+    }
+}
+
+impl InnerConnection {
+    fn register_arrow_inner(&mut self, name: *const c_char, factory: *mut c_void) -> Result<()> {
+        // SAFETY: `self.con` is a live duckdb_connection; the shim returns 0 on success.
+        let rc = unsafe { ddb_rs_arrow_register(self.con, name, factory) };
+        if rc != 0 {
+            return Err(duckdb_err(
+                "ddb_rs_arrow_register failed (C++ exception in arrow_scan/CreateView)",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn sample() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int64, false),
+            Field::new("region", DataType::Utf8, true),
+        ]));
+        let k = Int64Array::from(vec![1, 2, 3, 4]);
+        let region = StringArray::from(vec![Some("us"), Some("eu"), None, Some("us")]);
+        RecordBatch::try_new(schema, vec![Arc::new(k), Arc::new(region)]).unwrap()
+    }
+
+    #[test]
+    fn round_trip_select_star() {
+        let conn = Connection::open_in_memory().unwrap();
+        let batch = sample();
+        let reg = conn.register_arrow("v", vec![batch.clone()]).unwrap();
+        // count
+        let n: i64 = conn.query_row("SELECT count(*) FROM v", [], |r| r.get(0)).unwrap();
+        assert_eq!(n, 4);
+        // sum of k
+        let sum_k: i64 = conn.query_row("SELECT sum(k) FROM v", [], |r| r.get(0)).unwrap();
+        assert_eq!(sum_k, 10);
+        drop(reg); // handle dropped after queries (lifetime rule)
+    }
+
+    #[test]
+    fn projection_subset() {
+        let conn = Connection::open_in_memory().unwrap();
+        let reg = conn.register_arrow("v", vec![sample()]).unwrap();
+        // Select only `region` — DuckDB pushes a single-column projection into the factory.
+        let count_us: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM (SELECT region FROM v) WHERE region = 'us'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count_us, 2);
+        drop(reg);
+    }
+
+    #[test]
+    fn self_join_is_replayable() {
+        // A self-join scans the view twice → the factory's produce is called more than once.
+        // Each call must yield fresh data (the one-shot deprecated path returns empty on the 2nd).
+        let conn = Connection::open_in_memory().unwrap();
+        let reg = conn.register_arrow("v", vec![sample()]).unwrap();
+        let pairs: i64 = conn
+            .query_row("SELECT count(*) FROM v a JOIN v b ON a.k = b.k", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(pairs, 4); // each of 4 distinct k matches itself exactly once
+        drop(reg);
+    }
+
+    #[test]
+    fn filter_correct_with_pushdown_enabled() {
+        // With filter pushdown ON (default), the C++ shim now serialises filters into the wire
+        // buffer and Rust applies them — correct results without needing disabled_optimizers.
+        let conn = Connection::open_in_memory().unwrap();
+        let reg = conn.register_arrow("v", vec![sample()]).unwrap();
+        // k > 2 keeps k in {3,4} → sum = 7
+        let sum_hi: i64 = conn
+            .query_row("SELECT sum(k) FROM v WHERE k > 2", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(sum_hi, 7);
+        drop(reg);
+    }
+
+    #[test]
+    fn constant_comparison_filter_applied_no_global_setting() {
+        // No `SET disabled_optimizers='filter_pushdown'` — the factory must honor the pushed filter.
+        let conn = Connection::open_in_memory().unwrap();
+        let reg = conn.register_arrow("v", vec![sample()]).unwrap();
+        let sum_gt2: i64 = conn
+            .query_row("SELECT sum(k) FROM v WHERE k > 2", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(sum_gt2, 7); // 3 + 4
+        let cnt_eq: i64 = conn
+            .query_row("SELECT count(*) FROM v WHERE k = 2", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(cnt_eq, 1);
+        drop(reg);
+    }
+
+    #[test]
+    fn unhandled_filter_kind_errors_not_silently_wrong() {
+        use super::filter::{FilterNode, evaluate};
+        let err = evaluate(&FilterNode::Unhandled(9), &sample());
+        assert!(err.is_err(), "unhandled filter kind must error, got {err:?}");
+    }
+
+    // Direct unit tests of the evaluator: DuckDB applies IS_NULL/IS_NOT_NULL/OR above the scan for
+    // simple queries, so the SQL tests don't reliably reach these arms. These exercise them
+    // deterministically (hand-constructed FilterNodes), bypassing the optimizer.
+    #[test]
+    fn evaluate_is_null_and_is_not_null_direct() {
+        use super::filter::{FilterNode, evaluate};
+        // sample(): region (col 1) = [us, eu, NULL, us]
+        let batch = sample();
+        let null_mask = evaluate(&FilterNode::IsNull { col: 1 }, &batch).unwrap();
+        assert_eq!(
+            null_mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![false, false, true, false]
+        );
+        let not_null_mask = evaluate(&FilterNode::IsNotNull { col: 1 }, &batch).unwrap();
+        assert_eq!(
+            not_null_mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![true, true, false, true]
+        );
+    }
+
+    #[test]
+    fn evaluate_or_direct() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        // sample(): k (col 0) = [1, 2, 3, 4]; k = 1 OR k = 4
+        let batch = sample();
+        let node = FilterNode::Or(vec![
+            FilterNode::Compare {
+                col: 0,
+                op: CmpOp::Eq,
+                val: ScalarVal::I64(1),
+            },
+            FilterNode::Compare {
+                col: 0,
+                op: CmpOp::Eq,
+                val: ScalarVal::I64(4),
+            },
+        ]);
+        let mask = evaluate(&node, &batch).unwrap();
+        assert_eq!(
+            mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![true, false, false, true]
+        );
+    }
+
+    #[test]
+    fn evaluate_in_does_not_match_null_column() {
+        use super::filter::{FilterNode, ScalarVal, evaluate};
+        // sample(): region (col 1) = [us, eu, NULL, us]; region IN ('us') must NOT match the NULL row
+        let batch = sample();
+        let node = FilterNode::In {
+            col: 1,
+            vals: vec![ScalarVal::Utf8("us".into())],
+        };
+        let mask = evaluate(&node, &batch).unwrap();
+        assert_eq!(
+            mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![true, false, false, true]
+        );
+    }
+
+    #[test]
+    fn null_and_conjunction_and_in_filters() {
+        let conn = Connection::open_in_memory().unwrap();
+        let reg = conn.register_arrow("v", vec![sample()]).unwrap();
+        let is_null: i64 = conn
+            .query_row("SELECT count(*) FROM v WHERE region IS NULL", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(is_null, 1);
+        let not_null: i64 = conn
+            .query_row("SELECT count(*) FROM v WHERE region IS NOT NULL", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(not_null, 3);
+        let conj: i64 = conn
+            .query_row("SELECT sum(k) FROM v WHERE k > 1 AND k < 4", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(conj, 5); // 2 + 3
+        let in_list: i64 = conn
+            .query_row("SELECT sum(k) FROM v WHERE k IN (1, 3)", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(in_list, 4); // 1 + 3
+        drop(reg);
+    }
+
+    #[test]
+    fn inner_join_with_filter_matches_appender() {
+        // A join can push a dynamic/bloom filter to the arrow scan; skipping those must stay correct
+        // because the join re-checks. Compare the zero-copy result to the Appender's.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t AS SELECT * FROM (VALUES (2),(3),(9)) AS x(k)")
+            .unwrap();
+        let reg = conn.register_arrow("v", vec![sample()]).unwrap();
+        let joined: i64 = conn
+            .query_row("SELECT sum(v.k) FROM v JOIN t ON v.k = t.k WHERE v.k > 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(joined, 5); // v.k in {2,3} match t, >1 → 2+3
+        drop(reg);
+    }
+
+    fn sample_types() -> RecordBatch {
+        use arrow::array::{BooleanArray, Float64Array, Int32Array, StringArray, UInt32Array};
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("i32", DataType::Int32, false),
+            Field::new("u32", DataType::UInt32, false),
+            Field::new("f64", DataType::Float64, false),
+            Field::new("b", DataType::Boolean, false),
+            Field::new("s", DataType::Utf8, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![-1, 0, 1, 2, 3])),
+                Arc::new(UInt32Array::from(vec![10u32, 50, 99, 100, 200])),
+                Arc::new(Float64Array::from(vec![0.5, 1.0, 1.5, 2.0, 2.5])),
+                Arc::new(BooleanArray::from(vec![true, false, true, false, true])),
+                Arc::new(StringArray::from(vec!["x", "y", "x", "z", "x"])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn filter_pushdown_across_scalar_types() {
+        let conn = Connection::open_in_memory().unwrap();
+        let reg = conn.register_arrow("v", vec![sample_types()]).unwrap();
+        let q = |sql: &str| conn.query_row::<i64, _, _>(sql, [], |r| r.get(0)).unwrap();
+        assert_eq!(q("SELECT count(*) FROM v WHERE i32 >= 0"), 4); // 0,1,2,3
+        assert_eq!(q("SELECT count(*) FROM v WHERE u32 < 100"), 3); // 10,50,99
+        assert_eq!(q("SELECT count(*) FROM v WHERE f64 > 1.5"), 2); // 2.0,2.5
+        assert_eq!(q("SELECT count(*) FROM v WHERE b = true"), 3); // 3 trues
+        assert_eq!(q("SELECT count(*) FROM v WHERE s = 'x'"), 3); // 3 x's
+        drop(reg);
+    }
+
+    // Direct unit tests for new compare arms — DuckDB may apply these above the scan
+    // rather than pushing them, so SQL tests alone don't prove the Rust arms ran.
+    #[test]
+    fn evaluate_compare_int32_direct() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        // sample_types(): i32 (col 0) = [-1, 0, 1, 2, 3]; i32 >= 0 → [false, true, true, true, true]
+        let batch = sample_types();
+        let node = FilterNode::Compare {
+            col: 0,
+            op: CmpOp::Ge,
+            val: ScalarVal::I64(0),
+        };
+        let mask = evaluate(&node, &batch).unwrap();
+        assert_eq!(
+            mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![false, true, true, true, true]
+        );
+    }
+
+    #[test]
+    fn evaluate_compare_uint32_direct() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        // sample_types(): u32 (col 1) = [10, 50, 99, 100, 200]; u32 < 100 → [true, true, true, false, false]
+        let batch = sample_types();
+        let node = FilterNode::Compare {
+            col: 1,
+            op: CmpOp::Lt,
+            val: ScalarVal::U64(100),
+        };
+        let mask = evaluate(&node, &batch).unwrap();
+        assert_eq!(
+            mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![true, true, true, false, false]
+        );
+    }
+
+    #[test]
+    fn evaluate_compare_float64_direct() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        // sample_types(): f64 (col 2) = [0.5, 1.0, 1.5, 2.0, 2.5]; f64 > 1.5 → [false, false, false, true, true]
+        let batch = sample_types();
+        let node = FilterNode::Compare {
+            col: 2,
+            op: CmpOp::Gt,
+            val: ScalarVal::F64(1.5),
+        };
+        let mask = evaluate(&node, &batch).unwrap();
+        assert_eq!(
+            mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![false, false, false, true, true]
+        );
+    }
+
+    #[test]
+    fn evaluate_compare_boolean_direct() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        // sample_types(): b (col 3) = [true, false, true, false, true]; b = true → [true, false, true, false, true]
+        let batch = sample_types();
+        let node = FilterNode::Compare {
+            col: 3,
+            op: CmpOp::Eq,
+            val: ScalarVal::Bool(true),
+        };
+        let mask = evaluate(&node, &batch).unwrap();
+        assert_eq!(
+            mask.iter().map(|v| v.unwrap_or(false)).collect::<Vec<_>>(),
+            vec![true, false, true, false, true]
+        );
+    }
+
+    #[test]
+    fn evaluate_compare_unsupported_combo_errors() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        // Int32 column (col 0) with an F64 scalar — no arm covers this combo; must fail loud.
+        let node = FilterNode::Compare {
+            col: 0,
+            op: CmpOp::Eq,
+            val: ScalarVal::F64(1.0),
+        };
+        assert!(
+            evaluate(&node, &sample_types()).is_err(),
+            "mismatched scalar/column type must error, not silently pass"
+        );
+    }
+
+    #[test]
+    fn evaluate_compare_out_of_range_scalar_errors() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        use arrow::array::Int8Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        // Int8 column; scalar 300 (> i8::MAX) must fail loud, NOT wrap to 44 and filter wrongly.
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int8, false)]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(Int8Array::from(vec![1i8, 2, 3]))]).unwrap();
+        let node = FilterNode::Compare {
+            col: 0,
+            op: CmpOp::Ge,
+            val: ScalarVal::I64(300),
+        };
+        assert!(
+            evaluate(&node, &batch).is_err(),
+            "out-of-range scalar must error, not wrap"
+        );
+    }
+
+    #[test]
+    fn drop_unregisters_view() {
+        let conn = Connection::open_in_memory().unwrap();
+        let reg = conn.register_arrow("v", vec![sample()]).unwrap();
+        let n: i64 = conn.query_row("SELECT count(*) FROM v", [], |r| r.get(0)).unwrap();
+        assert_eq!(n, 4);
+        drop(reg);
+        // After drop the view must be gone — query must error.
+        assert!(
+            conn.query_row::<i64, _, _>("SELECT count(*) FROM v", [], |r| r.get(0))
+                .is_err(),
+            "view must be unregistered after the ArrowView is dropped"
+        );
+    }
+
+    #[test]
+    fn mismatched_schemas_error() {
+        use arrow::datatypes::{DataType, Field, Schema};
+        let schema1 = Arc::new(Schema::new(vec![Field::new("a", DataType::Int64, false)]));
+        let schema2 = Arc::new(Schema::new(vec![Field::new("b", DataType::Utf8, false)]));
+        let arr1: Arc<dyn arrow::array::Array> = Arc::new(arrow::array::Int64Array::from(vec![1i64]));
+        let arr2: Arc<dyn arrow::array::Array> = Arc::new(arrow::array::StringArray::from(vec!["x"]));
+        let batch1 = RecordBatch::try_new(schema1, vec![arr1]).unwrap();
+        let batch2 = RecordBatch::try_new(schema2, vec![arr2]).unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        let result = conn.register_arrow("v", vec![batch1, batch2]);
+        assert!(result.is_err(), "mismatched schemas must return Err");
+    }
+
+    #[test]
+    fn multi_column_projection_and_filter_matches_appender() {
+        use arrow::array::{ArrayRef, Int64Array};
+        use arrow::datatypes::{DataType, Field, Schema};
+        // 6 Int64 columns; filter columns that are NOT first in projection order. A filter<->column
+        // mapping bug silently returns wrong rows here — regression guard for the reverse-map bug.
+        let n = 20i64;
+        let fields: Vec<Field> = (0..6)
+            .map(|c| Field::new(format!("c{c}"), DataType::Int64, false))
+            .collect();
+        let schema = Arc::new(Schema::new(fields));
+        let cols: Vec<ArrayRef> = (0..6)
+            .map(|c| Arc::new(Int64Array::from_iter_values((0..n).map(|i| i * 10 + c as i64))) as ArrayRef)
+            .collect();
+        let batch = RecordBatch::try_new(schema, cols).unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (c0 BIGINT, c1 BIGINT, c2 BIGINT, c3 BIGINT, c4 BIGINT, c5 BIGINT)")
+            .unwrap();
+        {
+            let mut app = conn.appender("t").unwrap();
+            app.append_record_batch(batch.clone()).unwrap();
+        }
+        let reg = conn.register_arrow("v", vec![batch]).unwrap();
+
+        // Projects {c1,c3,c5} (a non-prefix subset) and filters non-first columns. The Appender
+        // table `t` is the oracle; the zero-copy view `v` must agree.
+        let where_clause = "WHERE c5 > 50 AND c1 > 30 AND c3 > 20";
+        let q = |sql: String| conn.query_row::<i64, _, _>(&sql, [], |r| r.get(0)).unwrap();
+        assert_eq!(
+            q(format!("SELECT count(*) FROM v {where_clause}")),
+            q(format!("SELECT count(*) FROM t {where_clause}")),
+            "row count must match the Appender oracle"
+        );
+        let v_sum = q(format!("SELECT COALESCE(sum(c1), 0) FROM v {where_clause}"));
+        let t_sum = q(format!("SELECT COALESCE(sum(c1), 0) FROM t {where_clause}"));
+        assert_eq!(v_sum, t_sum, "projected/filtered value must match the Appender oracle");
+        assert!(v_sum > 0, "the test query should select some rows");
+        drop(reg);
+    }
+}

--- a/crates/duckdb/src/arrow_zerocopy/mod.rs
+++ b/crates/duckdb/src/arrow_zerocopy/mod.rs
@@ -751,6 +751,127 @@ mod test {
     }
 
     #[test]
+    fn timestamp_unknown_unit_byte_errors_not_panics() {
+        // An out-of-range timestamp unit byte (from a corrupt/forward-incompatible wire buffer)
+        // must fail loud (FilterError), NOT panic on an out-of-bounds factor-table index.
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        use arrow::array::TimestampMicrosecondArray;
+        use arrow::datatypes::{DataType, Field, TimeUnit};
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            false,
+        )]));
+        let ts = TimestampMicrosecondArray::from(vec![1_000_000i64, 2_000_000, 3_000_000]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ts)]).unwrap();
+        let node = FilterNode::Compare {
+            path: vec![0],
+            op: CmpOp::Gt,
+            val: ScalarVal::Timestamp { unit: 9, v: 1_000_000 }, // 9 = invalid unit byte
+        };
+        assert!(
+            evaluate(&node, &batch).is_err(),
+            "unknown timestamp unit byte must error, not panic"
+        );
+    }
+
+    #[test]
+    fn typed_scalar_filters_match_appender() {
+        use arrow::array::{ArrayRef, BinaryArray, Date32Array, TimestampMicrosecondArray};
+        use arrow::datatypes::{DataType, Field, TimeUnit};
+        // date d (Date32), ts (Timestamp µs, no tz), b (Binary)
+        let d = Arc::new(Date32Array::from(vec![19000i32, 19001, 19002, 19003])) as ArrayRef; // days since epoch
+        let ts = Arc::new(TimestampMicrosecondArray::from(vec![
+            1_000_000i64, 2_000_000, 3_000_000, 4_000_000,
+        ])) as ArrayRef;
+        let b = Arc::new(BinaryArray::from(vec![
+            b"aa".as_ref(), b"bb".as_ref(), b"cc".as_ref(), b"dd".as_ref(),
+        ])) as ArrayRef;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("d", DataType::Date32, false),
+            Field::new("ts", DataType::Timestamp(TimeUnit::Microsecond, None), false),
+            Field::new("b", DataType::Binary, false),
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![d, ts, b]).unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (d DATE, ts TIMESTAMP, b BLOB)").unwrap();
+        {
+            let mut app = conn.appender("t").unwrap();
+            app.append_record_batch(batch.clone()).unwrap();
+        }
+        let reg = conn.register_arrow("v", vec![batch]).unwrap();
+
+        let q = |sql: String| conn.query_row::<i64, _, _>(&sql, [], |r| r.get(0)).unwrap();
+        for where_clause in [
+            "WHERE d > DATE '2022-01-02'",
+            "WHERE ts >= TIMESTAMP '1970-01-01 00:00:03'",
+            "WHERE b = '\\x63\\x63'::BLOB",
+        ] {
+            assert_eq!(
+                q(format!("SELECT count(*) FROM v {where_clause}")),
+                q(format!("SELECT count(*) FROM t {where_clause}")),
+                "typed-scalar filter must match the Appender oracle: {where_clause}"
+            );
+        }
+        drop(reg);
+    }
+
+    #[test]
+    fn decimal128_filter_matches_appender() {
+        use arrow::array::{ArrayRef, Decimal128Array};
+        use arrow::datatypes::{DataType, Field};
+        // DECIMAL(38,2): values 1.00, 2.50, 3.00, 4.25 → unscaled i128 *100
+        let dec = Arc::new(
+            Decimal128Array::from(vec![100i128, 250, 300, 425])
+                .with_precision_and_scale(38, 2)
+                .unwrap(),
+        ) as ArrayRef;
+        let schema = Arc::new(Schema::new(vec![Field::new("p", DataType::Decimal128(38, 2), false)]));
+        let batch = RecordBatch::try_new(schema, vec![dec]).unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE t (p DECIMAL(38,2))").unwrap();
+        {
+            let mut app = conn.appender("t").unwrap();
+            app.append_record_batch(batch.clone()).unwrap();
+        }
+        let reg = conn.register_arrow("v", vec![batch]).unwrap();
+        let q = |sql: String| conn.query_row::<i64, _, _>(&sql, [], |r| r.get(0)).unwrap();
+        for where_clause in ["WHERE p > 2.50", "WHERE p = 3.00", "WHERE p <= 2.50"] {
+            assert_eq!(
+                q(format!("SELECT count(*) FROM v {where_clause}")),
+                q(format!("SELECT count(*) FROM t {where_clause}")),
+                "decimal128 filter must match the Appender oracle: {where_clause}"
+            );
+        }
+        drop(reg);
+    }
+
+    #[test]
+    fn nan_compare_total_order_direct() {
+        use super::filter::{CmpOp, FilterNode, ScalarVal, evaluate};
+        use arrow::array::{Array, Float64Array};
+        use arrow::datatypes::{DataType, Field};
+        // values: 1.0, NaN, 3.0, NULL
+        let schema = Arc::new(Schema::new(vec![Field::new("f", DataType::Float64, true)]));
+        let arr = Float64Array::from(vec![Some(1.0), Some(f64::NAN), Some(3.0), None]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
+        let eval = |op| {
+            let node = FilterNode::Compare { path: vec![0], op, val: ScalarVal::F64(f64::NAN) };
+            let m = evaluate(&node, &batch).unwrap();
+            (0..m.len()).map(|i| m.is_valid(i) && m.value(i)).collect::<Vec<bool>>()
+        };
+        // DuckDB total order: NaN is the largest; NaN == NaN; NULL never matches.
+        assert_eq!(eval(CmpOp::Eq), vec![false, true, false, false]);   // = NaN → only NaN
+        assert_eq!(eval(CmpOp::Ne), vec![true, false, true, false]);    // <> NaN → non-NaN, non-null
+        assert_eq!(eval(CmpOp::Lt), vec![true, false, true, false]);    // < NaN → everything below NaN
+        assert_eq!(eval(CmpOp::Le), vec![true, true, true, false]);     // <= NaN → all non-null
+        assert_eq!(eval(CmpOp::Gt), vec![false, false, false, false]);  // > NaN → nothing
+        assert_eq!(eval(CmpOp::Ge), vec![false, true, false, false]);   // >= NaN → only NaN
+    }
+
+    #[test]
     fn multi_column_projection_and_filter_matches_appender() {
         use arrow::array::{ArrayRef, Int64Array};
         use arrow::datatypes::{DataType, Field, Schema};

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -103,6 +103,10 @@ pub mod core;
 mod error;
 mod appender;
 mod appender_params;
+#[cfg(all(feature = "bundled", feature = "vtab-arrow"))]
+mod arrow_zerocopy;
+#[cfg(all(feature = "bundled", feature = "vtab-arrow"))]
+pub use arrow_zerocopy::ArrowView;
 mod arrow_batch;
 mod cache;
 mod column;

--- a/crates/libduckdb-sys/build_bundled_cc.rs
+++ b/crates/libduckdb-sys/build_bundled_cc.rs
@@ -107,6 +107,11 @@ pub fn main(out_dir: &str, out_path: &Path) {
         cfg.file(f);
     }
 
+    // Zero-copy Arrow registration shim (compiled with the amalgamation so it links against the
+    // DuckDB C++ API and shares its include dirs).
+    cfg.file("src/arrow_zerocopy_shim.cpp");
+    println!("cargo:rerun-if-changed=src/arrow_zerocopy_shim.cpp");
+
     cfg.cpp(true)
         .flag_if_supported("-std=c++11")
         .flag_if_supported("/utf-8")

--- a/crates/libduckdb-sys/build_bundled_cmake.rs
+++ b/crates/libduckdb-sys/build_bundled_cmake.rs
@@ -144,6 +144,27 @@ pub fn main(out_dir: &str, out_path: &Path) {
     }
     link_static_library(&lib_dir, &cmake_build_type, "duckdb_static");
     link_system_libs();
+
+    // Compile the zero-copy Arrow registration shim under the cmake backend.
+    // The amalgamation's headers are available via `include_path`; the shim links
+    // against the same DuckDB API surface as the cc-backend path.
+    // Compiled unconditionally (no vtab-arrow gate), mirroring the cc backend.
+    {
+        let mut shim = cc::Build::new();
+        shim.file("src/arrow_zerocopy_shim.cpp")
+            .include(&include_path)
+            .cpp(true)
+            .flag_if_supported("-std=c++11")
+            .flag_if_supported("/utf-8")
+            .warnings(false)
+            .flag_if_supported("-w");
+        if win_target() && is_compiler("msvc") {
+            shim.flag("/EHsc");
+        }
+        shim.compile("arrow_zerocopy_shim");
+        println!("cargo:rerun-if-changed=src/arrow_zerocopy_shim.cpp");
+    }
+
     println!("cargo:lib_dir={}", lib_dir.display());
 }
 

--- a/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
+++ b/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
@@ -273,7 +273,14 @@ static void emit_filter(const duckdb::TableFilter &filter, const std::vector<duc
         auto &sf = filter.Cast<duckdb::StructFilter>();
         std::vector<duckdb::idx_t> child_path = path;
         child_path.push_back(sf.child_idx);
-        emit_filter(*sf.child_filter, child_path, buf);
+        if (sf.child_filter) {
+            emit_filter(*sf.child_filter, child_path, buf);
+        } else {
+            // DuckDB always supplies a child filter; guard defensively so a null can never be
+            // dereferenced (mirrors the OPTIONAL_FILTER guard). Empty AND = keep all rows.
+            push_u8(buf, 3);
+            push_u32(buf, 0);
+        }
     } else if (filter.filter_type == TableFilterType::DYNAMIC_FILTER ||
                filter.filter_type == TableFilterType::BLOOM_FILTER) {
         // Join-reduction filters: not required for correctness; the join above re-checks.

--- a/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
+++ b/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
@@ -1,0 +1,280 @@
+// Zero-copy Arrow registration shim.
+//
+// Registers DuckDB's native `arrow_scan` table function with a Rust-driven, replayable,
+// projection-honoring factory. All Arrow logic lives in Rust; this file is a trampoline
+// (translate the C++ ArrowStreamParameters that Rust cannot read into plain C) plus the
+// TableFunction/CreateView registration call.
+//
+// Ownership: `factory_ptr` is a Rust Box<ArrowFactory>; its first two fields are the Rust
+// callback pointers (matched by RustCallbacks below, #[repr(C)] on the Rust side). DuckDB
+// stores `factory_ptr` in the view's bind data and calls ShimProduce per scan and
+// ShimGetSchema at bind time. The view references the factory by pointer; the Rust side keeps
+// the box alive until the view is gone (see ArrowView).
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+#include "duckdb.h"                                   // duckdb_connection
+#include "duckdb.hpp"                                 // duckdb::Connection, Value, Relation
+#include "duckdb/function/table/arrow.hpp"           // ArrowStreamParameters, stream factory typedefs
+#include "duckdb/common/arrow/arrow_wrapper.hpp"     // ArrowArrayStreamWrapper
+#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/null_filter.hpp"
+#include "duckdb/planner/filter/in_filter.hpp"
+#include "duckdb/planner/filter/optional_filter.hpp"
+#include "duckdb/common/enums/expression_type.hpp"
+
+using duckdb::ArrowArrayStreamWrapper;
+using duckdb::ArrowStreamParameters;
+
+// Must match the first two fields of the Rust #[repr(C)] ArrowFactory.
+typedef void (*RustProduceFn)(void *factory, const char *const *names, size_t n,
+                              const uint8_t *filter_buf, size_t filter_len, ArrowArrayStream *out);
+typedef void (*RustGetSchemaFn)(void *factory, ArrowSchema *out);
+struct RustCallbacks {
+    RustProduceFn produce;
+    RustGetSchemaFn get_schema;
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Filter wire-format helpers
+// ──────────────────────────────────────────────────────────────────────────────
+//
+// The wire format is a little-endian byte buffer that encodes DuckDB's TableFilterSet
+// into a tree of FilterNode structures. The Rust filter module decodes this buffer and
+// evaluates it against the projected RecordBatch before returning the Arrow stream.
+//
+// Node format:  tag:u8 + payload
+//   tag 0  (COMPARE):    col:u32 + op:u8 + scalar
+//   tag 1  (IS_NULL):    col:u32
+//   tag 2  (IS_NOT_NULL): col:u32
+//   tag 3  (AND):        n:u32  + n*node
+//   tag 4  (OR):         n:u32  + n*node
+//   tag 5  (IN):         col:u32 + n:u32 + n*scalar
+//   tag 255 (UNHANDLED): raw_filter_type:u32
+//
+// Scalar format:  stype:u8 + payload
+//   stype 0 (i64):         value:i64  (8 bytes LE)
+//   stype 1 (u64):         value:u64  (8 bytes LE)
+//   stype 2 (f64):         value:f64  (8 bytes LE, IEEE 754 bits)
+//   stype 3 (bool):        value:u8   (0 = false, 1 = true)
+//   stype 4 (utf8):        len:u32 + len bytes (UTF-8, no NUL terminator)
+//   stype 5 (null):        (no payload)
+//   stype 255 (unsupported): (no payload)
+//
+// op byte (for tag 0):  0=EQ 1=NE 2=LT 3=GT 4=LE 5=GE  (matches ExpressionType 25–30)
+
+static void push_u8(std::vector<uint8_t> &buf, uint8_t v) { buf.push_back(v); }
+
+static void push_u32(std::vector<uint8_t> &buf, uint32_t v) {
+    buf.push_back((uint8_t)(v & 0xff));
+    buf.push_back((uint8_t)((v >> 8) & 0xff));
+    buf.push_back((uint8_t)((v >> 16) & 0xff));
+    buf.push_back((uint8_t)((v >> 24) & 0xff));
+}
+
+static void push_i64(std::vector<uint8_t> &buf, int64_t v) {
+    uint64_t u = (uint64_t)v;
+    for (int i = 0; i < 8; i++) { buf.push_back((uint8_t)(u & 0xff)); u >>= 8; }
+}
+
+static void push_u64(std::vector<uint8_t> &buf, uint64_t v) {
+    for (int i = 0; i < 8; i++) { buf.push_back((uint8_t)(v & 0xff)); v >>= 8; }
+}
+
+static void push_f64(std::vector<uint8_t> &buf, double v) {
+    uint64_t u;
+    memcpy(&u, &v, 8);
+    for (int i = 0; i < 8; i++) { buf.push_back((uint8_t)(u & 0xff)); u >>= 8; }
+}
+
+static void emit_scalar(const duckdb::Value &v, std::vector<uint8_t> &buf) {
+    if (v.IsNull()) { push_u8(buf, 5); return; }
+    auto type_id = v.type().id();
+    switch (type_id) {
+        case duckdb::LogicalTypeId::BIGINT:
+        case duckdb::LogicalTypeId::INTEGER:
+        case duckdb::LogicalTypeId::SMALLINT:
+        case duckdb::LogicalTypeId::TINYINT:
+            push_u8(buf, 0); push_i64(buf, v.GetValue<int64_t>()); break;
+        case duckdb::LogicalTypeId::UBIGINT:
+        case duckdb::LogicalTypeId::UINTEGER:
+        case duckdb::LogicalTypeId::USMALLINT:
+        case duckdb::LogicalTypeId::UTINYINT:
+            push_u8(buf, 1); push_u64(buf, v.GetValue<uint64_t>()); break;
+        case duckdb::LogicalTypeId::DOUBLE:
+        case duckdb::LogicalTypeId::FLOAT:
+            push_u8(buf, 2); push_f64(buf, v.GetValue<double>()); break;
+        case duckdb::LogicalTypeId::BOOLEAN:
+            push_u8(buf, 3); push_u8(buf, v.GetValue<bool>() ? 1 : 0); break;
+        case duckdb::LogicalTypeId::VARCHAR: {
+            push_u8(buf, 4);
+            std::string s = v.ToString();
+            push_u32(buf, (uint32_t)s.size());
+            for (char c : s) { buf.push_back((uint8_t)c); }
+            break;
+        }
+        default:
+            push_u8(buf, 255); break;
+    }
+}
+
+// Returns true if this filter_type is handled (will not emit tag 255).
+static bool is_handled_filter_type(duckdb::TableFilterType t) {
+    using duckdb::TableFilterType;
+    switch (t) {
+        case TableFilterType::CONSTANT_COMPARISON:
+        case TableFilterType::IS_NULL:
+        case TableFilterType::IS_NOT_NULL:
+        case TableFilterType::CONJUNCTION_AND:
+        case TableFilterType::CONJUNCTION_OR:
+        case TableFilterType::IN_FILTER:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static void emit_filter(const duckdb::TableFilter &filter, duckdb::idx_t projected_col, std::vector<uint8_t> &buf) {
+    using duckdb::TableFilterType;
+    if (filter.filter_type == TableFilterType::CONSTANT_COMPARISON) {
+        auto &c = filter.Cast<duckdb::ConstantFilter>();
+        push_u8(buf, 0); // tag COMPARE
+        push_u32(buf, (uint32_t)projected_col);
+        // Map ExpressionType to op byte: EQ=25->0, NE=26->1, LT=27->2, GT=28->3, LE=29->4, GE=30->5
+        uint8_t op = 255;
+        switch ((int)c.comparison_type) {
+            case 25: op = 0; break; // COMPARE_EQUAL
+            case 26: op = 1; break; // COMPARE_NOTEQUAL
+            case 27: op = 2; break; // COMPARE_LESSTHAN
+            case 28: op = 3; break; // COMPARE_GREATERTHAN
+            case 29: op = 4; break; // COMPARE_LESSTHANOREQUALTO
+            case 30: op = 5; break; // COMPARE_GREATERTHANOREQUALTO
+        }
+        push_u8(buf, op);
+        emit_scalar(c.constant, buf);
+    } else if (filter.filter_type == TableFilterType::IS_NULL) {
+        push_u8(buf, 1); // tag IS_NULL
+        push_u32(buf, (uint32_t)projected_col);
+    } else if (filter.filter_type == TableFilterType::IS_NOT_NULL) {
+        push_u8(buf, 2); // tag IS_NOT_NULL
+        push_u32(buf, (uint32_t)projected_col);
+    } else if (filter.filter_type == TableFilterType::CONJUNCTION_AND) {
+        // Recursively emit children (all share the same projected_col)
+        auto &conj = filter.Cast<duckdb::ConjunctionAndFilter>();
+        push_u8(buf, 3); // tag AND
+        push_u32(buf, (uint32_t)conj.child_filters.size());
+        for (auto &child : conj.child_filters) {
+            emit_filter(*child, projected_col, buf);
+        }
+    } else if (filter.filter_type == TableFilterType::CONJUNCTION_OR) {
+        // Recursively emit children (all share the same projected_col)
+        auto &conj = filter.Cast<duckdb::ConjunctionOrFilter>();
+        push_u8(buf, 4); // tag OR
+        push_u32(buf, (uint32_t)conj.child_filters.size());
+        for (auto &child : conj.child_filters) {
+            emit_filter(*child, projected_col, buf);
+        }
+    } else if (filter.filter_type == TableFilterType::IN_FILTER) {
+        auto &inf = filter.Cast<duckdb::InFilter>();
+        push_u8(buf, 5); // tag IN
+        push_u32(buf, (uint32_t)projected_col);
+        push_u32(buf, (uint32_t)inf.values.size());
+        for (auto &v : inf.values) {
+            emit_scalar(v, buf);
+        }
+    } else if (filter.filter_type == TableFilterType::OPTIONAL_FILTER) {
+        // OPTIONAL_FILTER is not required for correctness; the join above re-checks.
+        // If the child is a handled kind, emit it; otherwise skip safely (empty AND = keep all rows).
+        auto &opt = filter.Cast<duckdb::OptionalFilter>();
+        if (opt.child_filter && is_handled_filter_type(opt.child_filter->filter_type)) {
+            emit_filter(*opt.child_filter, projected_col, buf);
+        } else {
+            push_u8(buf, 3); // tag AND
+            push_u32(buf, 0); // 0 children = no-op (keep all rows)
+        }
+    } else if (filter.filter_type == TableFilterType::DYNAMIC_FILTER ||
+               filter.filter_type == TableFilterType::BLOOM_FILTER) {
+        // Join-reduction filters: not required for correctness; the join above re-checks.
+        // Skip safely: emit empty AND(0) = keep all rows.
+        push_u8(buf, 3); // tag AND
+        push_u32(buf, 0); // 0 children = no-op
+    } else {
+        // Truly unhandled: tag 255 + raw filter_type as u32.
+        // The Rust evaluator will return FilterError, routing to error_stream (clean failure).
+        push_u8(buf, 255);
+        push_u32(buf, (uint32_t)filter.filter_type);
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Shim callbacks
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Produce a fresh stream for one scan, honoring projection and filters. Called by DuckDB possibly
+// many times (self-joins, repeated scans) — replayability comes from Rust building a new stream
+// from the held batches each call.
+static duckdb::unique_ptr<ArrowArrayStreamWrapper> ShimProduce(uintptr_t factory_ptr,
+                                                               ArrowStreamParameters &params) {
+    auto *cbs = reinterpret_cast<RustCallbacks *>(factory_ptr);
+    std::vector<const char *> names;
+    names.reserve(params.projected_columns.columns.size());
+    for (auto &col : params.projected_columns.columns) {
+        names.push_back(col.c_str());
+    }
+
+    // Build filter buffer: root AND node, one child per filter entry.
+    //
+    // The TableFilterSet is keyed by the SCAN / PROJECTED output-column position, NOT a
+    // table-column index — verified against DuckDB's physical_table_scan (the key indexes
+    // `column_ids`) and arrow_scan's own `filter_to_col` (also keyed by scan position). So the
+    // key indexes the produced projected batch directly; an earlier reverse-map via
+    // `filter_to_col` was WRONG and silently mis-filtered multi-column projections.
+    std::vector<uint8_t> filter_buf;
+    if (params.filters && !params.filters->filters.empty()) {
+        auto &filters = params.filters->filters;
+        push_u8(filter_buf, 3); // tag AND
+        push_u32(filter_buf, (uint32_t)filters.size());
+        for (auto &kv : filters) {
+            duckdb::idx_t projected_col = kv.first; // already the projected batch position
+            const duckdb::TableFilter &tf = *kv.second;
+            emit_filter(tf, projected_col, filter_buf);
+        }
+    } else {
+        // No filters: emit empty AND (keep all rows)
+        push_u8(filter_buf, 3); // tag AND
+        push_u32(filter_buf, 0); // 0 children
+    }
+
+    auto wrapper = duckdb::make_uniq<ArrowArrayStreamWrapper>();
+    // Rust fills wrapper->arrow_array_stream in place; the wrapper owns + releases it.
+    cbs->produce(reinterpret_cast<void *>(factory_ptr), names.data(), names.size(),
+                 filter_buf.data(), filter_buf.size(), &wrapper->arrow_array_stream);
+    return wrapper;
+}
+
+// DuckDB passes the same registered factory pointer here, typed as ArrowArrayStream* per the
+// typedef; reinterpret it back to the factory.
+static void ShimGetSchema(ArrowArrayStream *factory_ptr, ArrowSchema &schema) {
+    auto *cbs = reinterpret_cast<RustCallbacks *>(factory_ptr);
+    cbs->get_schema(reinterpret_cast<void *>(factory_ptr), &schema);
+}
+
+extern "C" int ddb_rs_arrow_register(duckdb_connection conn, const char *name, void *factory_ptr) {
+    try {
+        auto *connection = reinterpret_cast<duckdb::Connection *>(conn);
+        duckdb::vector<duckdb::Value> values;
+        values.push_back(duckdb::Value::POINTER(reinterpret_cast<uintptr_t>(factory_ptr)));
+        values.push_back(duckdb::Value::POINTER(reinterpret_cast<uintptr_t>(&ShimProduce)));
+        values.push_back(duckdb::Value::POINTER(reinterpret_cast<uintptr_t>(&ShimGetSchema)));
+        connection->TableFunction("arrow_scan", values)->CreateView(name, /*replace*/ true, /*temporary*/ true);
+        return 0;
+    } catch (...) {
+        return 1;
+    }
+}

--- a/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
+++ b/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
@@ -29,6 +29,10 @@
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/common/types/date.hpp"
+#include "duckdb/common/types/decimal.hpp"
+#include "duckdb/common/types/time.hpp"
+#include "duckdb/common/types/timestamp.hpp"
 
 using duckdb::ArrowArrayStreamWrapper;
 using duckdb::ArrowStreamParameters;
@@ -64,8 +68,10 @@ struct RustCallbacks {
 //
 // Scalar format:  stype:u8 + payload
 //   stype 0 (i64) 1 (u64) 2 (f64) 3 (bool) 4 (utf8 len:u32+bytes) 5 (null)
+//   stype 6 (date32 i32:days) 7 (time unit:u8 + i64:µs) 8 (timestamp unit:u8 + i64)
+//   stype 9 (decimal128 i128:16LE-bytes + scale:u8)  stype 10 (blob len:u32 + bytes)
+//   unit byte: 0=s 1=ms 2=µs 3=ns
 //   stype 255 (unsupported)
-//   (Date/Time/Timestamp/Decimal128/Blob scalars are added in later tasks.)
 //
 // op byte (for tag 0):  0=EQ 1=NE 2=LT 3=GT 4=LE 5=GE  (matches ExpressionType 25-30)
 
@@ -78,6 +84,11 @@ static void push_u32(std::vector<uint8_t> &buf, uint32_t v) {
     buf.push_back((uint8_t)((v >> 24) & 0xff));
 }
 
+static void push_i32(std::vector<uint8_t> &buf, int32_t v) {
+    uint32_t u = (uint32_t)v;
+    for (int i = 0; i < 4; i++) { buf.push_back((uint8_t)(u & 0xff)); u >>= 8; }
+}
+
 static void push_i64(std::vector<uint8_t> &buf, int64_t v) {
     uint64_t u = (uint64_t)v;
     for (int i = 0; i < 8; i++) { buf.push_back((uint8_t)(u & 0xff)); u >>= 8; }
@@ -85,6 +96,12 @@ static void push_i64(std::vector<uint8_t> &buf, int64_t v) {
 
 static void push_u64(std::vector<uint8_t> &buf, uint64_t v) {
     for (int i = 0; i < 8; i++) { buf.push_back((uint8_t)(v & 0xff)); v >>= 8; }
+}
+
+static void push_i128(std::vector<uint8_t> &buf, duckdb::hugeint_t h) {
+    // Little-endian i128: low 64 bits then high 64 bits (two's complement).
+    push_u64(buf, h.lower);
+    push_i64(buf, h.upper);
 }
 
 static void push_f64(std::vector<uint8_t> &buf, double v) {
@@ -122,6 +139,53 @@ static void emit_scalar(const duckdb::Value &v, std::vector<uint8_t> &buf) {
             std::string s = v.ToString();
             push_u32(buf, (uint32_t)s.size());
             for (char c : s) { buf.push_back((uint8_t)c); }
+            break;
+        }
+        case duckdb::LogicalTypeId::DATE:
+            push_u8(buf, 6);
+            push_i32(buf, duckdb::DateValue::Get(v).days);
+            break;
+        case duckdb::LogicalTypeId::TIME:
+            push_u8(buf, 7);
+            push_u8(buf, 2); // unit = µs
+            push_i64(buf, duckdb::TimeValue::Get(v).micros);
+            break;
+        case duckdb::LogicalTypeId::TIMESTAMP:
+        case duckdb::LogicalTypeId::TIMESTAMP_TZ:
+            push_u8(buf, 8);
+            push_u8(buf, 2); // µs
+            push_i64(buf, duckdb::TimestampValue::Get(v).value);
+            break;
+        case duckdb::LogicalTypeId::TIMESTAMP_MS:
+            push_u8(buf, 8);
+            push_u8(buf, 1); // ms
+            push_i64(buf, duckdb::TimestampMSValue::Get(v).value);
+            break;
+        case duckdb::LogicalTypeId::TIMESTAMP_NS:
+            push_u8(buf, 8);
+            push_u8(buf, 3); // ns
+            push_i64(buf, duckdb::TimestampNSValue::Get(v).value);
+            break;
+        case duckdb::LogicalTypeId::TIMESTAMP_SEC:
+            push_u8(buf, 8);
+            push_u8(buf, 0); // s
+            push_i64(buf, duckdb::TimestampSValue::Get(v).value);
+            break;
+        case duckdb::LogicalTypeId::BLOB: {
+            push_u8(buf, 10);
+            const std::string &s = duckdb::StringValue::Get(v);
+            push_u32(buf, (uint32_t)s.size());
+            for (char c : s) { buf.push_back((uint8_t)c); }
+            break;
+        }
+        case duckdb::LogicalTypeId::DECIMAL: {
+            // Only INT128-physical decimals are pushed by CanPushdown; the arrow column is Decimal128.
+            uint8_t width = duckdb::DecimalType::GetWidth(v.type());
+            uint8_t scale = duckdb::DecimalType::GetScale(v.type());
+            if (width <= 18) { push_u8(buf, 255); break; } // not INT128-physical → unsupported (fail-loud)
+            push_u8(buf, 9);
+            push_i128(buf, v.GetValueUnsafe<duckdb::hugeint_t>());
+            push_u8(buf, scale);
             break;
         }
         default:

--- a/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
+++ b/crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp
@@ -27,6 +27,7 @@
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
+#include "duckdb/planner/filter/struct_filter.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
 
 using duckdb::ArrowArrayStreamWrapper;
@@ -50,24 +51,23 @@ struct RustCallbacks {
 // evaluates it against the projected RecordBatch before returning the Arrow stream.
 //
 // Node format:  tag:u8 + payload
-//   tag 0  (COMPARE):    col:u32 + op:u8 + scalar
-//   tag 1  (IS_NULL):    col:u32
-//   tag 2  (IS_NOT_NULL): col:u32
+//   tag 0  (COMPARE):    path + op:u8 + scalar
+//   tag 1  (IS_NULL):    path
+//   tag 2  (IS_NOT_NULL): path
 //   tag 3  (AND):        n:u32  + n*node
 //   tag 4  (OR):         n:u32  + n*node
-//   tag 5  (IN):         col:u32 + n:u32 + n*scalar
+//   tag 5  (IN):         path + n:u32 + n*scalar
 //   tag 255 (UNHANDLED): raw_filter_type:u32
 //
-// Scalar format:  stype:u8 + payload
-//   stype 0 (i64):         value:i64  (8 bytes LE)
-//   stype 1 (u64):         value:u64  (8 bytes LE)
-//   stype 2 (f64):         value:f64  (8 bytes LE, IEEE 754 bits)
-//   stype 3 (bool):        value:u8   (0 = false, 1 = true)
-//   stype 4 (utf8):        len:u32 + len bytes (UTF-8, no NUL terminator)
-//   stype 5 (null):        (no payload)
-//   stype 255 (unsupported): (no payload)
+// path:  depth:u32 + depth*u32  (depth >= 1; index[0] = projected root column,
+//        index[1..] = struct child indices)
 //
-// op byte (for tag 0):  0=EQ 1=NE 2=LT 3=GT 4=LE 5=GE  (matches ExpressionType 25–30)
+// Scalar format:  stype:u8 + payload
+//   stype 0 (i64) 1 (u64) 2 (f64) 3 (bool) 4 (utf8 len:u32+bytes) 5 (null)
+//   stype 255 (unsupported)
+//   (Date/Time/Timestamp/Decimal128/Blob scalars are added in later tasks.)
+//
+// op byte (for tag 0):  0=EQ 1=NE 2=LT 3=GT 4=LE 5=GE  (matches ExpressionType 25-30)
 
 static void push_u8(std::vector<uint8_t> &buf, uint8_t v) { buf.push_back(v); }
 
@@ -91,6 +91,11 @@ static void push_f64(std::vector<uint8_t> &buf, double v) {
     uint64_t u;
     memcpy(&u, &v, 8);
     for (int i = 0; i < 8; i++) { buf.push_back((uint8_t)(u & 0xff)); u >>= 8; }
+}
+
+static void push_column_path(std::vector<uint8_t> &buf, const std::vector<duckdb::idx_t> &path) {
+    push_u32(buf, (uint32_t)path.size());
+    for (auto idx : path) { push_u32(buf, (uint32_t)idx); }
 }
 
 static void emit_scalar(const duckdb::Value &v, std::vector<uint8_t> &buf) {
@@ -134,18 +139,19 @@ static bool is_handled_filter_type(duckdb::TableFilterType t) {
         case TableFilterType::CONJUNCTION_AND:
         case TableFilterType::CONJUNCTION_OR:
         case TableFilterType::IN_FILTER:
+        case TableFilterType::STRUCT_EXTRACT:
             return true;
         default:
             return false;
     }
 }
 
-static void emit_filter(const duckdb::TableFilter &filter, duckdb::idx_t projected_col, std::vector<uint8_t> &buf) {
+static void emit_filter(const duckdb::TableFilter &filter, const std::vector<duckdb::idx_t> &path, std::vector<uint8_t> &buf) {
     using duckdb::TableFilterType;
     if (filter.filter_type == TableFilterType::CONSTANT_COMPARISON) {
         auto &c = filter.Cast<duckdb::ConstantFilter>();
         push_u8(buf, 0); // tag COMPARE
-        push_u32(buf, (uint32_t)projected_col);
+        push_column_path(buf, path);
         // Map ExpressionType to op byte: EQ=25->0, NE=26->1, LT=27->2, GT=28->3, LE=29->4, GE=30->5
         uint8_t op = 255;
         switch ((int)c.comparison_type) {
@@ -160,30 +166,30 @@ static void emit_filter(const duckdb::TableFilter &filter, duckdb::idx_t project
         emit_scalar(c.constant, buf);
     } else if (filter.filter_type == TableFilterType::IS_NULL) {
         push_u8(buf, 1); // tag IS_NULL
-        push_u32(buf, (uint32_t)projected_col);
+        push_column_path(buf, path);
     } else if (filter.filter_type == TableFilterType::IS_NOT_NULL) {
         push_u8(buf, 2); // tag IS_NOT_NULL
-        push_u32(buf, (uint32_t)projected_col);
+        push_column_path(buf, path);
     } else if (filter.filter_type == TableFilterType::CONJUNCTION_AND) {
-        // Recursively emit children (all share the same projected_col)
+        // Recursively emit children (all share the same path)
         auto &conj = filter.Cast<duckdb::ConjunctionAndFilter>();
         push_u8(buf, 3); // tag AND
         push_u32(buf, (uint32_t)conj.child_filters.size());
         for (auto &child : conj.child_filters) {
-            emit_filter(*child, projected_col, buf);
+            emit_filter(*child, path, buf);
         }
     } else if (filter.filter_type == TableFilterType::CONJUNCTION_OR) {
-        // Recursively emit children (all share the same projected_col)
+        // Recursively emit children (all share the same path)
         auto &conj = filter.Cast<duckdb::ConjunctionOrFilter>();
         push_u8(buf, 4); // tag OR
         push_u32(buf, (uint32_t)conj.child_filters.size());
         for (auto &child : conj.child_filters) {
-            emit_filter(*child, projected_col, buf);
+            emit_filter(*child, path, buf);
         }
     } else if (filter.filter_type == TableFilterType::IN_FILTER) {
         auto &inf = filter.Cast<duckdb::InFilter>();
         push_u8(buf, 5); // tag IN
-        push_u32(buf, (uint32_t)projected_col);
+        push_column_path(buf, path);
         push_u32(buf, (uint32_t)inf.values.size());
         for (auto &v : inf.values) {
             emit_scalar(v, buf);
@@ -193,11 +199,17 @@ static void emit_filter(const duckdb::TableFilter &filter, duckdb::idx_t project
         // If the child is a handled kind, emit it; otherwise skip safely (empty AND = keep all rows).
         auto &opt = filter.Cast<duckdb::OptionalFilter>();
         if (opt.child_filter && is_handled_filter_type(opt.child_filter->filter_type)) {
-            emit_filter(*opt.child_filter, projected_col, buf);
+            emit_filter(*opt.child_filter, path, buf);
         } else {
             push_u8(buf, 3); // tag AND
             push_u32(buf, 0); // 0 children = no-op (keep all rows)
         }
+    } else if (filter.filter_type == TableFilterType::STRUCT_EXTRACT) {
+        // Descend into a struct child: append child_idx to the path and recurse on the child filter.
+        auto &sf = filter.Cast<duckdb::StructFilter>();
+        std::vector<duckdb::idx_t> child_path = path;
+        child_path.push_back(sf.child_idx);
+        emit_filter(*sf.child_filter, child_path, buf);
     } else if (filter.filter_type == TableFilterType::DYNAMIC_FILTER ||
                filter.filter_type == TableFilterType::BLOOM_FILTER) {
         // Join-reduction filters: not required for correctness; the join above re-checks.
@@ -243,7 +255,7 @@ static duckdb::unique_ptr<ArrowArrayStreamWrapper> ShimProduce(uintptr_t factory
         for (auto &kv : filters) {
             duckdb::idx_t projected_col = kv.first; // already the projected batch position
             const duckdb::TableFilter &tf = *kv.second;
-            emit_filter(tf, projected_col, filter_buf);
+            emit_filter(tf, std::vector<duckdb::idx_t>{projected_col}, filter_buf);
         }
     } else {
         // No filters: emit empty AND (keep all rows)


### PR DESCRIPTION
## What

Adds `Connection::register_arrow(name, Vec<RecordBatch>) -> ArrowView<'conn>`: register
in-memory Arrow data as a DuckDB view whose scans reference the Arrow buffers **in place**
(no copy into DuckDB native storage, unlike `Appender`). The view honors **projection
pushdown** and **filter pushdown**, with filters evaluated in Rust via arrow-compute before
each chunk is returned.

```rust
let view = conn.register_arrow("t", batches)?;
let n: i64 = conn.query_row("SELECT count(*) FROM t WHERE k > 2 AND s.id = 7", [], |r| r.get(0))?;
// `view` unregisters the DuckDB view automatically when dropped.
```

## Why

`Appender` copies rows into DuckDB storage. For workloads that already hold Arrow data and want
to query it (joins, aggregations, filtered scans) without materializing a copy, a zero-copy
registration over the native `arrow_scan` table function is substantially cheaper and
integrates with DuckDB's optimizer (projection + filter pushdown).

## How

- A small C++ shim (`crates/libduckdb-sys/src/arrow_zerocopy_shim.cpp`) registers `arrow_scan`
  with a **replayable** Rust factory (a fresh `FFI_ArrowArrayStream` per scan, so self-joins
  work) and translates DuckDB's `ArrowStreamParameters` (projected columns + `TableFilterSet`) —
  which Rust can't read directly — into a compact little-endian wire buffer.
- The Rust evaluator (`crates/duckdb/src/arrow_zerocopy/filter.rs`) decodes the buffer into a
  `FilterNode` tree and produces a `BooleanArray` for `filter_record_batch`.
- `ArrowView<'conn>` is an RAII handle: it borrows the connection and, on `Drop`, runs
  `DROP VIEW IF EXISTS` **before** freeing the factory, so a late scan errors cleanly rather
  than dereferencing freed memory. It is `!Send`/`!Sync` (raw factory pointer, single-threaded
  `Connection` model).

## Filter coverage

Handled end-to-end: `CONSTANT_COMPARISON` (all 6 ops), `IS [NOT] NULL`, `CONJUNCTION_AND/OR`
(nested), `IN_FILTER`, and `STRUCT_EXTRACT` (struct-field predicates via column paths, with
correct NULL-struct semantics). Scalar types: all signed/unsigned ints, `FLOAT`/`DOUBLE` (incl.
NaN **total-order** matching DuckDB), `BOOLEAN`, `VARCHAR`, `BLOB`, `DATE`, `TIME` (µs),
`TIMESTAMP` (all four units incl. TZ), `DECIMAL128`.

`OPTIONAL_FILTER` / `DYNAMIC_FILTER` / `BLOOM_FILTER` are safely skipped (the engine re-applies
them above the scan). Any other / untranslatable **required** filter produces an error stream —
**fail-loud, never silently wrong** — because DuckDB does not re-apply filters it has pushed to
the scan.

## Correctness

The invariant is: never an over- or under-inclusive row set for a *translated* filter. AND/OR
require all children translatable (no silent dropping); unsupported scalar/column combinations,
out-of-range narrowing, and corrupt wire input all fail loud. Extracting a field from a NULL
struct reads as NULL. NaN constant comparisons follow DuckDB's float total order.

## DuckDB version note

Built against the currently bundled DuckDB **v1.5.4** (`08e34c44`); no submodule bump. On v1.5.4
the optimizer routes every pushable arrow-scan filter to a structured `TableFilter` kind (it
constant-folds expressions and keeps genuinely-complex predicates above the scan), so the
catch-all `EXPRESSION_FILTER` is not emitted for arrow scans and is handled as a fail-loud
fallback. When a future bundled release retires the structured kinds in favor of
`EXPRESSION_FILTER`, an expression-tree walker can be added behind the same wire format.

## Testing

- Full `duckdb` suite green: **307 lib unit tests + integration tests + 53 doctests, 0 failures**.
- Oracle tests compare the zero-copy view against an equivalent `Appender`-ingested native table
  across comparisons, null/IN/AND/OR, struct fields, every scalar type, multi-column
  projection+filter, self-join replayability, and inner-join (dynamic/bloom skip) cases; plus
  direct evaluator unit tests for NULL-struct masking, NaN total-order, and fail-loud paths.
- `cargo clippy --features "bundled appender-arrow" --all-targets -- -D warnings` clean.
