### PR TITLE
Represent DuckDB decimals natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,17 @@ These extensions are only available through the CMake build backend and imply `b
 
 - `appender-arrow` - Efficient bulk insertion of Arrow data into DuckDB tables.
 - `polars` - Integration with Polars DataFrames.
+- `rust_decimal` - Compatibility impls for `rust_decimal::Decimal`. DuckDB
+  `DECIMAL` values use `duckdb::types::Decimal` as the core full-domain
+  carrier; this feature restores `ToSql`/`FromSql` conversions for
+  `rust_decimal::Decimal` when values fit that crate's decimal domain,
+  including compatibility reads from `FLOAT`, `DOUBLE`, and text columns.
 
 ### Convenience features
 
 - `vtab-full` - Enables virtual table features: `vtab-arrow` and `appender-arrow`; retains the deprecated `vtab-excel` compatibility flag.
 - `extensions-full` - Enables all major extensions: `json`, `parquet`, and `vtab-full`.
-- `modern-full` - Enables modern Rust ecosystem integrations: `chrono`, `serde_json`, `url`, `r2d2`, `uuid`, and `polars`.
+- `modern-full` - Enables modern Rust ecosystem integrations: `chrono`, `serde_json`, `url`, `r2d2`, `uuid`, `polars`, and `rust_decimal`.
 
 ### Build configuration
 

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -39,8 +39,9 @@ appender-arrow = ["vtab-arrow"]
 vtab-full = ["vtab-excel", "vtab-arrow", "appender-arrow"]
 extensions-full = ["json", "parquet", "vtab-full"]
 buildtime_bindgen = ["libduckdb-sys/buildtime_bindgen"]
-modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars"]
+modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars", "rust_decimal"]
 polars = ["dep:polars", "dep:polars-core"]
+rust_decimal = ["dep:rust_decimal"]
 # Warning: experimental feature
 loadable-extension = ["vtab", "duckdb-loadable-macros", "libduckdb-sys/loadable-extension"]
 
@@ -58,7 +59,7 @@ num-integer = { workspace = true }
 polars = { workspace = true, features = ["dtype-full"], optional = true }
 polars-core = { workspace = true, optional = true }
 r2d2 = { workspace = true, optional = true }
-rust_decimal = { workspace = true }
+rust_decimal = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 url = { workspace = true, optional = true }
@@ -80,7 +81,7 @@ tempfile = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [package.metadata.docs.rs]
-features = ["vtab-full", "modern-full", "vscalar", "vscalar-arrow"]
+features = ["vtab-full", "modern-full", "vscalar", "vscalar-arrow", "rust_decimal"]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -341,10 +341,11 @@ fn validate_appender_value_ref(value: ValueRef<'_>) -> Result<()> {
 
 #[cfg(test)]
 mod test {
-    use rust_decimal::Decimal;
-
     use super::Appender;
-    use crate::{Connection, Error, Result, params};
+    use crate::{
+        Connection, Error, Result, params,
+        types::{Decimal, Value},
+    };
 
     #[test]
     fn appender_is_sync() {
@@ -807,9 +808,9 @@ mod test {
 
     #[test]
     fn test_appender_decimal() -> Result<()> {
-        let d1 = Decimal::from_i128_with_scale(11344, 4);
-        let d2 = Decimal::from_i128_with_scale(12312, 3);
-        let d3 = Decimal::from_i128_with_scale(-98765, 5);
+        let d1 = Decimal::new(20, 4, 11344)?;
+        let d2 = Decimal::new(20, 3, 12312)?;
+        let d3 = Decimal::new(20, 5, -98765)?;
 
         let conn = Connection::open_in_memory()?;
         conn.execute_batch("CREATE TABLE decimals (value DECIMAL(20, 10));")?;
@@ -825,15 +826,22 @@ mod test {
             .query_map([], |row| row.get(0))?
             .collect::<Result<Vec<Decimal>>>()?;
 
-        assert_eq!(results, vec![d3, d1, d2]);
+        assert_eq!(
+            results,
+            vec![
+                Decimal::new(20, 10, -9876500000)?,
+                Decimal::new(20, 10, 11344000000)?,
+                Decimal::new(20, 10, 123120000000)?,
+            ]
+        );
 
         Ok(())
     }
 
     #[test]
     fn test_appender_decimal_hugeint_upper_bits() -> Result<()> {
-        let negative = Decimal::from_i128_with_scale(-7922816251426433759354395033_i128, 10);
-        let positive = Decimal::from_i128_with_scale(7922816251426433759354395033_i128, 10);
+        let negative = Decimal::new(28, 10, -7922816251426433759354395033_i128)?;
+        let positive = Decimal::new(28, 10, 7922816251426433759354395033_i128)?;
 
         let conn = Connection::open_in_memory()?;
         conn.execute_batch("CREATE TABLE decimals (value DECIMAL(28, 10));")?;
@@ -857,9 +865,12 @@ mod test {
         let conn = Connection::open_in_memory()?;
         conn.execute_batch("CREATE TABLE decimals (value DECIMAL(29, 0));")?;
 
+        let zero = Decimal::new(29, 0, 0)?;
+        let max = Decimal::new(29, 0, 79_228_162_514_264_337_593_543_950_335)?;
+
         let mut appender = conn.appender("decimals")?;
-        appender.append_row(params![Decimal::ZERO])?;
-        appender.append_row(params![Decimal::MAX])?;
+        appender.append_row(params![zero])?;
+        appender.append_row(params![max])?;
         appender.flush()?;
 
         let results: Vec<Decimal> = conn
@@ -867,7 +878,29 @@ mod test {
             .query_map([], |row| row.get(0))?
             .collect::<Result<Vec<Decimal>>>()?;
 
-        assert_eq!(results, vec![Decimal::ZERO, Decimal::MAX]);
+        assert_eq!(results, vec![zero, max]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_appender_duck_decimal() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE decimals (value DECIMAL(38, 2));")?;
+
+        let direct = Decimal::new(38, 2, 12_345_678_901_234_567_890_123_456_789_012)?;
+        let owned = Decimal::new(38, 2, -12_345_678_901_234_567_890_123_456_789_012)?;
+
+        let mut appender = conn.appender("decimals")?;
+        appender.append_row(params![direct])?;
+        appender.append_row(params![Value::Decimal(owned)])?;
+        appender.flush()?;
+
+        let results: Vec<Decimal> = conn
+            .prepare("SELECT value FROM decimals ORDER BY value ASC")?
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<Vec<Decimal>>>()?;
+
+        assert_eq!(results, vec![owned, direct]);
         Ok(())
     }
 }

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -883,7 +883,7 @@ mod test {
     }
 
     #[test]
-    fn test_appender_duck_decimal() -> Result<()> {
+    fn test_appender_native_decimal() -> Result<()> {
         let conn = Connection::open_in_memory()?;
         conn.execute_batch("CREATE TABLE decimals (value DECIMAL(38, 2));")?;
 

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -2,7 +2,7 @@ use std::{convert, sync::Arc};
 
 use super::{Error, Result, Statement};
 use crate::core::LogicalTypeId;
-use crate::types::{self, EnumType, FromSql, FromSqlError, ListType, ValueRef};
+use crate::types::{self, Decimal, EnumType, FromSql, FromSqlError, ListType, ValueRef};
 
 use arrow::{
     array::{
@@ -13,7 +13,6 @@ use arrow::{
 };
 use fallible_iterator::FallibleIterator;
 use fallible_streaming_iterator::FallibleStreamingIterator;
-use rust_decimal::prelude::*;
 
 /// An handle for the resulting rows of a query.
 #[must_use = "Rows is lazy and will do nothing unless consumed"]
@@ -374,13 +373,21 @@ impl<'stmt> Row<'stmt> {
         let column = self.arr.as_ref().as_ref().unwrap().column(col);
         let value = Self::value_ref_internal(row, column);
 
-        // Arrow decodes HUGEINT, UHUGEINT, and scale-zero DECIMAL through the
-        // signed HugeInt carrier. Promote only when DuckDB's result metadata
-        // explicitly reports UHUGEINT; otherwise preserve the existing HugeInt
-        // fallback for parameter-derived or metadata-less results.
+        // Arrow gives HUGEINT, UHUGEINT, and DECIMAL(38,0) the same
+        // Decimal128(38,0) physical shape. value_ref_internal keeps that
+        // ambiguous shape in the signed HugeInt carrier. Top-level result
+        // metadata recovers UHUGEINT and DECIMAL; otherwise preserve the
+        // existing HugeInt fallback for parameter-derived or metadata-less
+        // results.
         if let ValueRef::HugeInt(value) = value {
-            if matches!(self.stmt.result_column_logical_id(col), Some(LogicalTypeId::UHugeint)) {
-                return ValueRef::UHugeInt(value as u128);
+            match self.stmt.result_column_logical_id(col) {
+                Some(LogicalTypeId::UHugeint) => return ValueRef::UHugeInt(value as u128),
+                Some(LogicalTypeId::Decimal) => {
+                    if let DataType::Decimal128(width, 0) = column.data_type() {
+                        return ValueRef::Decimal(Decimal::from_chunk(*width, 0, value));
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -462,14 +469,14 @@ impl<'stmt> Row<'stmt> {
                 let array = column.as_any().downcast_ref::<array::Float64Array>().unwrap();
                 ValueRef::Double(array.value(row))
             }
-            DataType::Decimal128(_, scale) => {
+            DataType::Decimal128(width, scale) => {
                 let array = column.as_any().downcast_ref::<array::Decimal128Array>().unwrap();
                 let value = array.value(row);
-                let scale = u32::try_from(*scale).expect("Arrow decimal scale must be non-negative");
-                if scale == 0 {
+                let scale = u8::try_from(*scale).expect("Arrow decimal scale must be non-negative");
+                if scale == 0 && *width == Decimal::MAX_WIDTH {
                     ValueRef::HugeInt(value)
                 } else {
-                    ValueRef::Decimal(Decimal::from_i128_with_scale(value, scale))
+                    ValueRef::Decimal(Decimal::from_chunk(*width, scale, value))
                 }
             }
             DataType::Timestamp(unit, _) if *unit == TimeUnit::Second => {
@@ -687,11 +694,13 @@ tuples_try_from_row!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
 mod tests {
     use crate::{
         Connection, Error, Result,
-        types::{Type, Value, ValueRef},
+        types::{Decimal, Type, Value, ValueRef},
     };
 
     const U128_MAX_SQL: &str = "340282366920938463463374607431768211455";
     const I128_MAX_PLUS_ONE_SQL: &str = "170141183460469231731687303715884105728";
+    const WIDE_DECIMAL_SQL: &str = "123456789012345678901234567890.12";
+    const WIDE_DECIMAL_MANTISSA: i128 = 12_345_678_901_234_567_890_123_456_789_012;
 
     #[test]
     fn test_try_from_row_for_tuple_0() -> Result<()> {
@@ -877,7 +886,7 @@ mod tests {
 
         assert_eq!(row.get_ref(0)?, ValueRef::HugeInt(1));
         assert_eq!(row.get_ref(1)?, ValueRef::UHugeInt(2));
-        assert_eq!(row.get_ref(2)?, ValueRef::HugeInt(3));
+        assert_eq!(row.get_ref(2)?, ValueRef::Decimal(Decimal::new(38, 0, 3)?));
         assert_eq!(row.get_ref(3)?, ValueRef::UHugeInt(u128::MAX));
 
         Ok(())
@@ -913,6 +922,38 @@ mod tests {
             row.get_ref(0).map(|value| value.to_owned())
         })?;
         assert_eq!(decimal, Value::HugeInt(5));
+
+        Ok(())
+    }
+
+    #[test]
+    fn decimal_columns_use_duck_decimal_carrier() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let value = db.query_row("SELECT 1.23::DECIMAL(38,2)", [], |row| {
+            row.get_ref(0).map(|value| value.to_owned())
+        })?;
+        assert_eq!(value, Value::Decimal(Decimal::new(38, 2, 123)?));
+
+        let value = db.query_row("SELECT 3::DECIMAL(38,0)", [], |row| {
+            row.get_ref(0).map(|value| value.to_owned())
+        })?;
+        match value {
+            Value::Decimal(decimal) => {
+                assert_eq!(decimal.width(), 38);
+                assert_eq!(decimal, Decimal::new(38, 0, 3)?);
+            }
+            other => panic!("expected decimal, got {other:?}"),
+        }
+
+        let decimal = db.query_row(&format!("SELECT {WIDE_DECIMAL_SQL}::DECIMAL(38,2)"), [], |row| {
+            assert_eq!(
+                row.get_ref(0)?,
+                ValueRef::Decimal(Decimal::new(38, 2, WIDE_DECIMAL_MANTISSA)?)
+            );
+            row.get::<_, Decimal>(0)
+        })?;
+        assert_eq!(decimal, Decimal::new(38, 2, WIDE_DECIMAL_MANTISSA)?);
 
         Ok(())
     }
@@ -976,6 +1017,52 @@ mod tests {
             }
             other => panic!("expected struct, got {other:?}"),
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn nested_scale_zero_decimal_uses_decimal_when_width_is_unambiguous() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let list = db.query_row("SELECT [3::DECIMAL(5,0)]", [], |row| {
+            let value = row.get_ref(0)?;
+            assert!(matches!(value.data_type(), Type::List(ref inner) if **inner == Type::Decimal));
+            Ok(value.to_owned())
+        })?;
+
+        assert_eq!(list, Value::List(vec![Value::Decimal(Decimal::new(5, 0, 3)?)]));
+
+        let structure = db.query_row("SELECT struct_pack(a := 1.5::DECIMAL(5,1))", [], |row| {
+            let value = row.get_ref(0)?;
+            assert!(matches!(value.data_type(), Type::Struct(_)));
+            Ok(value.to_owned())
+        })?;
+
+        match structure {
+            Value::Struct(fields) => {
+                assert_eq!(
+                    fields.get(&"a".to_string()),
+                    Some(&Value::Decimal(Decimal::new(5, 1, 15)?))
+                );
+            }
+            other => panic!("expected struct, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn nested_decimal_38_0_keeps_metadata_less_hugeint_fallback() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let list = db.query_row("SELECT [3::DECIMAL(38,0)]", [], |row| {
+            let value = row.get_ref(0)?;
+            assert!(matches!(value.data_type(), Type::List(ref inner) if **inner == Type::Decimal));
+            Ok(value.to_owned())
+        })?;
+
+        assert_eq!(list, Value::List(vec![Value::HugeInt(3)]));
 
         Ok(())
     }

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -927,7 +927,7 @@ mod tests {
     }
 
     #[test]
-    fn decimal_columns_use_duck_decimal_carrier() -> Result<()> {
+    fn decimal_columns_use_native_decimal_carrier() -> Result<()> {
         let db = Connection::open_in_memory()?;
 
         let value = db.query_row("SELECT 1.23::DECIMAL(38,2)", [], |row| {

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -1741,7 +1741,7 @@ mod test {
     }
 
     #[test]
-    fn test_with_duck_decimal() -> Result<()> {
+    fn test_with_native_decimal() -> Result<()> {
         let db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE foo(x DECIMAL(38, 2));")?;
 

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -681,9 +681,8 @@ mod test {
         Connection, Error, Result,
         core::LogicalTypeId,
         params_from_iter,
-        types::{ListType, ToSql, ToSqlOutput, Type, ValueRef},
+        types::{Decimal, ListType, ToSql, ToSqlOutput, Type, ValueRef},
     };
-    use rust_decimal::Decimal;
 
     struct BorrowedList(ListArray);
     impl BorrowedList {
@@ -1725,45 +1724,73 @@ mod test {
             COMMIT;",
         )?;
 
-        // If duckdb's scale is larger than rust_decimal's scale, value should not be truncated.
-        let value = Decimal::from_i128_with_scale(12345, 4);
+        // If DuckDB's scale matches the value scale, the scaled integer is preserved.
+        let value = Decimal::new(18, 4, 12345)?;
         db.execute("INSERT INTO foo(x) VALUES (?)", [&value])?;
         let row: Decimal = db.query_row("SELECT x FROM foo", [], |r| r.get::<_, Decimal>(0))?;
         assert_eq!(row, value);
 
-        // If duckdb's scale is smaller than rust_decimal's scale, value should be truncated (1.2345 -> 1.23).
-        let value = Decimal::from_i128_with_scale(12345, 4);
+        // If DuckDB's scale is smaller than the value scale, DuckDB coerces
+        // 1.2345 to the target DECIMAL(18,2) value.
+        let value = Decimal::new(18, 4, 12345)?;
         db.execute("INSERT INTO bar(y) VALUES (?)", [&value])?;
         let row: Decimal = db.query_row("SELECT y FROM bar", [], |r| r.get::<_, Decimal>(0))?;
-        assert_eq!(row, Decimal::from_i128_with_scale(123, 2));
+        assert_eq!(row, Decimal::new(18, 2, 123)?);
 
         Ok(())
     }
 
     #[test]
-    fn test_decimal_from_sql_integer_and_float() -> Result<()> {
+    fn test_with_duck_decimal() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE foo(x DECIMAL(38, 2));")?;
+
+        let value = Decimal::new(38, 2, 12_345_678_901_234_567_890_123_456_789_012)?;
+        db.execute("INSERT INTO foo(x) VALUES (?)", [&value])?;
+
+        let row: Decimal = db.query_row("SELECT x FROM foo", [], |r| r.get(0))?;
+        assert_eq!(row, value);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decimal_from_sql_integer() -> Result<()> {
         let db = Connection::open_in_memory()?;
 
         // FromSql: INTEGER -> Decimal
         let row: Decimal = db.query_row("SELECT 42", [], |r| r.get(0))?;
-        assert_eq!(row, Decimal::from(42));
+        assert_eq!(row, Decimal::new(2, 0, 42)?);
 
         // FromSql: BIGINT -> Decimal
         let row: Decimal = db.query_row("SELECT 9999999999::BIGINT", [], |r| r.get(0))?;
-        assert_eq!(row, Decimal::from(9999999999_i64));
-
-        // FromSql: DOUBLE -> Decimal (inherits float imprecision)
-        let row: Decimal = db.query_row("SELECT 3.14::DOUBLE", [], |r| r.get(0))?;
-        let diff = (row - Decimal::from_str_exact("3.14").unwrap()).abs();
-        assert!(diff < Decimal::from_str_exact("0.0001").unwrap());
-
-        // FromSql: VARCHAR -> Decimal
-        let row: Decimal = db.query_row("SELECT '123.456'::VARCHAR", [], |r| r.get(0))?;
-        assert_eq!(row, Decimal::from_str_exact("123.456").unwrap());
+        assert_eq!(row, Decimal::new(10, 0, 9999999999_i64 as i128)?);
 
         // FromSql: HUGEINT -> Decimal
         let row: Decimal = db.query_row("SELECT 12345678901234567890::HUGEINT", [], |r| r.get(0))?;
-        assert_eq!(row, Decimal::from_i128_with_scale(12345678901234567890, 0));
+        assert_eq!(row, Decimal::new(20, 0, 12345678901234567890)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decimal_from_sql_float_targets_preserve_fraction() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let row: f64 = db.query_row("SELECT 123.45::DECIMAL(10,2)", [], |r| r.get(0))?;
+        assert!((row - 123.45).abs() < f64::EPSILON);
+
+        let row: f32 = db.query_row("SELECT 0.4::DECIMAL(10,1)", [], |r| r.get(0))?;
+        assert!((row - 0.4).abs() < f32::EPSILON);
+
+        let row: f32 = db.query_row("SELECT -0.4::DECIMAL(10,1)", [], |r| r.get(0))?;
+        assert!((row + 0.4).abs() < f32::EPSILON);
+
+        let row: f64 = db.query_row("SELECT 1.5::DECIMAL(10,1)", [], |r| r.get(0))?;
+        assert!((row - 1.5).abs() < f64::EPSILON);
+
+        let row: f64 = db.query_row("SELECT -1.5::DECIMAL(10,1)", [], |r| r.get(0))?;
+        assert!((row + 1.5).abs() < f64::EPSILON);
 
         Ok(())
     }

--- a/crates/duckdb/src/test_all_types.rs
+++ b/crates/duckdb/src/test_all_types.rs
@@ -1,9 +1,8 @@
 use pretty_assertions::assert_eq;
-use rust_decimal::Decimal;
 
 use crate::{
     Connection,
-    types::{OrderedMap, TimeUnit, Type, Value, ValueRef},
+    types::{Decimal, OrderedMap, TimeUnit, Type, Value, ValueRef},
 };
 
 #[test]
@@ -20,7 +19,7 @@ fn test_large_arrow_types() -> crate::Result<()> {
 }
 
 fn test_with_database(database: &Connection) -> crate::Result<()> {
-    let excluded = ["time_tz", "time_ns", "dec38_10", "bignum", "geometry"];
+    let excluded = ["time_tz", "time_ns", "bignum", "geometry"];
 
     let mut binding = database.prepare(&format!(
         "SELECT * EXCLUDE ({}) FROM test_all_types()",
@@ -115,8 +114,8 @@ fn test_single(idx: &mut i32, column: String, value: ValueRef<'_>) {
             _ => assert_eq!(value, ValueRef::Null),
         },
         "decimal" => match idx {
-            0 => assert_eq!(value, ValueRef::Decimal(Decimal::from_i128_with_scale(0, 0))),
-            1 => assert_eq!(value, ValueRef::Decimal(Decimal::from_i128_with_scale(1, 0))),
+            0 => assert_eq!(value, ValueRef::Decimal(Decimal::new(18, 0, 0).unwrap())),
+            1 => assert_eq!(value, ValueRef::Decimal(Decimal::new(18, 0, 1).unwrap())),
             _ => assert_eq!(value, ValueRef::Null),
         },
         "date" => match idx {
@@ -155,23 +154,34 @@ fn test_single(idx: &mut i32, column: String, value: ValueRef<'_>) {
             _ => assert_eq!(value, ValueRef::Null),
         },
         "dec_4_1" => match idx {
-            0 => assert_eq!(value, ValueRef::Decimal(Decimal::from_i128_with_scale(-9999, 1))),
-            1 => assert_eq!(value, ValueRef::Decimal(Decimal::from_i128_with_scale(9999, 1))),
+            0 => assert_eq!(value, ValueRef::Decimal(Decimal::new(4, 1, -9999).unwrap())),
+            1 => assert_eq!(value, ValueRef::Decimal(Decimal::new(4, 1, 9999).unwrap())),
             _ => assert_eq!(value, ValueRef::Null),
         },
         "dec_9_4" => match idx {
-            0 => assert_eq!(value, ValueRef::Decimal(Decimal::from_i128_with_scale(-999999999, 4))),
-            1 => assert_eq!(value, ValueRef::Decimal(Decimal::from_i128_with_scale(999999999, 4))),
+            0 => assert_eq!(value, ValueRef::Decimal(Decimal::new(9, 4, -999999999).unwrap())),
+            1 => assert_eq!(value, ValueRef::Decimal(Decimal::new(9, 4, 999999999).unwrap())),
             _ => assert_eq!(value, ValueRef::Null),
         },
         "dec_18_6" => match idx {
             0 => assert_eq!(
                 value,
-                ValueRef::Decimal(Decimal::from_i128_with_scale(-999999999999999999, 6))
+                ValueRef::Decimal(Decimal::new(18, 6, -999999999999999999).unwrap())
             ),
             1 => assert_eq!(
                 value,
-                ValueRef::Decimal(Decimal::from_i128_with_scale(999999999999999999, 6))
+                ValueRef::Decimal(Decimal::new(18, 6, 999999999999999999).unwrap())
+            ),
+            _ => assert_eq!(value, ValueRef::Null),
+        },
+        "dec38_10" => match idx {
+            0 => assert_eq!(
+                value,
+                ValueRef::Decimal(Decimal::new(38, 10, -99_999_999_999_999_999_999_999_999_999_999_999_999).unwrap())
+            ),
+            1 => assert_eq!(
+                value,
+                ValueRef::Decimal(Decimal::new(38, 10, 99_999_999_999_999_999_999_999_999_999_999_999_999).unwrap())
             ),
             _ => assert_eq!(value, ValueRef::Null),
         },

--- a/crates/duckdb/src/types/decimal.rs
+++ b/crates/duckdb/src/types/decimal.rs
@@ -1,33 +1,285 @@
+use std::{
+    error, fmt,
+    hash::{Hash, Hasher},
+};
+
+use crate::{
+    Result, ToSql, ffi,
+    types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, Value, ValueRef},
+};
+
+use super::{TimeUnit, to_duckdb_hugeint};
+
+#[cfg(feature = "rust_decimal")]
 use rust_decimal::prelude::FromPrimitive as _;
 
-use super::TimeUnit;
-use crate::types::{FromSql, FromSqlError, FromSqlResult, ToSqlOutput, Value, ValueRef};
-use crate::{Result, ToSql, ffi};
+/// A DuckDB `DECIMAL(width, scale)` value.
+///
+/// `value` stores the scaled integer payload. For example,
+/// `123.45::DECIMAL(9, 2)` is represented as
+/// `Decimal::new(9, 2, 12345)?`.
+///
+/// The declared width is preserved when reading and writing DuckDB `DECIMAL`
+/// columns. Values converted from non-decimal sources, such as integers or
+/// `rust_decimal` values, infer the smallest width that can represent the
+/// scaled payload. Width is not part of equality or hashing: values with the
+/// same `scale` and scaled integer payload compare equal even if they arrived
+/// through paths with different declared widths. Use [`Decimal::width`] when
+/// the declared width matters; `Eq` and `Hash` do not preserve it.
+///
+/// Scale is part of identity: `DECIMAL(2, 1)` with payload `12` and
+/// `DECIMAL(3, 2)` with payload `120` compare different. `Decimal`
+/// intentionally does not implement `Ord` or `PartialOrd`; sort in SQL or
+/// compare an explicitly normalized representation when ordering is needed.
+#[derive(Copy, Clone, Debug)]
+pub struct Decimal {
+    width: u8,
+    scale: u8,
+    value: i128,
+}
 
-/// Convert a rust_decimal::Decimal to a ffi::duckdb_decimal
-pub(crate) fn to_duckdb_decimal(d: rust_decimal::Decimal) -> ffi::duckdb_decimal {
-    // The max value of rust_decimal's scale is 28.
-    let d_scale = d.scale() as u8;
-    let d_width = decimal_width(d).max(d_scale);
-    let mantissa = d.mantissa();
-    let d_value = ffi::duckdb_hugeint {
-        lower: mantissa as u64,
-        upper: (mantissa >> 64) as i64,
-    };
-
-    ffi::duckdb_decimal {
-        width: d_width,
-        scale: d_scale,
-        value: d_value,
+impl PartialEq for Decimal {
+    fn eq(&self, other: &Self) -> bool {
+        self.scale == other.scale && self.value == other.value
     }
 }
 
-/// Get the length of the decimal significant digits of a rust_decimal::Decimal
-fn decimal_width(d: rust_decimal::Decimal) -> u8 {
-    let abs = d.mantissa().unsigned_abs();
-    if abs == 0 { 1 } else { abs.ilog10() as u8 + 1 }
+impl Eq for Decimal {}
+
+impl Hash for Decimal {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.scale.hash(state);
+        self.value.hash(state);
+    }
 }
 
+impl fmt::Display for Decimal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let scale = usize::from(self.scale);
+        let raw = self.value.unsigned_abs().to_string();
+
+        if scale == 0 {
+            return f.pad_integral(!self.value.is_negative(), "", &raw);
+        }
+
+        let mut magnitude = String::new();
+        if raw.len() <= scale {
+            magnitude.push_str("0.");
+            for _ in 0..(scale - raw.len()) {
+                magnitude.push('0');
+            }
+            magnitude.push_str(&raw);
+        } else {
+            let point = raw.len() - scale;
+            magnitude.push_str(&raw[..point]);
+            magnitude.push('.');
+            magnitude.push_str(&raw[point..]);
+        }
+
+        f.pad_integral(!self.value.is_negative(), "", &magnitude)
+    }
+}
+
+impl Decimal {
+    /// DuckDB's maximum `DECIMAL` width.
+    pub const MAX_WIDTH: u8 = 38;
+
+    /// Builds a valid `DECIMAL(width, scale)` wrapper.
+    ///
+    /// Returns [`DecimalError`] when `width` is outside DuckDB's `1..=38`
+    /// range, `scale` is larger than `width`, or `value` has more digits than
+    /// `width` allows.
+    pub fn new(width: u8, scale: u8, value: i128) -> std::result::Result<Self, DecimalError> {
+        if width == 0 || width > Self::MAX_WIDTH {
+            return Err(DecimalError::InvalidWidth {
+                width,
+                max: Self::MAX_WIDTH,
+            });
+        }
+        if scale > width {
+            return Err(DecimalError::ScaleExceedsWidth { scale, width });
+        }
+        let digits = decimal_digits(value);
+        if digits > width {
+            return Err(DecimalError::ValueExceedsWidth { digits, width });
+        }
+        Ok(Self { width, scale, value })
+    }
+
+    /// Builds a decimal value from trusted DuckDB output.
+    ///
+    /// The caller must ensure `width`, `scale`, and `value` are a valid DuckDB
+    /// decimal triple.
+    pub(crate) fn from_chunk(width: u8, scale: u8, value: i128) -> Self {
+        debug_assert!(
+            Self::new(width, scale, value).is_ok(),
+            "DuckDB produced an invalid decimal triple"
+        );
+        Self { width, scale, value }
+    }
+
+    /// Returns the declared precision for DuckDB `DECIMAL` values.
+    ///
+    /// Values converted from non-decimal sources infer the smallest width that
+    /// can represent the scaled payload.
+    #[inline]
+    pub const fn width(self) -> u8 {
+        self.width
+    }
+
+    /// Returns the number of fractional digits.
+    #[inline]
+    pub const fn scale(self) -> u8 {
+        self.scale
+    }
+
+    /// Returns the scaled integer payload.
+    #[inline]
+    pub const fn value(self) -> i128 {
+        self.value
+    }
+}
+
+/// Error returned when constructing an invalid [`Decimal`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecimalError {
+    /// The width is outside DuckDB's supported range.
+    InvalidWidth {
+        /// The requested width.
+        width: u8,
+        /// DuckDB's maximum decimal width.
+        max: u8,
+    },
+    /// The scale is larger than the width.
+    ScaleExceedsWidth {
+        /// The requested scale.
+        scale: u8,
+        /// The requested width.
+        width: u8,
+    },
+    /// The scaled integer payload has more digits than the width allows.
+    ValueExceedsWidth {
+        /// Number of digits in the payload.
+        digits: u8,
+        /// The requested width.
+        width: u8,
+    },
+}
+
+impl fmt::Display for DecimalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::InvalidWidth { width, max } => {
+                write!(f, "decimal width {width} is outside DuckDB's 1..={max} range")
+            }
+            Self::ScaleExceedsWidth { scale, width } => {
+                write!(f, "decimal scale {scale} exceeds width {width}")
+            }
+            Self::ValueExceedsWidth { digits, width } => {
+                write!(f, "decimal value has {digits} digits, exceeding width {width}")
+            }
+        }
+    }
+}
+
+impl error::Error for DecimalError {}
+
+impl From<DecimalError> for crate::Error {
+    fn from(err: DecimalError) -> Self {
+        Self::ToSqlConversionFailure(err.into())
+    }
+}
+
+pub(crate) fn to_duckdb_decimal(decimal: Decimal) -> ffi::duckdb_decimal {
+    ffi::duckdb_decimal {
+        width: decimal.width,
+        scale: decimal.scale,
+        value: to_duckdb_hugeint(decimal.value),
+    }
+}
+
+fn decimal_digits_unsigned(value: u128) -> u8 {
+    value.checked_ilog10().map_or(1, |digits| digits as u8 + 1)
+}
+
+fn decimal_digits(value: i128) -> u8 {
+    decimal_digits_unsigned(value.unsigned_abs())
+}
+
+fn integer_decimal(value: i128) -> FromSqlResult<Decimal> {
+    let digits = decimal_digits(value);
+    if digits > Decimal::MAX_WIDTH {
+        return Err(FromSqlError::OutOfRange(value));
+    }
+    Ok(Decimal::from_chunk(digits, 0, value))
+}
+
+fn unsigned_integer_decimal(value: u128) -> FromSqlResult<Decimal> {
+    let digits = decimal_digits_unsigned(value);
+    if digits > Decimal::MAX_WIDTH {
+        return Err(FromSqlError::OutOfRangeUnsigned(value));
+    }
+    Ok(Decimal::from_chunk(digits, 0, value as i128))
+}
+
+impl ToSql for Decimal {
+    fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::Owned(Value::Decimal(*self)))
+    }
+}
+
+impl FromSql for Decimal {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        match value {
+            ValueRef::Decimal(decimal) => Ok(decimal),
+            ValueRef::TinyInt(i) => integer_decimal(i as i128),
+            ValueRef::SmallInt(i) => integer_decimal(i as i128),
+            ValueRef::Int(i) => integer_decimal(i as i128),
+            ValueRef::BigInt(i) => integer_decimal(i as i128),
+            ValueRef::HugeInt(i) => integer_decimal(i),
+            ValueRef::UHugeInt(i) => unsigned_integer_decimal(i),
+            ValueRef::UTinyInt(i) => integer_decimal(i as i128),
+            ValueRef::USmallInt(i) => integer_decimal(i as i128),
+            ValueRef::UInt(i) => integer_decimal(i as i128),
+            ValueRef::UBigInt(i) => integer_decimal(i as i128),
+            ValueRef::Timestamp(_, i) => integer_decimal(i as i128),
+            ValueRef::Date32(i) => integer_decimal(i as i128),
+            ValueRef::Time64(TimeUnit::Microsecond, i) => integer_decimal(i as i128),
+            _ => Err(FromSqlError::InvalidType),
+        }
+    }
+}
+
+#[cfg(feature = "rust_decimal")]
+impl From<rust_decimal::Decimal> for Decimal {
+    fn from(decimal: rust_decimal::Decimal) -> Self {
+        let scale = decimal.scale() as u8;
+        let mantissa = decimal.mantissa();
+        let width = decimal_digits(mantissa).max(scale);
+
+        // rust_decimal's scale is <= 28 and its mantissa fits in 96 bits, so
+        // every valid rust_decimal value fits DuckDB's DECIMAL(38, scale).
+        Self::new(width, scale, mantissa).expect("rust_decimal values fit DuckDB DECIMAL")
+    }
+}
+
+#[cfg(feature = "rust_decimal")]
+impl TryFrom<Decimal> for rust_decimal::Decimal {
+    type Error = rust_decimal::Error;
+
+    fn try_from(decimal: Decimal) -> std::result::Result<Self, Self::Error> {
+        Self::try_from_i128_with_scale(decimal.value(), u32::from(decimal.scale()))
+    }
+}
+
+#[cfg(feature = "rust_decimal")]
+impl ToSql for rust_decimal::Decimal {
+    fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::Owned(Value::Decimal((*self).into())))
+    }
+}
+
+#[cfg(feature = "rust_decimal")]
 fn invalid_decimal_float(kind: &str, value: impl std::fmt::Debug) -> FromSqlError {
     FromSqlError::Other(Box::new(std::io::Error::new(
         std::io::ErrorKind::InvalidData,
@@ -35,23 +287,21 @@ fn invalid_decimal_float(kind: &str, value: impl std::fmt::Debug) -> FromSqlErro
     )))
 }
 
+#[cfg(feature = "rust_decimal")]
 fn decimal_from_f32(value: f32) -> FromSqlResult<rust_decimal::Decimal> {
     rust_decimal::Decimal::from_f32(value).ok_or_else(|| invalid_decimal_float("FLOAT", value))
 }
 
+#[cfg(feature = "rust_decimal")]
 fn decimal_from_f64(value: f64) -> FromSqlResult<rust_decimal::Decimal> {
     rust_decimal::Decimal::from_f64(value).ok_or_else(|| invalid_decimal_float("DOUBLE", value))
 }
 
-impl ToSql for rust_decimal::Decimal {
-    fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        Ok(ToSqlOutput::Owned(Value::Decimal(*self)))
-    }
-}
-
+#[cfg(feature = "rust_decimal")]
 impl FromSql for rust_decimal::Decimal {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         match value {
+            ValueRef::Decimal(decimal) => decimal.try_into().map_err(|err| FromSqlError::Other(Box::new(err))),
             ValueRef::TinyInt(i) => rust_decimal::Decimal::from_i8(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::SmallInt(i) => rust_decimal::Decimal::from_i16(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::Int(i) => rust_decimal::Decimal::from_i32(i).ok_or(FromSqlError::OutOfRange(i as i128)),
@@ -64,7 +314,6 @@ impl FromSql for rust_decimal::Decimal {
             ValueRef::UBigInt(i) => rust_decimal::Decimal::from_u64(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::Float(f) => decimal_from_f32(f),
             ValueRef::Double(d) => decimal_from_f64(d),
-            ValueRef::Decimal(decimal) => Ok(decimal),
             ValueRef::Timestamp(_, i) => rust_decimal::Decimal::from_i64(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::Date32(i) => rust_decimal::Decimal::from_i32(i).ok_or(FromSqlError::OutOfRange(i as i128)),
             ValueRef::Time64(TimeUnit::Microsecond, i) => {
@@ -87,44 +336,130 @@ impl FromSql for rust_decimal::Decimal {
 
 #[cfg(test)]
 mod test {
-    use rust_decimal::Decimal;
-
     use super::*;
     use crate::{Connection, Error, Result};
 
     #[test]
-    fn test_to_duckdb_decimal_large_negative_upper_bits() {
-        let decimal = Decimal::from_i128_with_scale(-7922816251426433759354395033_i128, 10);
+    fn decimal_new_accepts_valid_values() -> Result<()> {
+        let decimal = Decimal::new(9, 2, 12345)?;
+
+        assert_eq!(decimal.width(), 9);
+        assert_eq!(decimal.scale(), 2);
+        assert_eq!(decimal.value(), 12345);
+
+        Ok(())
+    }
+
+    #[test]
+    fn decimal_identity_ignores_width() {
+        use std::collections::HashSet;
+
+        let declared = Decimal::new(38, 0, 3).unwrap();
+        let inferred = Decimal::new(1, 0, 3).unwrap();
+
+        assert_eq!(declared.width(), 38);
+        assert_eq!(inferred.width(), 1);
+        assert_eq!(declared, inferred);
+        assert_eq!(Value::Decimal(declared), Value::Decimal(inferred));
+
+        let mut values = HashSet::new();
+        values.insert(declared);
+        values.insert(inferred);
+
+        assert_eq!(values.len(), 1);
+    }
+
+    #[test]
+    fn decimal_identity_keeps_scale() {
+        use std::collections::HashSet;
+
+        let integer = Decimal::new(2, 0, 10).unwrap();
+        let fractional = Decimal::new(2, 1, 10).unwrap();
+
+        assert_ne!(integer, fractional);
+
+        let mut values = HashSet::new();
+        values.insert(integer);
+        values.insert(fractional);
+
+        assert_eq!(values.len(), 2);
+    }
+
+    #[test]
+    fn decimal_display_renders_scaled_value() {
+        assert_eq!(Decimal::new(9, 2, 12345).unwrap().to_string(), "123.45");
+        assert_eq!(Decimal::new(3, 3, 1).unwrap().to_string(), "0.001");
+        assert_eq!(Decimal::new(4, 3, -1).unwrap().to_string(), "-0.001");
+        assert_eq!(Decimal::new(3, 0, -123).unwrap().to_string(), "-123");
+        assert_eq!(Decimal::new(5, 2, -12345).unwrap().to_string(), "-123.45");
+        assert_eq!(Decimal::new(2, 2, 99).unwrap().to_string(), "0.99");
+        assert_eq!(Decimal::new(1, 0, 0).unwrap().to_string(), "0");
+        assert_eq!(format!("{:>10}", Decimal::new(9, 2, 12345).unwrap()), "    123.45");
+        assert_eq!(format!("{:+}", Decimal::new(9, 2, 12345).unwrap()), "+123.45");
+        assert_eq!(format!("{:08}", Decimal::new(9, 2, 12345).unwrap()), "00123.45");
+    }
+
+    #[test]
+    fn decimal_new_rejects_invalid_values() {
+        assert!(Decimal::new(3, 3, 1).is_ok());
+        assert_eq!(
+            Decimal::new(0, 0, 0).unwrap_err(),
+            DecimalError::InvalidWidth {
+                width: 0,
+                max: Decimal::MAX_WIDTH,
+            }
+        );
+        assert_eq!(
+            Decimal::new(39, 0, 0).unwrap_err(),
+            DecimalError::InvalidWidth {
+                width: 39,
+                max: Decimal::MAX_WIDTH,
+            }
+        );
+        assert_eq!(
+            Decimal::new(9, 10, 0).unwrap_err(),
+            DecimalError::ScaleExceedsWidth { scale: 10, width: 9 }
+        );
+        assert_eq!(
+            Decimal::new(2, 1, 100).unwrap_err(),
+            DecimalError::ValueExceedsWidth { digits: 3, width: 2 }
+        );
+        assert_eq!(
+            Decimal::new(38, 0, i128::MAX).unwrap_err(),
+            DecimalError::ValueExceedsWidth { digits: 39, width: 38 }
+        );
+    }
+
+    #[test]
+    fn test_to_duckdb_decimal_large_negative_upper_bits() -> Result<()> {
+        let decimal = Decimal::new(28, 10, -7922816251426433759354395033_i128)?;
         let duck_decimal = to_duckdb_decimal(decimal);
 
         assert_eq!(duck_decimal.width, 28);
         assert_eq!(duck_decimal.scale, 10);
         assert_eq!(duck_decimal.value.lower, 7_378_697_629_483_820_647);
         assert_eq!(duck_decimal.value.upper, -429_496_730);
+        Ok(())
     }
 
     #[test]
-    fn test_to_duckdb_decimal_zero_and_max_boundaries() {
-        let zero = to_duckdb_decimal(Decimal::ZERO);
+    fn test_to_duckdb_decimal_zero_and_boundaries() -> Result<()> {
+        let zero = to_duckdb_decimal(Decimal::new(1, 0, 0)?);
         assert_eq!(zero.width, 1);
         assert_eq!(zero.scale, 0);
         assert_eq!(zero.value.lower, 0);
         assert_eq!(zero.value.upper, 0);
 
-        let max = to_duckdb_decimal(Decimal::MAX);
-        assert_eq!(max.width, 29);
+        let max = to_duckdb_decimal(Decimal::new(
+            38,
+            0,
+            99_999_999_999_999_999_999_999_999_999_999_999_999_i128,
+        )?);
+        assert_eq!(max.width, 38);
         assert_eq!(max.scale, 0);
-        assert_eq!(max.value.lower, u64::MAX);
-        assert_eq!(max.value.upper, 4_294_967_295);
-    }
-
-    #[test]
-    fn test_from_sql_hugeint_overflow_is_out_of_range() {
-        let err = Decimal::column_result(ValueRef::HugeInt(i128::MAX)).unwrap_err();
-        match err {
-            FromSqlError::OutOfRange(value) => assert_eq!(value, i128::MAX),
-            _ => panic!("expected OutOfRange, got {err}"),
-        }
+        assert_eq!(max.value.lower, 687_399_551_400_673_279);
+        assert_eq!(max.value.upper, 5_421_010_862_427_522_170);
+        Ok(())
     }
 
     #[test]
@@ -132,8 +467,54 @@ mod test {
         let err = Decimal::column_result(ValueRef::UHugeInt(u128::MAX)).unwrap_err();
         match err {
             FromSqlError::OutOfRangeUnsigned(value) => assert_eq!(value, u128::MAX),
+            _ => panic!("expected OutOfRangeUnsigned, got {err}"),
+        }
+    }
+
+    #[test]
+    fn test_from_sql_integer_decimal_overflow_is_out_of_range() {
+        let err = Decimal::column_result(ValueRef::HugeInt(i128::MAX)).unwrap_err();
+        match err {
+            FromSqlError::OutOfRange(value) => assert_eq!(value, i128::MAX),
             _ => panic!("expected OutOfRange, got {err}"),
         }
+
+        let value = 10_u128.pow(38);
+        let err = Decimal::column_result(ValueRef::UHugeInt(value)).unwrap_err();
+        match err {
+            FromSqlError::OutOfRangeUnsigned(err_value) => assert_eq!(err_value, value),
+            _ => panic!("expected OutOfRangeUnsigned, got {err}"),
+        }
+    }
+
+    #[test]
+    fn test_from_sql_time_values_as_decimal() -> Result<()> {
+        assert_eq!(
+            Decimal::column_result(ValueRef::Timestamp(TimeUnit::Second, -123))?,
+            Decimal::new(3, 0, -123)?
+        );
+        assert_eq!(Decimal::column_result(ValueRef::Date32(42))?, Decimal::new(2, 0, 42)?);
+        assert_eq!(
+            Decimal::column_result(ValueRef::Time64(TimeUnit::Microsecond, 1_234_567))?,
+            Decimal::new(7, 0, 1_234_567)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_native_decimal_rejects_float_double_and_text() {
+        assert_eq!(
+            Decimal::column_result(ValueRef::Float(1.25)),
+            Err(FromSqlError::InvalidType)
+        );
+        assert_eq!(
+            Decimal::column_result(ValueRef::Double(1.25)),
+            Err(FromSqlError::InvalidType)
+        );
+        assert_eq!(
+            Decimal::column_result(ValueRef::Text(b"123.456")),
+            Err(FromSqlError::InvalidType)
+        );
     }
 
     #[test]
@@ -143,7 +524,7 @@ mod test {
         let db = Connection::open_in_memory()?;
 
         let value: Decimal = db.query_row("SELECT (5)::UHUGEINT", [], |row| row.get(0))?;
-        assert_eq!(value, Decimal::from(5));
+        assert_eq!(value, Decimal::new(1, 0, 5)?);
 
         let err = db
             .query_row(&format!("SELECT ({U128_MAX_SQL})::UHUGEINT"), [], |row| {
@@ -159,22 +540,82 @@ mod test {
         Ok(())
     }
 
+    #[cfg(feature = "rust_decimal")]
     #[test]
-    fn test_from_sql_unrepresentable_float_errors_are_descriptive() {
-        let err = Decimal::column_result(ValueRef::Float(f32::INFINITY)).unwrap_err();
+    fn test_rust_decimal_converts_to_native_decimal() {
+        let decimal = rust_decimal::Decimal::from_i128_with_scale(12345, 2);
+        let native = Decimal::from(decimal);
+
+        assert_eq!(native, Decimal::new(5, 2, 12345).unwrap());
+
+        let decimal = rust_decimal::Decimal::from_i128_with_scale(1, 3);
+        let native = Decimal::from(decimal);
+
+        assert_eq!(native, Decimal::new(3, 3, 1).unwrap());
+    }
+
+    #[cfg(feature = "rust_decimal")]
+    #[test]
+    fn test_rust_decimal_round_trips_through_decimal_column() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let value = rust_decimal::Decimal::from_i128_with_scale(12345, 2);
+
+        let read: rust_decimal::Decimal = db.query_row("SELECT ?::DECIMAL(5,2)", [value], |row| row.get(0))?;
+
+        assert_eq!(read, value);
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_decimal")]
+    #[test]
+    fn test_rust_decimal_reads_representable_wide_duckdb_decimal() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let read: rust_decimal::Decimal = db.query_row("SELECT 1.23::DECIMAL(38,2)", [], |row| row.get(0))?;
+
+        assert_eq!(read, rust_decimal::Decimal::from_i128_with_scale(123, 2));
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_decimal")]
+    #[test]
+    fn test_rust_decimal_compat_reads_float_double_and_text() {
+        let float = rust_decimal::Decimal::column_result(ValueRef::Float(1.25)).unwrap();
+        assert_eq!(float, rust_decimal::Decimal::from_f32(1.25).unwrap());
+
+        let double = rust_decimal::Decimal::column_result(ValueRef::Double(1.25)).unwrap();
+        assert_eq!(double, rust_decimal::Decimal::from_f64(1.25).unwrap());
+
+        let text = rust_decimal::Decimal::column_result(ValueRef::Text(b"123.456")).unwrap();
+        assert_eq!(text, "123.456".parse::<rust_decimal::Decimal>().unwrap());
+    }
+
+    #[cfg(feature = "rust_decimal")]
+    #[test]
+    fn test_rust_decimal_errors_on_oversized_duckdb_decimal() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+
+        let err = db
+            .query_row("SELECT 123456789012345678901234567890.12::DECIMAL(38,2)", [], |row| {
+                row.get::<_, rust_decimal::Decimal>(0)
+            })
+            .unwrap_err();
+
         match err {
-            FromSqlError::Other(err) => {
-                assert_eq!(err.to_string(), "FLOAT value inf cannot be represented as Decimal");
-            }
-            _ => panic!("expected Other, got {err}"),
+            Error::FromSqlConversionFailure(0, crate::types::Type::Decimal, _) => {}
+            other => panic!("expected Decimal conversion failure, got {other:?}"),
         }
 
-        let err = Decimal::column_result(ValueRef::Double(1.5e30)).unwrap_err();
-        match err {
-            FromSqlError::Other(err) => {
-                assert_eq!(err.to_string(), "DOUBLE value 1.5e30 cannot be represented as Decimal");
-            }
-            _ => panic!("expected Other, got {err}"),
-        }
+        Ok(())
+    }
+
+    #[cfg(feature = "rust_decimal")]
+    #[test]
+    fn test_rust_decimal_unrepresentable_float_errors_are_descriptive() {
+        let err = rust_decimal::Decimal::column_result(ValueRef::Float(f32::NAN)).unwrap_err();
+        assert_eq!(err.to_string(), "FLOAT value NaN cannot be represented as Decimal");
+
+        let err = rust_decimal::Decimal::column_result(ValueRef::Double(f64::INFINITY)).unwrap_err();
+        assert_eq!(err.to_string(), "DOUBLE value inf cannot be represented as Decimal");
     }
 }

--- a/crates/duckdb/src/types/decimal.rs
+++ b/crates/duckdb/src/types/decimal.rs
@@ -433,12 +433,12 @@ mod test {
     #[test]
     fn test_to_duckdb_decimal_large_negative_upper_bits() -> Result<()> {
         let decimal = Decimal::new(28, 10, -7922816251426433759354395033_i128)?;
-        let duck_decimal = to_duckdb_decimal(decimal);
+        let duckdb_decimal = to_duckdb_decimal(decimal);
 
-        assert_eq!(duck_decimal.width, 28);
-        assert_eq!(duck_decimal.scale, 10);
-        assert_eq!(duck_decimal.value.lower, 7_378_697_629_483_820_647);
-        assert_eq!(duck_decimal.value.upper, -429_496_730);
+        assert_eq!(duckdb_decimal.width, 28);
+        assert_eq!(duckdb_decimal.scale, 10);
+        assert_eq!(duckdb_decimal.value.lower, 7_378_697_629_483_820_647);
+        assert_eq!(duckdb_decimal.value.upper, -429_496_730);
         Ok(())
     }
 

--- a/crates/duckdb/src/types/from_sql.rs
+++ b/crates/duckdb/src/types/from_sql.rs
@@ -1,9 +1,8 @@
 use std::{error::Error, fmt};
 
 use cast;
-use rust_decimal::RoundingStrategy::MidpointAwayFromZero;
 
-use super::{TimeUnit, Value, ValueRef};
+use super::{Decimal, TimeUnit, Value, ValueRef};
 
 /// Enum listing possible errors from [`FromSql`] trait.
 #[derive(Debug)]
@@ -78,8 +77,40 @@ pub trait FromSql: Sized {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self>;
 }
 
-macro_rules! from_sql_integral(
-    ($t:ident) => (
+fn rounded_decimal(value: i128, scale: u8) -> Option<i128> {
+    let divisor = 10_i128.checked_pow(u32::from(scale))?;
+    let quotient = value / divisor;
+    let remainder = value % divisor;
+
+    // Mirror DuckDB's DECIMAL-to-INTEGER cast: round to nearest, with
+    // fractional ties rounded away from zero.
+    if remainder.unsigned_abs() * 2 < divisor as u128 {
+        return Some(quotient);
+    }
+
+    if value.is_negative() {
+        quotient.checked_sub(1)
+    } else {
+        quotient.checked_add(1)
+    }
+}
+
+fn rounded_decimal_result(value: i128, scale: u8) -> FromSqlResult<i128> {
+    rounded_decimal(value, scale).ok_or(FromSqlError::OutOfRange(value))
+}
+
+fn decimal_to_f32(decimal: Decimal) -> f32 {
+    // Preserve decimal scale, while inheriting normal binary float precision loss.
+    decimal.value() as f32 / 10_f32.powi(i32::from(decimal.scale()))
+}
+
+fn decimal_to_f64(decimal: Decimal) -> f64 {
+    // Preserve decimal scale, while inheriting normal binary float precision loss.
+    decimal.value() as f64 / 10_f64.powi(i32::from(decimal.scale()))
+}
+
+macro_rules! from_sql_numeric(
+    ($t:ident, $decimal:expr) => (
         impl FromSql for $t {
             #[inline]
             fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
@@ -100,11 +131,7 @@ macro_rules! from_sql_integral(
                     ValueRef::Float(i) => <$t as cast::From<f32>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
                     ValueRef::Double(i) => <$t as cast::From<f64>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
 
-                    ValueRef::Decimal(d) => {
-                         // DuckDB rounds DECIMAL to INTEGER (following PostgreSQL behavior)
-                        let rounded = d.round_dp_with_strategy(0, MidpointAwayFromZero);
-                        <$t as cast::From<i128>>::cast(rounded.mantissa()).into_result(FromSqlError::OutOfRange(d.mantissa()))
-                    }
+                    ValueRef::Decimal(decimal) => ($decimal)(decimal),
 
                     ValueRef::Timestamp(_, i) => <$t as cast::From<i64>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
                     ValueRef::Date32(i) => <$t as cast::From<i32>>::cast(i).into_result(FromSqlError::OutOfRange(i as i128)),
@@ -121,6 +148,22 @@ macro_rules! from_sql_integral(
                 }
             }
         }
+    )
+);
+
+macro_rules! from_sql_integral(
+    ($t:ident) => (
+        from_sql_numeric!($t, |decimal: Decimal| {
+            let rounded = rounded_decimal_result(decimal.value(), decimal.scale())?;
+            <$t as cast::From<i128>>::cast(rounded)
+                .into_result(FromSqlError::OutOfRange(rounded))
+        });
+    )
+);
+
+macro_rules! from_sql_float(
+    ($t:ident, $decimal_to_float:ident) => (
+        from_sql_numeric!($t, |decimal: Decimal| Ok($decimal_to_float(decimal)));
     )
 );
 
@@ -181,8 +224,8 @@ from_sql_integral!(u32);
 from_sql_integral!(u64);
 from_sql_integral!(u128);
 from_sql_integral!(usize);
-from_sql_integral!(f32);
-from_sql_integral!(f64);
+from_sql_float!(f32, decimal_to_f32);
+from_sql_float!(f64, decimal_to_f64);
 
 impl FromSql for bool {
     #[inline]
@@ -600,6 +643,17 @@ mod test {
         );
         assert_eq!(
             db.query_row("SELECT -0.50::DECIMAL(38,2)", [], |row| row.get::<_, i32>(0))?,
+            -1
+        );
+        assert_eq!(
+            db.query_row("SELECT 0.500000000000000000000000000000::DECIMAL(38,30)", [], |row| row
+                .get::<_, i32>(0))?,
+            1
+        );
+        assert_eq!(
+            db.query_row("SELECT -0.500000000000000000000000000000::DECIMAL(38,30)", [], |row| {
+                row.get::<_, i32>(0)
+            })?,
             -1
         );
 

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -23,11 +23,30 @@
 //! aliases, or expression text. Cast the result expression so DuckDB reports
 //! stable logical metadata when a dynamic `UHUGEINT` carrier is required.
 //!
-//! DuckDB `DECIMAL(38, s)` values that do not fit `rust_decimal::Decimal`
-//! remain a separate limitation; a full-width decimal carrier can be added in a
-//! follow-up without changing the `UHUGEINT` binding support added here.
+//! DuckDB `DECIMAL` values use [`Decimal`], a full-domain carrier storing
+//! DuckDB's decimal width, scale, and scaled integer payload.
+//! Reading a [`Decimal`] as `f32` or `f64` preserves its fractional component
+//! but still inherits normal binary floating-point precision loss. Read
+//! [`Decimal`] directly when exact decimal transport matters.
+//! Enable the `rust_decimal` feature for compatibility impls that convert to
+//! and from `rust_decimal::Decimal` when the value fits that crate's smaller
+//! decimal domain, including compatibility reads from `FLOAT`, `DOUBLE`, and
+//! text columns.
+//!
+//! Arrow decimal result values use [`Value::Decimal`] and [`ValueRef::Decimal`]
+//! directly except for scale-zero `Decimal128(38, 0)`, which is also the Arrow
+//! shape DuckDB uses for `HUGEINT` and `UHUGEINT`. Top-level result columns use
+//! DuckDB logical metadata to distinguish those cases when DuckDB reports it.
+//! Narrower scale-zero `DECIMAL` widths are unambiguous and materialize as
+//! [`Decimal`] rather than the legacy signed [`Value::HugeInt`] fallback.
+//! Metadata-less scale-zero `Decimal128(38, 0)` values preserve the existing
+//! signed [`Value::HugeInt`] fallback. This affects parameter-derived
+//! expressions where DuckDB reports `Invalid` metadata, and nested container
+//! children where the borrowed container API does not carry DuckDB child
+//! logical metadata.
 
 pub use self::{
+    decimal::{Decimal, DecimalError},
     from_sql::{FromSql, FromSqlError, FromSqlResult},
     ordered_map::OrderedMap,
     string::DuckString,

--- a/crates/duckdb/src/types/value.rs
+++ b/crates/duckdb/src/types/value.rs
@@ -1,5 +1,4 @@
-use super::{Null, OrderedMap, TimeUnit, Type};
-use rust_decimal::prelude::*;
+use super::{Decimal, Null, OrderedMap, TimeUnit, Type};
 
 /// Owning [dynamic type value](https://duckdb.org/docs/stable/sql/data_types/overview.html).
 /// Value's type is typically dictated by DuckDB (not by the caller).
@@ -46,7 +45,10 @@ pub enum Value {
     Float(f32),
     /// The value is a f64.
     Double(f64),
-    /// The value is a Decimal.
+    /// The value is a DuckDB decimal.
+    ///
+    /// [`Decimal`] stores DuckDB's decimal width, scale, and scaled integer
+    /// payload.
     Decimal(Decimal),
     /// The value is a timestamp.
     Timestamp(TimeUnit, i64),
@@ -188,6 +190,13 @@ impl From<u128> for Value {
     #[inline]
     fn from(i: u128) -> Self {
         Self::UHugeInt(i)
+    }
+}
+
+impl From<Decimal> for Value {
+    #[inline]
+    fn from(decimal: Decimal) -> Self {
+        Self::Decimal(decimal)
     }
 }
 

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -1,9 +1,7 @@
 use super::{Type, Value};
-use crate::types::{FromSqlError, FromSqlResult, OrderedMap};
+use crate::types::{Decimal, FromSqlError, FromSqlResult, OrderedMap};
 
 use crate::{Error, Result, Row};
-use rust_decimal::prelude::*;
-
 use arrow::{
     array::{
         Array, ArrayRef, DictionaryArray, FixedSizeListArray, LargeListArray, ListArray, MapArray, StringArray,
@@ -82,7 +80,10 @@ pub enum ValueRef<'a> {
     Float(f32),
     /// The value is a f64.
     Double(f64),
-    /// The value is a Decimal.
+    /// The value is a DuckDB decimal.
+    ///
+    /// [`Decimal`] stores DuckDB's decimal width, scale, and scaled integer
+    /// payload.
     Decimal(Decimal),
     /// The value is a timestamp.
     Timestamp(TimeUnit, i64),
@@ -363,6 +364,13 @@ impl<'a> From<&'a [u8]> for ValueRef<'a> {
     #[inline]
     fn from(s: &[u8]) -> ValueRef<'_> {
         ValueRef::Blob(s)
+    }
+}
+
+impl From<Decimal> for ValueRef<'_> {
+    #[inline]
+    fn from(decimal: Decimal) -> Self {
+        Self::Decimal(decimal)
     }
 }
 

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, OnceLock, atomic::AtomicUsize};
 
 use crate::{
     core::{ArrayVector, FlatVector, Inserter, ListVector, LogicalTypeId, StructVector},
-    types::DuckString,
+    types::{Decimal, DuckString},
 };
 
 use arrow::{
@@ -308,7 +308,10 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalTypeHandle,
                     format!("Unsupported data type: {data_type}, negative decimal scale is not supported").into(),
                 );
             }
-            Ok(LogicalTypeHandle::decimal(*width, (*scale).try_into().unwrap()))
+            let scale = (*scale).try_into().unwrap();
+            Decimal::new(*width, scale, 0)
+                .map_err(|err| format!("Unsupported data type: {data_type}, invalid decimal type: {err}"))?;
+            Ok(LogicalTypeHandle::decimal(*width, scale))
         }
         DataType::Map(field, _) => arrow_map_to_duckdb_logical_type(field),
         DataType::Boolean
@@ -836,8 +839,8 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut FlatVector<'_>) -> Res
         DataType::Float64 => {
             primitive_array_to_flat_vector::<Float64Type>(as_primitive_array(array), out);
         }
-        DataType::Decimal128(width, _) => {
-            decimal_array_to_vector(as_primitive_array(array), out, *width);
+        DataType::Decimal128(width, scale) => {
+            decimal_array_to_vector(as_primitive_array(array), out, *width, *scale)?;
         }
         DataType::Interval(_) | DataType::Duration(_) => {
             let array = IntervalMonthDayNanoArray::from(
@@ -885,38 +888,71 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut FlatVector<'_>) -> Res
 }
 
 /// Convert Arrow [Decimal128Array] to a duckdb vector.
-fn decimal_array_to_vector(array: &Decimal128Array, out: &mut FlatVector<'_>, width: u8) {
+fn decimal_array_to_vector(
+    array: &Decimal128Array,
+    out: &mut FlatVector<'_>,
+    width: u8,
+    scale: i8,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let scale = u8::try_from(scale).map_err(|_| {
+        format!(
+            "Unsupported data type: {}, negative decimal scale is not supported",
+            array.data_type()
+        )
+    })?;
+    Decimal::new(width, scale, 0).map_err(|err| format!("invalid Arrow decimal type {}: {err}", array.data_type()))?;
+
     match width {
         1..=4 => {
             let out_data = unsafe { out.as_mut_slice() };
-            for (i, value) in array.values().iter().enumerate() {
-                out_data[i] = value.to_i16().unwrap();
+            for (i, slot) in out_data.iter_mut().enumerate().take(array.len()) {
+                let value = arrow_decimal_value(array, width, scale, i)?;
+                *slot = value.to_i16().unwrap();
             }
         }
         5..=9 => {
             let out_data = unsafe { out.as_mut_slice() };
-            for (i, value) in array.values().iter().enumerate() {
-                out_data[i] = value.to_i32().unwrap();
+            for (i, slot) in out_data.iter_mut().enumerate().take(array.len()) {
+                let value = arrow_decimal_value(array, width, scale, i)?;
+                *slot = value.to_i32().unwrap();
             }
         }
         10..=18 => {
             let out_data = unsafe { out.as_mut_slice() };
-            for (i, value) in array.values().iter().enumerate() {
-                out_data[i] = value.to_i64().unwrap();
+            for (i, slot) in out_data.iter_mut().enumerate().take(array.len()) {
+                let value = arrow_decimal_value(array, width, scale, i)?;
+                *slot = value.to_i64().unwrap();
             }
         }
         19..=38 => {
             let out_data = unsafe { out.as_mut_slice() };
-            for (i, value) in array.values().iter().enumerate() {
-                out_data[i] = value.to_i128().unwrap();
+            for (i, slot) in out_data.iter_mut().enumerate().take(array.len()) {
+                let value = arrow_decimal_value(array, width, scale, i)?;
+                *slot = value.to_i128().unwrap();
             }
         }
         // This should never happen, arrow only supports 1-38 decimal digits
-        _ => panic!("Invalid decimal width: {width}"),
+        _ => return Err(format!("Invalid decimal width: {width}").into()),
     }
 
     // Set nulls
     set_nulls_in_flat_vector(array, out);
+    Ok(())
+}
+
+fn arrow_decimal_value(
+    array: &Decimal128Array,
+    width: u8,
+    scale: u8,
+    row: usize,
+) -> Result<i128, Box<dyn std::error::Error>> {
+    if array.is_null(row) {
+        return Ok(0);
+    }
+
+    let value = array.value(row);
+    Decimal::new(width, scale, value).map_err(|err| format!("invalid Arrow decimal value at row {row}: {err}"))?;
+    Ok(value)
 }
 
 /// Convert Arrow [BooleanArray] to a duckdb vector.
@@ -2013,6 +2049,52 @@ mod test {
             Decimal128Array::from(vec![i128::from(12345)]).with_data_type(DataType::Decimal128(5, 0));
         check_rust_primitive_array_roundtrip(array.clone(), array)?;
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_decimal128_rejects_out_of_precision_values() -> Result<(), Box<dyn Error>> {
+        let db = Connection::open_in_memory()?;
+        db.register_table_function::<ArrowVTab>("arrow")?;
+
+        let schema = Schema::new(vec![Field::new("d", DataType::Decimal128(5, 2), true)]);
+        let array = Decimal128Array::from(vec![i128::from(999999)]).with_data_type(DataType::Decimal128(5, 2));
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array) as ArrayRef])?;
+        let param = arrow_recordbatch_to_query_params(batch);
+
+        let err = db
+            .query_row("SELECT d FROM arrow(?, ?)", param, |row| {
+                row.get::<_, crate::types::Value>(0)
+            })
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("invalid Arrow decimal value at row 0"),
+            "unexpected error: {err}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_decimal128_rejects_invalid_type_without_values() -> Result<(), Box<dyn Error>> {
+        let db = Connection::open_in_memory()?;
+        db.register_table_function::<ArrowVTab>("arrow")?;
+
+        let schema = Schema::new(vec![Field::new("d", DataType::Decimal128(5, 10), true)]);
+        let array = Decimal128Array::from(vec![None::<i128>]).with_data_type(DataType::Decimal128(5, 10));
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array) as ArrayRef])?;
+        let param = arrow_recordbatch_to_query_params(batch);
+
+        let err = db
+            .query_row("SELECT d FROM arrow(?, ?)", param, |row| {
+                row.get::<_, crate::types::Value>(0)
+            })
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("decimal scale 10 exceeds width 5"),
+            "unexpected error: {err}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Use a DuckDB-native `Decimal` type as the main carrier for dynamic `DECIMAL` values instead of `rust_decimal`. It keeps the full width, scale, and value, so it covers every DuckDB decimal up to `DECIMAL(38, s)` without falling back or panicking on large values.

`rust_decimal` stays available as an optional feature, with conversions for values that fit its range.

Also reject bad Arrow decimal input (wrong precision or scale) before it reaches DuckDB, so decimal reads stay correct instead of panicking or producing invalid values.