### PR TITLE
Fix stale logical metadata by decoding from executed result

### DIFF
--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -4,6 +4,8 @@ use super::{
 };
 
 /// A handle for the resulting RecordBatch of a query.
+///
+/// The iterator panics if DuckDB fails to convert a result chunk to Arrow.
 #[must_use = "Arrow is lazy and will do nothing unless consumed"]
 pub struct Arrow<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
@@ -28,11 +30,17 @@ impl<'stmt> Iterator for Arrow<'stmt> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(RecordBatch::from(&self.stmt?.step()?))
+        match self.stmt?.step() {
+            Ok(Some(array)) => Some(RecordBatch::from(&array)),
+            Ok(None) => None,
+            Err(err) => panic!("Failed to fetch Arrow record batch: {err}"),
+        }
     }
 }
 
-/// A handle for the resulting RecordBatch of a query in streaming
+/// A handle for the resulting RecordBatch of a query in streaming.
+///
+/// The iterator panics if DuckDB fails to convert a result chunk to Arrow.
 #[must_use = "Arrow stream is lazy and will not fetch data unless consumed"]
 #[allow(clippy::needless_lifetimes)]
 pub struct ArrowStream<'stmt> {
@@ -62,6 +70,10 @@ impl<'stmt> Iterator for ArrowStream<'stmt> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(RecordBatch::from(&self.stmt?.stream_step(self.get_schema())?))
+        match self.stmt?.stream_step(self.get_schema()) {
+            Ok(Some(array)) => Some(RecordBatch::from(&array)),
+            Ok(None) => None,
+            Err(err) => panic!("Failed to fetch streaming Arrow record batch: {err}"),
+        }
     }
 }

--- a/crates/duckdb/src/cache.rs
+++ b/crates/duckdb/src/cache.rs
@@ -175,8 +175,13 @@ impl StatementCache {
 #[cfg(test)]
 mod test {
     use super::StatementCache;
-    use crate::{Connection, Result};
+    use crate::{Connection, Result, core::LogicalTypeId, types::Value};
+    use arrow::{
+        array::Int32Array,
+        datatypes::{DataType, Field, Schema},
+    };
     use fallible_iterator::FallibleIterator;
+    use std::sync::Arc;
 
     impl StatementCache {
         fn clear(&self) {
@@ -302,6 +307,175 @@ mod test {
                 stmt.query([])?.map(|r| <(i32, i32)>::try_from(r)).next()
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_ddl_with_trailing_ambiguous_decimal_uses_executed_metadata() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch(
+            r#"
+            CREATE TABLE foo (x INT);
+            INSERT INTO foo VALUES (1);
+        "#,
+        )?;
+
+        let sql = "SELECT * FROM foo";
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            assert_eq!(Ok(Some(1i32)), stmt.query([])?.map(|r| r.get(0)).next());
+        }
+
+        db.execute_batch(
+            r#"
+            ALTER TABLE foo ADD COLUMN y UHUGEINT;
+            UPDATE foo SET y = 340282366920938463463374607431768211455::UHUGEINT;
+        "#,
+        )?;
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            assert_eq!(
+                Ok(Some((Value::Int(1), Value::UHugeInt(u128::MAX)))),
+                stmt.query([])?
+                    .map(|r| Ok((r.get_ref(0)?.to_owned(), r.get_ref(1)?.to_owned())))
+                    .next()
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_ddl_with_same_index_ambiguous_logical_type_uses_executed_metadata() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch(
+            r#"
+            CREATE TABLE foo (x HUGEINT);
+            INSERT INTO foo VALUES (0);
+        "#,
+        )?;
+
+        let sql = "SELECT * FROM foo";
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            assert_eq!(
+                Ok(Some(Value::HugeInt(0))),
+                stmt.query([])?.map(|r| r.get_ref(0).map(|v| v.to_owned())).next()
+            );
+        }
+
+        db.execute_batch(
+            r#"
+            DROP TABLE foo;
+            CREATE TABLE foo (x UHUGEINT);
+            INSERT INTO foo VALUES (340282366920938463463374607431768211455::UHUGEINT);
+        "#,
+        )?;
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            assert_eq!(
+                Ok(Some(Value::UHugeInt(u128::MAX))),
+                stmt.query([])?.map(|r| r.get_ref(0).map(|v| v.to_owned())).next()
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_ddl_with_same_index_ambiguous_logical_type_updates_column_logical_type() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch(
+            r#"
+            CREATE TABLE foo (x HUGEINT);
+            INSERT INTO foo VALUES (0);
+        "#,
+        )?;
+
+        let sql = "SELECT * FROM foo";
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            let value = {
+                let mut rows = stmt.query([])?;
+                rows.next()?.unwrap().get_ref(0)?.to_owned()
+            };
+            assert_eq!(Value::HugeInt(0), value);
+            assert_eq!(LogicalTypeId::Hugeint, stmt.column_logical_type(0).id());
+        }
+
+        db.execute_batch(
+            r#"
+            DROP TABLE foo;
+            CREATE TABLE foo (x UHUGEINT);
+            INSERT INTO foo VALUES (340282366920938463463374607431768211455::UHUGEINT);
+        "#,
+        )?;
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            let value = {
+                let mut rows = stmt.query([])?;
+                rows.next()?.unwrap().get_ref(0)?.to_owned()
+            };
+            assert_eq!(Value::UHugeInt(u128::MAX), value);
+            assert_eq!(LogicalTypeId::UHugeint, stmt.column_logical_type(0).id());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_ddl_with_stale_variant_uses_executed_streaming_metadata() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE foo (x VARIANT);")?;
+
+        let sql = "SELECT * FROM foo";
+
+        {
+            let stmt = db.prepare_cached(sql)?;
+            assert_eq!(LogicalTypeId::Variant, stmt.column_logical_type(0).id());
+        }
+
+        db.execute_batch(
+            r#"
+            DROP TABLE foo;
+            CREATE TABLE foo (x INTEGER);
+            INSERT INTO foo VALUES (42);
+        "#,
+        )?;
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, true)]));
+            let batches = stmt.stream_arrow([], schema)?.collect::<Vec<_>>();
+            assert_eq!(1, batches.len());
+
+            let values = batches[0].column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+            assert_eq!(42, values.value(0));
+            assert_eq!(LogicalTypeId::Integer, stmt.column_logical_type(0).id());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_prepare_cached_multichunk_reexecution_resets_result_chunks() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let sql = "SELECT i FROM range(3000) AS t(i) ORDER BY i";
+
+        for _ in 0..2 {
+            let mut stmt = db.prepare_cached(sql)?;
+            let values = stmt
+                .query_map([], |row| row.get::<_, i64>(0))?
+                .collect::<Result<Vec<_>>>()?;
+
+            assert_eq!(values.len(), 3000);
+            assert_eq!(values[0], 0);
+            assert_eq!(values[2048], 2048);
+            assert_eq!(values[2999], 2999);
+        }
+
         Ok(())
     }
 

--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -295,6 +295,29 @@ pub fn result_from_duckdb_prepare(code: ffi::duckdb_state, mut prepare: ffi::duc
 
 #[cold]
 #[inline]
+pub fn result_from_duckdb_result(code: ffi::duckdb_state, result: *mut ffi::duckdb_result) -> Result<()> {
+    if code == ffi::DuckDBSuccess {
+        return Ok(());
+    }
+    unsafe {
+        let message = if result.is_null() {
+            Some("result is null".to_string())
+        } else {
+            let c_err = ffi::duckdb_result_error(result);
+            let message = if c_err.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(c_err).to_string_lossy().to_string())
+            };
+            ffi::duckdb_destroy_result(result);
+            message
+        };
+        error_from_duckdb_code(code, message)
+    }
+}
+
+#[cold]
+#[inline]
 pub fn result_from_duckdb_arrow(code: ffi::duckdb_state, mut out: ffi::duckdb_arrow) -> Result<()> {
     if code == ffi::DuckDBSuccess {
         return Ok(());

--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -318,25 +318,6 @@ pub fn result_from_duckdb_result(code: ffi::duckdb_state, result: *mut ffi::duck
 
 #[cold]
 #[inline]
-pub fn result_from_duckdb_arrow(code: ffi::duckdb_state, mut out: ffi::duckdb_arrow) -> Result<()> {
-    if code == ffi::DuckDBSuccess {
-        return Ok(());
-    }
-    unsafe {
-        let message = if out.is_null() {
-            Some("out is null".to_string())
-        } else {
-            let c_err = ffi::duckdb_query_arrow_error(out);
-            let message = Some(CStr::from_ptr(c_err).to_string_lossy().to_string());
-            ffi::duckdb_destroy_arrow(&mut out);
-            message
-        };
-        error_from_duckdb_code(code, message)
-    }
-}
-
-#[cold]
-#[inline]
 pub fn result_from_duckdb_extract(
     num_statements: ffi::idx_t,
     mut extracted: ffi::duckdb_extracted_statements,

--- a/crates/duckdb/src/inner_connection.rs
+++ b/crates/duckdb/src/inner_connection.rs
@@ -9,8 +9,8 @@ use std::{
 use super::{Appender, Config, Connection, Result, ffi};
 use crate::{
     error::{
-        Error, result_from_duckdb_appender, result_from_duckdb_arrow, result_from_duckdb_extract,
-        result_from_duckdb_prepare,
+        Error, result_from_duckdb_appender, result_from_duckdb_extract, result_from_duckdb_prepare,
+        result_from_duckdb_result,
     },
     raw_statement::RawStatement,
     statement::Statement,
@@ -125,9 +125,9 @@ impl InnerConnection {
         let c_str = CString::new(sql)?;
         unsafe {
             let mut out = mem::zeroed();
-            let r = ffi::duckdb_query_arrow(self.con, c_str.as_ptr() as *const c_char, &mut out);
-            result_from_duckdb_arrow(r, out)?;
-            ffi::duckdb_destroy_arrow(&mut out);
+            let r = ffi::duckdb_query(self.con, c_str.as_ptr() as *const c_char, &mut out);
+            result_from_duckdb_result(r, &mut out)?;
+            ffi::duckdb_destroy_result(&mut out);
             Ok(())
         }
     }

--- a/crates/duckdb/src/polars_dataframe.rs
+++ b/crates/duckdb/src/polars_dataframe.rs
@@ -3,6 +3,9 @@ use polars::prelude::DataFrame;
 use super::{Statement, arrow::datatypes::SchemaRef};
 
 /// An handle for the resulting Polars DataFrame of a query.
+///
+/// The iterator panics if DuckDB fails to convert a result chunk to Arrow or
+/// if the Arrow chunk cannot be converted into a Polars DataFrame.
 #[must_use = "Polars is lazy and will do nothing unless consumed"]
 pub struct Polars<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
@@ -26,7 +29,11 @@ impl<'stmt> Iterator for Polars<'stmt> {
     type Item = DataFrame;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let struct_array = self.stmt?.step_polars()?;
+        let struct_array = match self.stmt?.step_polars() {
+            Ok(Some(array)) => array,
+            Ok(None) => return None,
+            Err(err) => panic!("Failed to fetch Polars DataFrame batch: {err}"),
+        };
         let df = DataFrame::try_from(struct_array)
             .unwrap_or_else(|e| panic!("Failed to construct DataFrame from StructArray: {e}"));
 
@@ -82,6 +89,49 @@ mod tests {
         let df = accumulate_dataframes_vertical_unchecked(pl);
         assert_eq!(df.height(), 3000);
         assert_eq!(df.column("t").unwrap().i32().unwrap().sum().unwrap(), 9000);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_polars_cached_ddl_uses_executed_metadata() -> Result<()> {
+        let db = checked_memory_handle();
+        db.execute_batch(
+            r#"
+            CREATE TABLE foo (x INTEGER);
+            INSERT INTO foo VALUES (0);
+        "#,
+        )?;
+
+        let sql = "SELECT * FROM foo";
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            let mut polars = stmt.query_polars([])?;
+            let df = polars.next().expect("Failed to get DataFrame");
+            let column = df.column("x").expect("missing x column");
+            assert_eq!(column.dtype(), &DataType::Int32);
+            assert_eq!(column.get(0).expect("missing x value"), AnyValue::Int32(0));
+            assert!(polars.next().is_none());
+        }
+
+        db.execute_batch(
+            r#"
+            DROP TABLE foo;
+            CREATE TABLE foo (x DECIMAL(38, 0));
+            INSERT INTO foo VALUES (5::DECIMAL(38,0));
+        "#,
+        )?;
+
+        {
+            let mut stmt = db.prepare_cached(sql)?;
+            let mut polars = stmt.query_polars([])?;
+            let df = polars.next().expect("Failed to get DataFrame");
+            let column = df.column("x").expect("missing x column");
+            assert_eq!(column.dtype(), &DataType::Decimal(Some(38), Some(0)));
+            assert_eq!(column.get(0).expect("missing x value"), AnyValue::Decimal(5, 0));
+            assert!(polars.next().is_none());
+        }
 
         Ok(())
     }

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -1,4 +1,10 @@
-use std::{cell::OnceCell, collections::HashMap, ffi::CStr, ops::Deref, ptr, rc::Rc, sync::Arc};
+use std::{
+    cell::{Cell, OnceCell},
+    collections::HashMap,
+    ffi::CStr,
+    ops::Deref,
+    sync::Arc,
+};
 
 use arrow::{
     array::StructArray,
@@ -10,7 +16,7 @@ use super::{Result, ffi};
 use crate::{
     Error,
     core::{LogicalTypeHandle, LogicalTypeId},
-    error::result_from_duckdb_arrow,
+    error::result_from_duckdb_result,
     types::Type,
 };
 #[cfg(feature = "polars")]
@@ -26,12 +32,15 @@ use polars_core::utils::arrow as polars_arrow;
 #[derive(Debug)]
 pub struct RawStatement {
     ptr: ffi::duckdb_prepared_statement,
-    result: Option<ffi::duckdb_arrow>,
     duckdb_result: Option<ffi::duckdb_result>,
     schema: Option<SchemaRef>,
     // Cached DuckDB logical ids for result columns. Arrow reports HUGEINT,
-    // UHUGEINT, and scale-zero DECIMAL through the same decimal shape.
+    // UHUGEINT, and DECIMAL(38,0) through the same decimal shape.
     result_column_logical_ids: Option<Box<[LogicalTypeId]>>,
+    #[cfg(feature = "polars")]
+    polars_arrow_field: OnceCell<polars_arrow::datatypes::Field>,
+    result_chunk_idx: Cell<usize>,
+    arrow_options: Cell<ffi::duckdb_arrow_options>,
     column_name_cache: OnceCell<HashMap<Box<str>, usize>>,
     // Tracks whether the duckdb_result is truly streaming or materialized.
     // This is needed because some statements (like CALL) return materialized
@@ -55,9 +64,12 @@ impl RawStatement {
     pub unsafe fn new(stmt: ffi::duckdb_prepared_statement) -> Self {
         Self {
             ptr: stmt,
-            result: None,
             schema: None,
             result_column_logical_ids: None,
+            #[cfg(feature = "polars")]
+            polars_arrow_field: OnceCell::new(),
+            result_chunk_idx: Cell::new(0),
+            arrow_options: Cell::new(std::ptr::null_mut()),
             column_name_cache: OnceCell::new(),
             duckdb_result: None,
             is_streaming: false,
@@ -91,143 +103,100 @@ impl RawStatement {
     }
 
     #[inline]
-    pub fn result_unwrap(&self) -> ffi::duckdb_arrow {
-        self.result.expect("The statement was not executed yet")
-    }
-
-    #[inline]
     pub fn row_count(&self) -> usize {
-        unsafe { ffi::duckdb_arrow_row_count(self.result_unwrap()) as usize }
-    }
-
-    #[inline]
-    pub fn step(&self) -> Option<StructArray> {
-        let out = self.result?;
         unsafe {
-            let mut arrays = FFI_ArrowArray::empty();
-            if ffi::duckdb_query_arrow_array(
-                out,
-                &mut std::ptr::addr_of_mut!(arrays) as *mut _ as *mut ffi::duckdb_arrow_array,
-            )
-            .ne(&ffi::DuckDBSuccess)
-            {
-                return None;
-            }
-
-            if arrays.is_empty() {
-                return None;
-            }
-
-            let mut schema = FFI_ArrowSchema::empty();
-            if ffi::duckdb_query_arrow_schema(
-                out,
-                &mut std::ptr::addr_of_mut!(schema) as *mut _ as *mut ffi::duckdb_arrow_schema,
-            ) != ffi::DuckDBSuccess
-            {
-                return None;
-            }
-
-            let array_data = from_ffi(arrays, &schema).expect("ok");
-            let struct_array = StructArray::from(array_data);
-            Some(struct_array)
+            let mut result = self.duckdb_result.expect("The statement was not executed yet");
+            ffi::duckdb_row_count(&mut result) as usize
         }
     }
 
     #[inline]
-    pub fn streaming_step(&self, schema: SchemaRef) -> Option<StructArray> {
+    pub fn step(&self) -> Result<Option<StructArray>> {
+        let Some(result) = self.duckdb_result else {
+            return Ok(None);
+        };
+        let Some(schema) = self.schema.clone() else {
+            return Ok(None);
+        };
+        unsafe {
+            let Some(chunk) = self.next_result_chunk(result)? else {
+                return Ok(None);
+            };
+            self.data_chunk_to_struct_array(result, chunk, schema)
+        }
+    }
+
+    #[inline]
+    pub fn streaming_step(&self, schema: SchemaRef) -> Result<Option<StructArray>> {
         if let Some(result) = self.duckdb_result {
             unsafe {
                 // Use duckdb_stream_fetch_chunk for truly streaming results,
                 // or duckdb_fetch_chunk for materialized results (e.g., from CALL statements)
-                let mut out = if self.is_streaming {
+                let out = if self.is_streaming {
                     ffi::duckdb_stream_fetch_chunk(result)
                 } else {
                     ffi::duckdb_fetch_chunk(result)
                 };
 
                 if out.is_null() {
-                    return None;
+                    return Ok(None);
                 }
 
-                let mut arrays = FFI_ArrowArray::empty();
-                ffi::duckdb_result_arrow_array(
-                    result,
-                    out,
-                    &mut std::ptr::addr_of_mut!(arrays) as *mut _ as *mut ffi::duckdb_arrow_array,
-                );
-
-                ffi::duckdb_destroy_data_chunk(&mut out);
-
-                if arrays.is_empty() {
-                    return None;
-                }
-
-                let schema = FFI_ArrowSchema::try_from(schema.deref()).ok()?;
-                let array_data = from_ffi(arrays, &schema).expect("ok");
-                let struct_array = StructArray::from(array_data);
-                return Some(struct_array);
+                return self.data_chunk_to_struct_array(result, out, schema);
             }
         }
 
-        None
+        Ok(None)
     }
 
     #[cfg(feature = "polars")]
     #[inline]
-    pub(crate) fn step_polars(&self) -> Option<polars_arrow::array::StructArray> {
-        let result = self.result?;
+    pub(crate) fn step_polars(&self) -> Result<Option<polars_arrow::array::StructArray>> {
+        let Some(result) = self.duckdb_result else {
+            return Ok(None);
+        };
 
         unsafe {
+            let Some(chunk) = self.next_result_chunk(result)? else {
+                return Ok(None);
+            };
+
             let mut ffi_arrow_array = polars_arrow::ffi::ArrowArray::empty();
+            self.chunk_to_arrow(result, chunk, &mut ffi_arrow_array as *mut _ as *mut ffi::ArrowArray)?;
 
-            if ffi::duckdb_query_arrow_array(
-                result,
-                &mut std::ptr::addr_of_mut!(ffi_arrow_array) as *mut _ as *mut ffi::duckdb_arrow_array,
-            )
-            .ne(&ffi::DuckDBSuccess)
-            {
-                return None;
-            }
-
-            let mut ffi_arrow_schema = polars_arrow::ffi::ArrowSchema::empty();
-
-            if ffi::duckdb_query_arrow_schema(
-                result,
-                &mut std::ptr::addr_of_mut!(ffi_arrow_schema) as *mut _ as *mut ffi::duckdb_arrow_schema,
-            )
-            .ne(&ffi::DuckDBSuccess)
-            {
-                return None;
-            }
-
-            let field =
-                polars_arrow::ffi::import_field_from_c(&ffi_arrow_schema).expect("Failed to import Polars Arrow field");
-            let import_array = polars_arrow::ffi::import_array_from_c(ffi_arrow_array, field.dtype);
+            let field = self.polars_arrow_field(result)?;
+            let import_array = polars_arrow::ffi::import_array_from_c(ffi_arrow_array, field.dtype.clone());
 
             let array = match import_array {
                 Ok(array) => array,
                 // When array is empty, import_array_from_c returns ComputeError with message
                 // "An ArrowArray of type X must have non-null children".
                 Err(polars::error::PolarsError::ComputeError(msg)) if msg.to_string().contains("non-null children") => {
-                    return None;
+                    return Ok(None);
                 }
-                Err(err) => panic!("Failed to import Polars Arrow array from C: {err}"),
+                Err(err) => {
+                    return Err(Self::duckdb_failure(format!(
+                        "Failed to import Polars Arrow array from C: {err}"
+                    )));
+                }
             };
             let struct_array = array
                 .as_any()
                 .downcast_ref::<polars_arrow::array::StructArray>()
-                .expect("Failed to downcast Polars Arrow array to StructArray")
+                .ok_or_else(|| Self::duckdb_failure("Failed to downcast Polars Arrow array to StructArray"))?
                 .to_owned();
 
-            Some(struct_array)
+            Ok(Some(struct_array))
         }
     }
 
-    // FIXME(mlafeldt): This currently panics if the query has not been executed yet.
-    // The C API doesn't have a function to get the column count without executing the query first.
     #[inline]
     pub fn column_count(&self) -> usize {
-        unsafe { ffi::duckdb_arrow_column_count(self.result_unwrap()) as usize }
+        self.schema
+            .as_ref()
+            .expect("The statement was not executed yet")
+            .fields()
+            .len()
     }
 
     #[inline]
@@ -243,6 +212,10 @@ impl RawStatement {
 
     #[inline]
     pub(crate) fn try_column_logical_type(&self, idx: usize) -> Result<LogicalTypeHandle> {
+        if let Some(mut result) = self.duckdb_result {
+            return unsafe { Self::try_result_column_logical_type(&mut result, idx) };
+        }
+
         unsafe {
             let ptr = ffi::duckdb_prepared_statement_column_logical_type(self.ptr, idx as u64);
             if ptr.is_null() {
@@ -300,23 +273,24 @@ impl RawStatement {
     /// NOTE: if execute failed, we shouldn't call any other methods which depends on result
     pub fn execute(&mut self) -> Result<usize> {
         self.reset_result();
-        let result_column_logical_ids = self.validate_and_load_result_column_logical_ids()?;
+        self.reject_unsupported_prepared_result_columns_for_dml()?;
         unsafe {
-            let mut out: ffi::duckdb_arrow = ptr::null_mut();
-            let rc = ffi::duckdb_execute_prepared_arrow(self.ptr, &mut out);
-            result_from_duckdb_arrow(rc, out)?;
+            let mut out: ffi::duckdb_result = std::mem::zeroed();
+            let rc = ffi::duckdb_execute_prepared(self.ptr, &mut out);
+            result_from_duckdb_result(rc, &mut out)?;
 
-            let rows_changed = ffi::duckdb_arrow_rows_changed(out);
-            let mut c_schema = Rc::into_raw(Rc::new(FFI_ArrowSchema::empty()));
-            let rc = ffi::duckdb_query_arrow_schema(out, &mut c_schema as *mut _ as *mut ffi::duckdb_arrow_schema);
-            if rc != ffi::DuckDBSuccess {
-                Rc::from_raw(c_schema);
-                result_from_duckdb_arrow(rc, out)?;
-            }
-            self.schema = Some(Arc::new(Schema::try_from(&*c_schema).unwrap()));
-            Rc::from_raw(c_schema);
+            let rows_changed = ffi::duckdb_rows_changed(&mut out);
+            let (schema, result_column_logical_ids) = match self.load_result_schema_and_logical_ids(&mut out) {
+                Ok(result) => result,
+                Err(err) => {
+                    self.destroy_arrow_options();
+                    ffi::duckdb_destroy_result(&mut out);
+                    return Err(err);
+                }
+            };
 
-            self.result = Some(out);
+            self.schema = Some(schema);
+            self.duckdb_result = Some(out);
             self.result_column_logical_ids = Some(result_column_logical_ids);
             Ok(rows_changed as usize)
         }
@@ -324,32 +298,28 @@ impl RawStatement {
 
     pub fn execute_streaming(&mut self) -> Result<()> {
         self.reset_result();
-        let result_column_logical_ids = self.validate_and_load_result_column_logical_ids()?;
+        self.reject_unsupported_prepared_result_columns_for_dml()?;
         unsafe {
             let mut out: ffi::duckdb_result = std::mem::zeroed();
 
             let rc = ffi::duckdb_execute_prepared_streaming(self.ptr, &mut out);
-            if rc != ffi::DuckDBSuccess {
-                let msg = {
-                    let c_err = ffi::duckdb_result_error(&mut out);
-                    if c_err.is_null() {
-                        None
-                    } else {
-                        Some(CStr::from_ptr(c_err).to_string_lossy().to_string())
-                    }
-                };
-                ffi::duckdb_destroy_result(&mut out);
-                return Err(Error::DuckDBFailure(ffi::Error::new(rc), msg));
-            }
+            result_from_duckdb_result(rc, &mut out)?;
+            let result_column_logical_ids = match Self::load_result_column_logical_ids(&mut out) {
+                Ok(result) => result,
+                Err(err) => {
+                    self.destroy_arrow_options();
+                    ffi::duckdb_destroy_result(&mut out);
+                    return Err(err);
+                }
+            };
 
             // Check if the result is truly streaming or materialized
             // Some statements (like CALL) return materialized results even when streaming is requested
             self.is_streaming = ffi::duckdb_result_is_streaming(out);
 
             self.duckdb_result = Some(out);
-            // Row decoding consumes this cache only for the non-streaming path
-            // today. Keep streaming execution state symmetrical for callers
-            // that inspect statement metadata after execution.
+            // Streaming does not use the ids directly, but loading them
+            // rejects unsupported Variant columns before streaming begins.
             self.result_column_logical_ids = Some(result_column_logical_ids);
 
             Ok(())
@@ -360,14 +330,14 @@ impl RawStatement {
     pub fn reset_result(&mut self) {
         self.schema = None;
         self.result_column_logical_ids = None;
+        #[cfg(feature = "polars")]
+        {
+            self.polars_arrow_field = OnceCell::new();
+        }
+        self.result_chunk_idx.set(0);
+        self.destroy_arrow_options();
         self.column_name_cache = OnceCell::new();
         self.is_streaming = false;
-        if self.result.is_some() {
-            unsafe {
-                ffi::duckdb_destroy_arrow(&mut self.result_unwrap());
-            }
-            self.result = None;
-        }
         if let Some(mut result) = self.duckdb_result {
             unsafe {
                 ffi::duckdb_destroy_result(&mut result);
@@ -404,22 +374,283 @@ impl RawStatement {
         }
     }
 
-    fn validate_and_load_result_column_logical_ids(&self) -> Result<Box<[LogicalTypeId]>> {
-        let column_count = unsafe { ffi::duckdb_prepared_statement_column_count(self.ptr) as usize };
-        let mut logical_ids = Vec::with_capacity(column_count);
-        for idx in 0..column_count {
-            let logical_type = self.try_column_logical_type(idx)?;
-            if logical_type.contains_type_id(LogicalTypeId::Variant) {
-                return Err(Error::FromSqlConversionFailure(
-                    idx,
-                    Type::Variant,
-                    "decoding Variant columns is not supported".into(),
-                ));
-            }
-            logical_ids.push(logical_type.id());
+    fn reject_unsupported_prepared_result_columns_for_dml(&self) -> Result<()> {
+        if !self.is_dml_statement() {
+            return Ok(());
         }
 
-        Ok(logical_ids.into_boxed_slice())
+        // This uses prepared metadata only as a pre-execution side-effect
+        // barrier for DML RETURNING. Executed result metadata remains the
+        // authoritative source for decoding after execution.
+        let column_count = unsafe { ffi::duckdb_prepared_statement_column_count(self.ptr) as usize };
+        for idx in 0..column_count {
+            let logical_type = self.try_column_logical_type(idx)?;
+            Self::reject_unsupported_result_logical_type(idx, &logical_type)?;
+        }
+
+        Ok(())
+    }
+
+    fn is_dml_statement(&self) -> bool {
+        matches!(
+            unsafe { ffi::duckdb_prepared_statement_type(self.ptr) },
+            ffi::duckdb_statement_type_DUCKDB_STATEMENT_TYPE_INSERT
+                | ffi::duckdb_statement_type_DUCKDB_STATEMENT_TYPE_UPDATE
+                | ffi::duckdb_statement_type_DUCKDB_STATEMENT_TYPE_DELETE
+        )
+    }
+
+    unsafe fn load_result_schema_and_logical_ids(
+        &self,
+        result: *mut ffi::duckdb_result,
+    ) -> Result<(SchemaRef, Box<[LogicalTypeId]>)> {
+        unsafe {
+            let mut c_schema = FFI_ArrowSchema::empty();
+            let logical_ids = self.result_to_arrow_schema(result, &mut c_schema as *mut _ as *mut ffi::ArrowSchema)?;
+            let schema = Arc::new(
+                Schema::try_from(&c_schema)
+                    .map_err(|err| Self::arrow_failure("Could not import DuckDB Arrow schema", err))?,
+            );
+            debug_assert_eq!(
+                schema.fields().len(),
+                logical_ids.len(),
+                "result schema and logical-id cache are built from the same DuckDB column count"
+            );
+
+            Ok((schema, logical_ids))
+        }
+    }
+
+    unsafe fn load_result_column_logical_ids(result: *mut ffi::duckdb_result) -> Result<Box<[LogicalTypeId]>> {
+        unsafe {
+            let logical_ids = Self::result_column_logical_types(result)?
+                .iter()
+                .map(LogicalTypeHandle::id)
+                .collect::<Vec<_>>();
+            Ok(logical_ids.into_boxed_slice())
+        }
+    }
+
+    unsafe fn result_column_logical_types(result: *mut ffi::duckdb_result) -> Result<Vec<LogicalTypeHandle>> {
+        unsafe {
+            let column_count = ffi::duckdb_column_count(result) as usize;
+            let mut logical_types = Vec::with_capacity(column_count);
+
+            for idx in 0..column_count {
+                let logical_type = Self::try_result_column_logical_type(result, idx)?;
+                Self::reject_unsupported_result_logical_type(idx, &logical_type)?;
+                logical_types.push(logical_type);
+            }
+
+            Ok(logical_types)
+        }
+    }
+
+    fn reject_unsupported_result_logical_type(idx: usize, logical_type: &LogicalTypeHandle) -> Result<()> {
+        if logical_type.contains_type_id(LogicalTypeId::Variant) {
+            return Err(Error::FromSqlConversionFailure(
+                idx,
+                Type::Variant,
+                "decoding Variant columns is not supported".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    unsafe fn try_result_column_logical_type(result: *mut ffi::duckdb_result, idx: usize) -> Result<LogicalTypeHandle> {
+        unsafe {
+            let ptr = ffi::duckdb_column_logical_type(result, idx as u64);
+            if ptr.is_null() {
+                return Err(Error::DuckDBFailure(
+                    ffi::Error::new(ffi::DuckDBError),
+                    Some(format!(
+                        "Could not retrieve logical type for result column at index {idx}"
+                    )),
+                ));
+            }
+            Ok(LogicalTypeHandle::new(ptr))
+        }
+    }
+
+    unsafe fn result_to_arrow_schema(
+        &self,
+        result: *mut ffi::duckdb_result,
+        dst: *mut ffi::ArrowSchema,
+    ) -> Result<Box<[LogicalTypeId]>> {
+        unsafe {
+            let column_count = ffi::duckdb_column_count(result) as usize;
+            let logical_types = Self::result_column_logical_types(result)?;
+            let logical_ids = logical_types.iter().map(LogicalTypeHandle::id).collect::<Vec<_>>();
+            let mut names = Vec::with_capacity(column_count);
+
+            for idx in 0..column_count {
+                let name = ffi::duckdb_column_name(result, idx as u64);
+                if name.is_null() {
+                    return Err(Error::DuckDBFailure(
+                        ffi::Error::new(ffi::DuckDBError),
+                        Some(format!("Could not retrieve name for result column at index {idx}")),
+                    ));
+                }
+                names.push(name);
+            }
+
+            let mut type_ptrs = logical_types
+                .iter()
+                .map(|logical_type| logical_type.ptr)
+                .collect::<Vec<_>>();
+            let arrow_options = self.arrow_options_for_result(*result)?;
+            let error_data = ffi::duckdb_to_arrow_schema(
+                arrow_options,
+                type_ptrs.as_mut_ptr(),
+                names.as_mut_ptr(),
+                column_count as u64,
+                dst,
+            );
+            Self::result_from_duckdb_error_data(error_data)?;
+
+            Ok(logical_ids.into_boxed_slice())
+        }
+    }
+
+    unsafe fn next_result_chunk(&self, result: ffi::duckdb_result) -> Result<Option<ffi::duckdb_data_chunk>> {
+        unsafe {
+            let chunk_idx = self.result_chunk_idx.get();
+            if chunk_idx >= ffi::duckdb_result_chunk_count(result) as usize {
+                return Ok(None);
+            }
+            let chunk = ffi::duckdb_result_get_chunk(result, chunk_idx as u64);
+            self.result_chunk_idx.set(chunk_idx + 1);
+            if chunk.is_null() {
+                Err(Self::duckdb_failure(format!(
+                    "Could not fetch result chunk at index {chunk_idx}"
+                )))
+            } else {
+                Ok(Some(chunk))
+            }
+        }
+    }
+
+    unsafe fn data_chunk_to_struct_array(
+        &self,
+        result: ffi::duckdb_result,
+        chunk: ffi::duckdb_data_chunk,
+        schema: SchemaRef,
+    ) -> Result<Option<StructArray>> {
+        unsafe {
+            let mut arrays = FFI_ArrowArray::empty();
+            self.chunk_to_arrow(result, chunk, &mut arrays as *mut _ as *mut ffi::ArrowArray)?;
+
+            if arrays.is_empty() {
+                return Ok(None);
+            }
+
+            let schema = FFI_ArrowSchema::try_from(schema.deref())
+                .map_err(|err| Self::arrow_failure("Could not export Arrow schema", err))?;
+            let array_data = from_ffi(arrays, &schema)
+                .map_err(|err| Self::arrow_failure("Could not import DuckDB Arrow array", err))?;
+            Ok(Some(StructArray::from(array_data)))
+        }
+    }
+
+    unsafe fn chunk_to_arrow(
+        &self,
+        result: ffi::duckdb_result,
+        mut chunk: ffi::duckdb_data_chunk,
+        dst: *mut ffi::ArrowArray,
+    ) -> Result<()> {
+        unsafe {
+            let arrow_options = match self.arrow_options_for_result(result) {
+                Ok(arrow_options) => arrow_options,
+                Err(err) => {
+                    ffi::duckdb_destroy_data_chunk(&mut chunk);
+                    return Err(err);
+                }
+            };
+            let error_data = ffi::duckdb_data_chunk_to_arrow(arrow_options, chunk, dst);
+            ffi::duckdb_destroy_data_chunk(&mut chunk);
+            Self::result_from_duckdb_error_data(error_data)
+        }
+    }
+
+    unsafe fn arrow_options_for_result(&self, mut result: ffi::duckdb_result) -> Result<ffi::duckdb_arrow_options> {
+        unsafe {
+            let arrow_options = self.arrow_options.get();
+            if !arrow_options.is_null() {
+                return Ok(arrow_options);
+            }
+
+            let arrow_options = ffi::duckdb_result_get_arrow_options(&mut result);
+            if arrow_options.is_null() {
+                return Err(Self::duckdb_failure("Could not retrieve Arrow options for result"));
+            }
+            self.arrow_options.set(arrow_options);
+            Ok(arrow_options)
+        }
+    }
+
+    fn destroy_arrow_options(&self) {
+        let mut arrow_options = self.arrow_options.replace(std::ptr::null_mut());
+        if !arrow_options.is_null() {
+            unsafe {
+                ffi::duckdb_destroy_arrow_options(&mut arrow_options);
+            }
+        }
+    }
+
+    unsafe fn result_from_duckdb_error_data(mut error_data: ffi::duckdb_error_data) -> Result<()> {
+        unsafe {
+            if error_data.is_null() {
+                return Ok(());
+            }
+            if !ffi::duckdb_error_data_has_error(error_data) {
+                ffi::duckdb_destroy_error_data(&mut error_data);
+                return Ok(());
+            }
+
+            let msg = {
+                let c_err = ffi::duckdb_error_data_message(error_data);
+                if c_err.is_null() {
+                    None
+                } else {
+                    Some(CStr::from_ptr(c_err).to_string_lossy().to_string())
+                }
+            };
+            ffi::duckdb_destroy_error_data(&mut error_data);
+            Err(Error::DuckDBFailure(ffi::Error::new(ffi::DuckDBError), msg))
+        }
+    }
+
+    #[cfg(feature = "polars")]
+    fn polars_arrow_field(&self, result: ffi::duckdb_result) -> Result<&polars_arrow::datatypes::Field> {
+        if self.polars_arrow_field.get().is_none() {
+            let field = unsafe { self.load_polars_arrow_field(result)? };
+            let _ = self.polars_arrow_field.set(field);
+        }
+        Ok(self
+            .polars_arrow_field
+            .get()
+            .expect("polars Arrow field cache was just initialized"))
+    }
+
+    #[cfg(feature = "polars")]
+    unsafe fn load_polars_arrow_field(&self, result: ffi::duckdb_result) -> Result<polars_arrow::datatypes::Field> {
+        unsafe {
+            let mut result = result;
+            let mut schema = polars_arrow::ffi::ArrowSchema::empty();
+            let _ = self.result_to_arrow_schema(&mut result, &mut schema as *mut _ as *mut ffi::ArrowSchema)?;
+
+            polars_arrow::ffi::import_field_from_c(&schema)
+                .map_err(|err| Self::duckdb_failure(format!("Failed to import Polars Arrow field: {err}")))
+        }
+    }
+
+    fn arrow_failure(context: &str, err: impl std::fmt::Display) -> Error {
+        Self::duckdb_failure(format!("{context}: {err}"))
+    }
+
+    fn duckdb_failure(message: impl Into<String>) -> Error {
+        Error::DuckDBFailure(ffi::Error::new(ffi::DuckDBError), Some(message.into()))
     }
     #[inline]
     pub fn sql(&self) -> Option<&CStr> {

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -20,14 +20,12 @@ pub struct Rows<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
     arr: Arc<Option<StructArray>>,
     row: Option<Row<'stmt>>,
-    current_row: usize,
     current_batch_row: usize,
 }
 
 impl<'stmt> Rows<'stmt> {
     #[inline]
     fn reset(&mut self) {
-        self.current_row = 0;
         self.current_batch_row = 0;
         self.arr = Arc::new(None);
     }
@@ -139,7 +137,6 @@ impl<'stmt> Rows<'stmt> {
             stmt: Some(stmt),
             arr: Arc::new(None),
             row: None,
-            current_row: 0,
             current_batch_row: 0,
         }
     }
@@ -251,28 +248,23 @@ impl<'stmt> FallibleStreamingIterator for Rows<'stmt> {
     fn advance(&mut self) -> Result<()> {
         match self.stmt {
             Some(stmt) => {
-                if self.current_row < stmt.row_count() {
-                    if self.current_batch_row >= self.batch_row_count() {
-                        self.arr = Arc::new(stmt.step());
-                        if self.arr.is_none() {
-                            self.row = None;
-                            return Ok(());
-                        }
-                        self.current_batch_row = 0;
+                while self.current_batch_row >= self.batch_row_count() {
+                    self.arr = Arc::new(stmt.step()?);
+                    if self.arr.is_none() {
+                        self.reset();
+                        self.row = None;
+                        return Ok(());
                     }
-                    self.row = Some(Row {
-                        stmt,
-                        arr: self.arr.clone(),
-                        current_row: self.current_batch_row,
-                    });
-                    self.current_row += 1;
-                    self.current_batch_row += 1;
-                    Ok(())
-                } else {
-                    self.reset();
-                    self.row = None;
-                    Ok(())
+                    self.current_batch_row = 0;
                 }
+
+                self.row = Some(Row {
+                    stmt,
+                    arr: self.arr.clone(),
+                    current_row: self.current_batch_row,
+                });
+                self.current_batch_row += 1;
+                Ok(())
             }
             None => {
                 self.row = None;
@@ -907,7 +899,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_arrow_decimal_metadata_keeps_hugeint_fallback() -> Result<()> {
+    fn ambiguous_decimal_expression_uses_executed_metadata() -> Result<()> {
         let db = Connection::open_in_memory()?;
 
         let byte = 255_i128;
@@ -921,7 +913,7 @@ mod tests {
         let decimal = db.query_row("SELECT ? + 0::DECIMAL(38,0)", [&value], |row| {
             row.get_ref(0).map(|value| value.to_owned())
         })?;
-        assert_eq!(decimal, Value::HugeInt(5));
+        assert_eq!(decimal, Value::Decimal(Decimal::new(38, 0, 5)?));
 
         Ok(())
     }
@@ -1091,6 +1083,41 @@ mod tests {
         assert_eq!(values[2048], Value::UHugeInt(2048));
         assert_eq!(values[2500], Value::Null);
         assert_eq!(values[2999], Value::UHugeInt(2999));
+
+        Ok(())
+    }
+
+    #[test]
+    fn zero_row_query_returns_none() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let mut stmt = db.prepare("SELECT 1 AS x WHERE false")?;
+        let mut rows = stmt.query([])?;
+
+        assert!(rows.next()?.is_none());
+        assert!(rows.next()?.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn wide_multichunk_query_iterates_all_rows() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let columns = (0..64)
+            .map(|idx| format!("i + {idx} AS c{idx}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("SELECT {columns} FROM range(3000) AS t(i) ORDER BY i");
+        let mut stmt = db.prepare(&sql)?;
+        let mut rows = stmt.query([])?;
+        let mut count = 0_i64;
+
+        while let Some(row) = rows.next()? {
+            assert_eq!(row.get::<_, i64>(0)?, count);
+            assert_eq!(row.get::<_, i64>(63)?, count + 63);
+            count += 1;
+        }
+
+        assert_eq!(count, 3000);
 
         Ok(())
     }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -395,21 +395,25 @@ impl Statement<'_> {
         self.stmt.row_count()
     }
 
-    /// Get next batch records in arrow-rs
+    /// Get next batch records in arrow-rs.
+    ///
+    /// Returns `Err` if DuckDB cannot convert the next result chunk to Arrow.
     #[inline]
-    pub fn step(&self) -> Option<StructArray> {
+    pub fn step(&self) -> Result<Option<StructArray>> {
         self.stmt.step()
     }
 
-    /// Get next batch records in arrow-rs in a streaming way
+    /// Get next batch records in arrow-rs in a streaming way.
+    ///
+    /// Returns `Err` if DuckDB cannot convert the next result chunk to Arrow.
     #[inline]
-    pub fn stream_step(&self, schema: SchemaRef) -> Option<StructArray> {
+    pub fn stream_step(&self, schema: SchemaRef) -> Result<Option<StructArray>> {
         self.stmt.streaming_step(schema)
     }
 
     #[cfg(feature = "polars")]
     #[inline]
-    pub(crate) fn step_polars(&self) -> Option<polars_arrow::array::StructArray> {
+    pub(crate) fn step_polars(&self) -> Result<Option<polars_arrow::array::StructArray>> {
         self.stmt.step_polars()
     }
 
@@ -1593,6 +1597,73 @@ mod test {
     }
 
     #[test]
+    fn test_step_after_streaming_materialized_result_returns_none() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch(
+            "CREATE TABLE test_data(id INTEGER);
+             INSERT INTO test_data VALUES (1), (2);
+             CREATE MACRO test_func() AS TABLE SELECT * FROM test_data;",
+        )?;
+
+        let mut stmt = db.prepare("CALL test_func()")?;
+        stmt.stmt.execute_streaming()?;
+
+        assert!(stmt.stmt.step()?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_row_count_after_query_execution() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let mut stmt = db.prepare("SELECT i FROM range(3000) AS t(i)")?;
+        {
+            let rows = stmt.query([])?;
+            drop(rows);
+        }
+
+        assert_eq!(3000, stmt.row_count());
+        Ok(())
+    }
+
+    #[test]
+    fn test_stream_arrow_large_result() -> Result<()> {
+        use std::sync::Arc;
+
+        use arrow::{
+            array::Int64Array,
+            datatypes::{DataType, Field, Schema},
+        };
+
+        let db = Connection::open_in_memory()?;
+        let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int64, true)]));
+        let batches = db
+            .prepare("SELECT i FROM range(3000) AS t(i) ORDER BY i")?
+            .stream_arrow([], schema)?
+            .collect::<Vec<_>>();
+
+        assert!(batches.len() > 1);
+        assert_eq!(3000, batches.iter().map(|batch| batch.num_rows()).sum::<usize>());
+
+        let values = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .iter()
+                    .map(Option::unwrap)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(0, values[0]);
+        assert_eq!(2048, values[2048]);
+        assert_eq!(2999, values[2999]);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_bind_date32() -> Result<()> {
         use crate::types::Value;
 
@@ -1850,6 +1921,45 @@ mod test {
         };
 
         assert_variant_decode_error(err, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_variant_returning_execute_rejected_before_mutation() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE t(id INTEGER, v VARIANT);")?;
+
+        let err = match db.execute("INSERT INTO t VALUES (1, {'a': 42}::VARIANT) RETURNING v", []) {
+            Ok(_) => panic!("expected Variant RETURNING execute to fail"),
+            Err(err) => err,
+        };
+
+        assert_variant_decode_error(err, 0);
+        let count: i64 = db.query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))?;
+        assert_eq!(0, count);
+        Ok(())
+    }
+
+    #[test]
+    fn test_variant_returning_streaming_rejected_before_mutation() -> Result<()> {
+        use std::sync::Arc;
+
+        use arrow::datatypes::Schema;
+
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("CREATE TABLE t(id INTEGER, v VARIANT);")?;
+
+        let err = match db
+            .prepare("INSERT INTO t VALUES (1, {'a': 42}::VARIANT) RETURNING v")?
+            .stream_arrow([], Arc::new(Schema::empty()))
+        {
+            Ok(_) => panic!("expected Variant RETURNING streaming execute to fail"),
+            Err(err) => err,
+        };
+
+        assert_variant_decode_error(err, 0);
+        let count: i64 = db.query_row("SELECT COUNT(*) FROM t", [], |row| row.get(0))?;
+        assert_eq!(0, count);
         Ok(())
     }
 


### PR DESCRIPTION
Fixes stale result type metadata when reusing cached prepared statements after schema changes.

The regression came from row decoding starting to rely on cached prepared statement metadata after:

- #795
- #799

Cached statements can outlive catalog changes, so that metadata may describe an older schema. This PR reads result schema and logical column types from the executed DuckDB result instead.

This also moves discarded batch execution and prepared result execution off DuckDB's deprecated `duckdb_arrow` result API. The wrapper now executes into `duckdb_result`, reads result metadata from the executed result, and converts result chunks to Arrow only when callers actually consume Arrow rows. Based on #778.

## Breaking

- `Statement::step` and `Statement::stream_step` now return `Result<Option<StructArray>>`.
- Arrow and Polars iterators now panic on chunk conversion errors instead of treating them as end-of-stream.
- `SELECT ? + 0::DECIMAL(38,0)` now decodes as `Decimal`, matching DuckDB's logical result type.