### PR TITLE
Extract RAII ExecutedResult owner

### DIFF
--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -45,23 +45,19 @@ impl<'stmt> Iterator for Arrow<'stmt> {
 #[allow(clippy::needless_lifetimes)]
 pub struct ArrowStream<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
-    pub(crate) schema: SchemaRef,
 }
 
 #[allow(clippy::needless_lifetimes)]
 impl<'stmt> ArrowStream<'stmt> {
     #[inline]
-    pub(crate) fn new(stmt: &'stmt Statement<'stmt>, schema: SchemaRef) -> Self {
-        ArrowStream {
-            stmt: Some(stmt),
-            schema,
-        }
+    pub(crate) fn new(stmt: &'stmt Statement<'stmt>) -> Self {
+        ArrowStream { stmt: Some(stmt) }
     }
 
     /// return arrow schema
     #[inline]
     pub fn get_schema(&self) -> SchemaRef {
-        self.schema.clone()
+        self.stmt.unwrap().stmt.schema()
     }
 }
 
@@ -70,7 +66,7 @@ impl<'stmt> Iterator for ArrowStream<'stmt> {
     type Item = RecordBatch;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.stmt?.stream_step(self.get_schema()) {
+        match self.stmt?.step() {
             Ok(Some(array)) => Some(RecordBatch::from(&array)),
             Ok(None) => None,
             Err(err) => panic!("Failed to fetch streaming Arrow record batch: {err}"),

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -19,7 +19,7 @@ impl<'stmt> Arrow<'stmt> {
         Arrow { stmt: Some(stmt) }
     }
 
-    /// return arrow schema
+    /// Return the Arrow schema reported by DuckDB after execution.
     #[inline]
     pub fn get_schema(&self) -> SchemaRef {
         self.stmt.unwrap().stmt.schema()

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -5,7 +5,8 @@ use super::{
 
 /// A handle for the resulting RecordBatch of a query.
 ///
-/// The iterator panics if DuckDB fails to convert a result chunk to Arrow.
+/// The iterator panics if DuckDB fails to fetch a result chunk or convert it
+/// to Arrow.
 #[must_use = "Arrow is lazy and will do nothing unless consumed"]
 pub struct Arrow<'stmt> {
     pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
@@ -40,7 +41,8 @@ impl<'stmt> Iterator for Arrow<'stmt> {
 
 /// A handle for the resulting RecordBatch of a query in streaming.
 ///
-/// The iterator panics if DuckDB fails to convert a result chunk to Arrow.
+/// The iterator panics if DuckDB fails to fetch a result chunk or convert it
+/// to Arrow.
 #[must_use = "Arrow stream is lazy and will not fetch data unless consumed"]
 #[allow(clippy::needless_lifetimes)]
 pub struct ArrowStream<'stmt> {
@@ -54,7 +56,7 @@ impl<'stmt> ArrowStream<'stmt> {
         ArrowStream { stmt: Some(stmt) }
     }
 
-    /// return arrow schema
+    /// Return the Arrow schema reported by DuckDB after execution.
     #[inline]
     pub fn get_schema(&self) -> SchemaRef {
         self.stmt.unwrap().stmt.schema()

--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -22,7 +22,10 @@ impl<'stmt> Arrow<'stmt> {
     /// Return the Arrow schema reported by DuckDB after execution.
     #[inline]
     pub fn get_schema(&self) -> SchemaRef {
-        self.stmt.unwrap().stmt.schema()
+        self.stmt
+            .expect("Arrow iterator always holds a statement")
+            .stmt
+            .schema()
     }
 }
 
@@ -59,7 +62,10 @@ impl<'stmt> ArrowStream<'stmt> {
     /// Return the Arrow schema reported by DuckDB after execution.
     #[inline]
     pub fn get_schema(&self) -> SchemaRef {
-        self.stmt.unwrap().stmt.schema()
+        self.stmt
+            .expect("ArrowStream iterator always holds a statement")
+            .stmt
+            .schema()
     }
 }
 

--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -336,15 +336,13 @@ pub fn result_from_duckdb_result(code: ffi::duckdb_state, result: *mut ffi::duck
         return Ok(());
     }
     unsafe {
-        let message = if result.is_null() {
-            Some("result is null".to_string())
+        if result.is_null() {
+            result_from_duckdb_state(code, Some("result is null".to_string()))
         } else {
-            result_error_message(result)
-        };
-        if !result.is_null() {
+            let message = result_error_message(result);
             ffi::duckdb_destroy_result(result);
+            result_from_duckdb_state(code, message)
         }
-        result_from_duckdb_state(code, message)
     }
 }
 

--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -261,6 +261,11 @@ pub(crate) fn duckdb_failure_from_state(code: ffi::duckdb_state, message: Option
 }
 
 #[inline]
+fn duckdb_failure_from_error_type(error_type: ffi::duckdb_error_type, message: Option<String>) -> Error {
+    Error::DuckDBFailure(ffi::Error::new(error_type as ffi::duckdb_state), message)
+}
+
+#[inline]
 pub(crate) fn duckdb_failure_from_message(message: impl Into<String>) -> Error {
     duckdb_failure_from_state(ffi::DuckDBError, Some(message.into()))
 }
@@ -378,6 +383,7 @@ pub(crate) unsafe fn result_from_duckdb_error_data(mut error_data: ffi::duckdb_e
             return Ok(());
         }
 
+        let error_type = ffi::duckdb_error_data_error_type(error_data);
         let message = {
             let c_err = ffi::duckdb_error_data_message(error_data);
             if c_err.is_null() {
@@ -387,7 +393,7 @@ pub(crate) unsafe fn result_from_duckdb_error_data(mut error_data: ffi::duckdb_e
             }
         };
         ffi::duckdb_destroy_error_data(&mut error_data);
-        result_from_duckdb_state(ffi::DuckDBError, message)
+        Err(duckdb_failure_from_error_type(error_type, message))
     }
 }
 
@@ -473,7 +479,13 @@ mod tests {
         let err = unsafe { result_from_duckdb_error_data(error_data) }.unwrap_err();
 
         match err {
-            Error::DuckDBFailure(_, Some(message)) => assert_eq!(message, "synthetic error"),
+            Error::DuckDBFailure(err, Some(message)) => {
+                assert_eq!(
+                    err.extended_code,
+                    ffi::duckdb_error_type_DUCKDB_ERROR_INTERNAL as ffi::duckdb_state
+                );
+                assert_eq!(message, "synthetic error");
+            }
             err => panic!("unexpected error: {err:?}"),
         }
     }

--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -251,8 +251,23 @@ impl error::Error for Error {
 // These are public but not re-exported by lib.rs, so only visible within crate.
 
 #[inline]
-fn error_from_duckdb_code(code: ffi::duckdb_state, message: Option<String>) -> Result<()> {
-    Err(Error::DuckDBFailure(ffi::Error::new(code), message))
+fn result_from_duckdb_state(code: ffi::duckdb_state, message: Option<String>) -> Result<()> {
+    Err(duckdb_failure_from_state(code, message))
+}
+
+#[inline]
+pub(crate) fn duckdb_failure_from_state(code: ffi::duckdb_state, message: Option<String>) -> Error {
+    Error::DuckDBFailure(ffi::Error::new(code), message)
+}
+
+#[inline]
+pub(crate) fn duckdb_failure_from_message(message: impl Into<String>) -> Error {
+    duckdb_failure_from_state(ffi::DuckDBError, Some(message.into()))
+}
+
+#[inline]
+pub(crate) fn arrow_conversion_failure(context: &str, err: impl fmt::Display) -> Error {
+    duckdb_failure_from_message(format!("{context}: {err}"))
 }
 
 #[inline]
@@ -286,7 +301,7 @@ pub fn result_from_duckdb_appender(code: ffi::duckdb_state, appender: *mut ffi::
         if !(*appender).is_null() {
             ffi::duckdb_appender_destroy(appender);
         }
-        error_from_duckdb_code(code, message)
+        result_from_duckdb_state(code, message)
     }
 }
 
@@ -305,7 +320,7 @@ pub fn result_from_duckdb_prepare(code: ffi::duckdb_state, mut prepare: ffi::duc
             ffi::duckdb_destroy_prepare(&mut prepare);
             message
         };
-        error_from_duckdb_code(code, message)
+        result_from_duckdb_state(code, message)
     }
 }
 
@@ -319,16 +334,60 @@ pub fn result_from_duckdb_result(code: ffi::duckdb_state, result: *mut ffi::duck
         let message = if result.is_null() {
             Some("result is null".to_string())
         } else {
-            let c_err = ffi::duckdb_result_error(result);
-            let message = if c_err.is_null() {
+            result_error_message(result)
+        };
+        if !result.is_null() {
+            ffi::duckdb_destroy_result(result);
+        }
+        result_from_duckdb_state(code, message)
+    }
+}
+
+/// Returns the current DuckDB error message for a result handle.
+///
+/// # Safety
+///
+/// `result` must be a live DuckDB result handle.
+pub(crate) unsafe fn result_error_message(result: *mut ffi::duckdb_result) -> Option<String> {
+    unsafe {
+        debug_assert!(!result.is_null());
+        let c_err = ffi::duckdb_result_error(result);
+        if c_err.is_null() {
+            None
+        } else {
+            Some(CStr::from_ptr(c_err).to_string_lossy().to_string())
+        }
+    }
+}
+
+/// Converts a DuckDB error-data handle into this crate's `Result`.
+///
+/// # Safety
+///
+/// `error_data` must be null or a valid handle allocated by DuckDB. This
+/// function takes ownership of non-null handles and always destroys them before
+/// returning.
+#[inline]
+pub(crate) unsafe fn result_from_duckdb_error_data(mut error_data: ffi::duckdb_error_data) -> Result<()> {
+    unsafe {
+        if error_data.is_null() {
+            return Ok(());
+        }
+        if !ffi::duckdb_error_data_has_error(error_data) {
+            ffi::duckdb_destroy_error_data(&mut error_data);
+            return Ok(());
+        }
+
+        let message = {
+            let c_err = ffi::duckdb_error_data_message(error_data);
+            if c_err.is_null() {
                 None
             } else {
                 Some(CStr::from_ptr(c_err).to_string_lossy().to_string())
-            };
-            ffi::duckdb_destroy_result(result);
-            message
+            }
         };
-        error_from_duckdb_code(code, message)
+        ffi::duckdb_destroy_error_data(&mut error_data);
+        result_from_duckdb_state(ffi::DuckDBError, message)
     }
 }
 
@@ -354,6 +413,68 @@ pub fn result_from_duckdb_extract(
             ffi::duckdb_destroy_extracted(&mut extracted);
             message
         };
-        error_from_duckdb_code(ffi::DuckDBError, message)
+        result_from_duckdb_state(ffi::DuckDBError, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::CString, ptr};
+
+    use super::{Error, result_from_duckdb_error_data};
+    use crate::ffi;
+
+    #[test]
+    fn result_from_duckdb_error_data_accepts_null() {
+        unsafe {
+            result_from_duckdb_error_data(ptr::null_mut()).unwrap();
+        }
+    }
+
+    #[test]
+    fn result_from_duckdb_error_data_accepts_no_error_handle() {
+        unsafe {
+            let mut db = ptr::null_mut();
+            assert_eq!(ffi::DuckDBSuccess, ffi::duckdb_open(ptr::null(), &mut db));
+
+            let mut con = ptr::null_mut();
+            assert_eq!(ffi::DuckDBSuccess, ffi::duckdb_connect(db, &mut con));
+
+            let sql = CString::new("CREATE TABLE t(i INTEGER)").unwrap();
+            let mut result: ffi::duckdb_result = std::mem::zeroed();
+            assert_eq!(ffi::DuckDBSuccess, ffi::duckdb_query(con, sql.as_ptr(), &mut result));
+            ffi::duckdb_destroy_result(&mut result);
+
+            let table = CString::new("t").unwrap();
+            let mut appender = ptr::null_mut();
+            assert_eq!(
+                ffi::DuckDBSuccess,
+                ffi::duckdb_appender_create(con, ptr::null(), table.as_ptr(), &mut appender)
+            );
+
+            let error_data = ffi::duckdb_appender_error_data(appender);
+            assert!(!error_data.is_null());
+            assert!(!ffi::duckdb_error_data_has_error(error_data));
+
+            result_from_duckdb_error_data(error_data).unwrap();
+
+            assert_eq!(ffi::DuckDBSuccess, ffi::duckdb_appender_destroy(&mut appender));
+            ffi::duckdb_disconnect(&mut con);
+            ffi::duckdb_close(&mut db);
+        }
+    }
+
+    #[test]
+    fn result_from_duckdb_error_data_returns_error_message() {
+        let message = CString::new("synthetic error").unwrap();
+        let error_data =
+            unsafe { ffi::duckdb_create_error_data(ffi::duckdb_error_type_DUCKDB_ERROR_INTERNAL, message.as_ptr()) };
+
+        let err = unsafe { result_from_duckdb_error_data(error_data) }.unwrap_err();
+
+        match err {
+            Error::DuckDBFailure(_, Some(message)) => assert_eq!(message, "synthetic error"),
+            err => panic!("unexpected error: {err:?}"),
+        }
     }
 }

--- a/crates/duckdb/src/executed_result.rs
+++ b/crates/duckdb/src/executed_result.rs
@@ -101,6 +101,9 @@ impl ExecutedResult {
 
             let mut ffi_arrow_array = polars_arrow::ffi::ArrowArray::empty();
             self.chunk_to_arrow(chunk, &mut ffi_arrow_array as *mut _ as *mut ffi::ArrowArray)?;
+            if Self::polars_arrow_array_is_empty(&ffi_arrow_array) {
+                return Ok(None);
+            }
 
             let field = self.polars_arrow_field()?;
             let array =
@@ -115,6 +118,14 @@ impl ExecutedResult {
 
             Ok(Some(struct_array))
         }
+    }
+
+    #[cfg(feature = "polars")]
+    fn polars_arrow_array_is_empty(array: &polars_arrow::ffi::ArrowArray) -> bool {
+        // Polars and libduckdb-sys both use the Arrow C Data Interface layout;
+        // the release callback being null is the structural empty marker.
+        let array = unsafe { &*(array as *const _ as *const ffi::ArrowArray) };
+        array.release.is_none()
     }
 
     pub(crate) fn schema_ref(&self) -> &SchemaRef {

--- a/crates/duckdb/src/executed_result.rs
+++ b/crates/duckdb/src/executed_result.rs
@@ -1,0 +1,407 @@
+use std::{
+    cell::{OnceCell, UnsafeCell},
+    collections::HashMap,
+    ffi::{CStr, CString},
+    ops::Deref,
+    os::raw::c_char,
+    ptr::NonNull,
+    sync::Arc,
+};
+
+use arrow::{
+    array::StructArray,
+    datatypes::{Schema, SchemaRef},
+    ffi::{FFI_ArrowArray, FFI_ArrowSchema, from_ffi},
+};
+
+use super::{Result, ffi};
+use crate::{
+    Error,
+    core::{LogicalTypeHandle, LogicalTypeId},
+    error::{
+        arrow_conversion_failure, duckdb_failure_from_message, result_error_message, result_from_duckdb_error_data,
+    },
+    types::Type,
+};
+#[cfg(feature = "polars")]
+use polars_core::utils::arrow as polars_arrow;
+
+#[derive(Debug)]
+pub(crate) struct ExecutedResult {
+    // Keep Arrow options before the result to match the old manual teardown
+    // order, even though DuckDB returns an independent options handle.
+    arrow_options: ArrowOptionsHandle,
+    result: DuckdbResultHandle,
+    schema: SchemaRef,
+    columns: Box<[ResultColumn]>,
+    arrow_schema: OnceCell<FFI_ArrowSchema>,
+    column_name_cache: OnceCell<HashMap<Box<str>, usize>>,
+    #[cfg(feature = "polars")]
+    polars_arrow_field: OnceCell<polars_arrow::datatypes::Field>,
+}
+
+// SAFETY: `ExecutedResult` is Send but not Sync. It owns its DuckDB result and
+// Arrow options handles, and OnceCell keeps cache mutation local to the
+// statement. Moving the owner to another thread transfers the only access path
+// to those handles; concurrent access is not promised.
+unsafe impl Send for ExecutedResult {}
+
+#[derive(Debug)]
+struct ResultColumn {
+    name: CString,
+    logical_type: LogicalTypeHandle,
+    // DuckDB logical metadata disambiguates Arrow carrier types that are shared
+    // by GEOMETRY/BLOB and HUGEINT/UHUGEINT/DECIMAL.
+    logical_id: LogicalTypeId,
+}
+
+impl ExecutedResult {
+    /// Takes ownership of a DuckDB result.
+    ///
+    /// # Safety
+    ///
+    /// `result` must be initialized by DuckDB and not owned anywhere else.
+    /// This function takes ownership unconditionally: after it is called, the
+    /// result is destroyed by `ExecutedResult` even if metadata loading fails.
+    pub(crate) unsafe fn new(result: ffi::duckdb_result) -> Result<Self> {
+        let result = DuckdbResultHandle::new(result);
+        let arrow_options = unsafe { ArrowOptionsHandle::new(&result)? };
+        let (schema, columns) = unsafe { Self::load_schema_and_columns(&result, &arrow_options)? };
+        Ok(Self {
+            arrow_options,
+            result,
+            schema,
+            columns,
+            arrow_schema: OnceCell::new(),
+            column_name_cache: OnceCell::new(),
+            #[cfg(feature = "polars")]
+            polars_arrow_field: OnceCell::new(),
+        })
+    }
+
+    pub(crate) fn row_count(&self) -> usize {
+        unsafe { ffi::duckdb_row_count(self.result.as_mut_ptr()) as usize }
+    }
+
+    pub(crate) fn step(&self) -> Result<Option<StructArray>> {
+        unsafe {
+            let Some(chunk) = self.next_chunk()? else {
+                return Ok(None);
+            };
+            self.data_chunk_to_struct_array(chunk)
+        }
+    }
+
+    #[cfg(feature = "polars")]
+    pub(crate) fn step_polars(&self) -> Result<Option<polars_arrow::array::StructArray>> {
+        unsafe {
+            let Some(chunk) = self.next_chunk()? else {
+                return Ok(None);
+            };
+
+            let mut ffi_arrow_array = polars_arrow::ffi::ArrowArray::empty();
+            self.chunk_to_arrow(chunk, &mut ffi_arrow_array as *mut _ as *mut ffi::ArrowArray)?;
+
+            let field = self.polars_arrow_field()?;
+            let array =
+                polars_arrow::ffi::import_array_from_c(ffi_arrow_array, field.dtype.clone()).map_err(|err| {
+                    duckdb_failure_from_message(format!("Failed to import Polars Arrow array from C: {err}"))
+                })?;
+            let struct_array = array
+                .as_any()
+                .downcast_ref::<polars_arrow::array::StructArray>()
+                .ok_or_else(|| duckdb_failure_from_message("Failed to downcast Polars Arrow array to StructArray"))?
+                .to_owned();
+
+            Ok(Some(struct_array))
+        }
+    }
+
+    pub(crate) fn schema_ref(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub(crate) fn result_column_logical_id(&self, idx: usize) -> LogicalTypeId {
+        assert!(
+            idx < self.columns.len(),
+            "result column logical-id cache is shorter than the result schema"
+        );
+        self.columns[idx].logical_id
+    }
+
+    pub(crate) fn try_column_logical_type(&self, idx: usize) -> Result<LogicalTypeHandle> {
+        unsafe { Self::try_result_column_logical_type(self.result.as_mut_ptr(), idx) }
+    }
+
+    pub(crate) fn column_name(&self, idx: usize) -> Option<&String> {
+        self.schema.fields().get(idx).map(|field| field.name())
+    }
+
+    pub(crate) fn column_index(&self, name: &str) -> Option<usize> {
+        let cache = self.column_name_cache.get_or_init(|| self.build_column_name_cache());
+        cache.get(&*name.to_ascii_lowercase()).copied()
+    }
+
+    fn build_column_name_cache(&self) -> HashMap<Box<str>, usize> {
+        let schema = self.schema_ref();
+        let mut cache = HashMap::with_capacity(schema.fields().len());
+        for (index, field) in schema.fields().iter().enumerate() {
+            cache
+                .entry(field.name().to_ascii_lowercase().into_boxed_str())
+                .or_insert(index);
+        }
+        cache
+    }
+
+    unsafe fn load_schema_and_columns(
+        result: &DuckdbResultHandle,
+        arrow_options: &ArrowOptionsHandle,
+    ) -> Result<(SchemaRef, Box<[ResultColumn]>)> {
+        unsafe {
+            let mut c_schema = FFI_ArrowSchema::empty();
+            let columns = Self::load_result_columns(result.as_mut_ptr())?;
+            Self::export_arrow_schema(
+                arrow_options,
+                &columns,
+                &mut c_schema as *mut _ as *mut ffi::ArrowSchema,
+            )?;
+            let schema = Arc::new(
+                Schema::try_from(&c_schema)
+                    .map_err(|err| arrow_conversion_failure("Could not import DuckDB Arrow schema", err))?,
+            );
+            debug_assert_eq!(
+                schema.fields().len(),
+                columns.len(),
+                "result schema and column cache are built from the same DuckDB column count"
+            );
+
+            Ok((schema, columns))
+        }
+    }
+
+    unsafe fn load_result_columns(result: *mut ffi::duckdb_result) -> Result<Box<[ResultColumn]>> {
+        unsafe {
+            let column_count = ffi::duckdb_column_count(result) as usize;
+            let mut columns = Vec::with_capacity(column_count);
+
+            for idx in 0..column_count {
+                let logical_type = Self::try_result_column_logical_type(result, idx)?;
+                reject_unsupported_result_logical_type(idx, &logical_type)?;
+                let logical_id = logical_type.id();
+
+                let name = ffi::duckdb_column_name(result, idx as u64);
+                if name.is_null() {
+                    return Err(duckdb_failure_from_message(format!(
+                        "Could not retrieve name for result column at index {idx}"
+                    )));
+                }
+                let name = CStr::from_ptr(name).to_owned();
+
+                columns.push(ResultColumn {
+                    name,
+                    logical_type,
+                    logical_id,
+                });
+            }
+
+            Ok(columns.into_boxed_slice())
+        }
+    }
+
+    unsafe fn try_result_column_logical_type(result: *mut ffi::duckdb_result, idx: usize) -> Result<LogicalTypeHandle> {
+        unsafe {
+            let ptr = ffi::duckdb_column_logical_type(result, idx as u64);
+            if ptr.is_null() {
+                return Err(duckdb_failure_from_message(format!(
+                    "Could not retrieve logical type for result column at index {idx}"
+                )));
+            }
+            Ok(LogicalTypeHandle::new(ptr))
+        }
+    }
+
+    unsafe fn export_arrow_schema(
+        arrow_options: &ArrowOptionsHandle,
+        columns: &[ResultColumn],
+        dst: *mut ffi::ArrowSchema,
+    ) -> Result<()> {
+        unsafe {
+            let mut type_ptrs = columns.iter().map(|column| column.logical_type.ptr).collect::<Vec<_>>();
+            let mut names = columns
+                .iter()
+                .map(|column| column.name.as_ptr() as *const c_char)
+                .collect::<Vec<_>>();
+            let error_data = ffi::duckdb_to_arrow_schema(
+                arrow_options.as_ptr(),
+                type_ptrs.as_mut_ptr(),
+                names.as_mut_ptr(),
+                columns.len() as ffi::idx_t,
+                dst,
+            );
+            result_from_duckdb_error_data(error_data)
+        }
+    }
+
+    unsafe fn next_chunk(&self) -> Result<Option<ffi::duckdb_data_chunk>> {
+        unsafe {
+            let chunk = ffi::duckdb_fetch_chunk(self.result.as_handle());
+            if !chunk.is_null() {
+                Ok(Some(chunk))
+            } else {
+                self.check_result_error()?;
+                Ok(None)
+            }
+        }
+    }
+
+    unsafe fn check_result_error(&self) -> Result<()> {
+        unsafe {
+            let Some(message) = result_error_message(self.result.as_mut_ptr()) else {
+                return Ok(());
+            };
+            Err(duckdb_failure_from_message(message))
+        }
+    }
+
+    unsafe fn data_chunk_to_struct_array(&self, chunk: ffi::duckdb_data_chunk) -> Result<Option<StructArray>> {
+        unsafe {
+            let mut arrays = FFI_ArrowArray::empty();
+            self.chunk_to_arrow(chunk, &mut arrays as *mut _ as *mut ffi::ArrowArray)?;
+
+            if arrays.is_empty() {
+                return Ok(None);
+            }
+
+            let schema = self.arrow_schema()?;
+            let array_data = from_ffi(arrays, schema)
+                .map_err(|err| arrow_conversion_failure("Could not import DuckDB Arrow array", err))?;
+            Ok(Some(StructArray::from(array_data)))
+        }
+    }
+
+    fn arrow_schema(&self) -> Result<&FFI_ArrowSchema> {
+        if self.arrow_schema.get().is_none() {
+            let schema = FFI_ArrowSchema::try_from(self.schema.deref())
+                .map_err(|err| arrow_conversion_failure("Could not export Arrow schema", err))?;
+            let _ = self.arrow_schema.set(schema);
+        }
+        Ok(self
+            .arrow_schema
+            .get()
+            .expect("Arrow schema cache was just initialized"))
+    }
+
+    unsafe fn chunk_to_arrow(&self, mut chunk: ffi::duckdb_data_chunk, dst: *mut ffi::ArrowArray) -> Result<()> {
+        unsafe {
+            let error_data = ffi::duckdb_data_chunk_to_arrow(self.arrow_options.as_ptr(), chunk, dst);
+            ffi::duckdb_destroy_data_chunk(&mut chunk);
+            result_from_duckdb_error_data(error_data)
+        }
+    }
+
+    #[cfg(feature = "polars")]
+    fn polars_arrow_field(&self) -> Result<&polars_arrow::datatypes::Field> {
+        if self.polars_arrow_field.get().is_none() {
+            let field = unsafe { self.load_polars_arrow_field()? };
+            let _ = self.polars_arrow_field.set(field);
+        }
+        Ok(self
+            .polars_arrow_field
+            .get()
+            .expect("polars Arrow field cache was just initialized"))
+    }
+
+    #[cfg(feature = "polars")]
+    unsafe fn load_polars_arrow_field(&self) -> Result<polars_arrow::datatypes::Field> {
+        unsafe {
+            let mut schema = polars_arrow::ffi::ArrowSchema::empty();
+            Self::export_arrow_schema(
+                &self.arrow_options,
+                &self.columns,
+                &mut schema as *mut _ as *mut ffi::ArrowSchema,
+            )?;
+
+            polars_arrow::ffi::import_field_from_c(&schema)
+                .map_err(|err| duckdb_failure_from_message(format!("Failed to import Polars Arrow field: {err}")))
+        }
+    }
+}
+
+pub(crate) fn reject_unsupported_result_logical_type(idx: usize, logical_type: &LogicalTypeHandle) -> Result<()> {
+    if logical_type.contains_type_id(LogicalTypeId::Variant) {
+        return Err(Error::FromSqlConversionFailure(
+            idx,
+            Type::Variant,
+            "decoding Variant columns is not supported".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct DuckdbResultHandle {
+    result: UnsafeCell<ffi::duckdb_result>,
+}
+
+impl DuckdbResultHandle {
+    fn new(result: ffi::duckdb_result) -> Self {
+        Self {
+            result: UnsafeCell::new(result),
+        }
+    }
+
+    fn as_handle(&self) -> ffi::duckdb_result {
+        unsafe { *self.result.get() }
+    }
+
+    fn as_mut_ptr(&self) -> *mut ffi::duckdb_result {
+        self.result.get()
+    }
+}
+
+impl Drop for DuckdbResultHandle {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::duckdb_destroy_result(self.result.get());
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ArrowOptionsHandle {
+    ptr: NonNull<ffi::_duckdb_arrow_options>,
+}
+
+impl ArrowOptionsHandle {
+    /// Takes ownership of a DuckDB Arrow options handle for `result`.
+    ///
+    /// # Safety
+    ///
+    /// `result` must be a live DuckDB result. The returned handle owns the
+    /// options pointer and destroys it on drop.
+    unsafe fn new(result: &DuckdbResultHandle) -> Result<Self> {
+        unsafe {
+            let arrow_options = ffi::duckdb_result_get_arrow_options(result.as_mut_ptr());
+            let Some(arrow_options) = NonNull::new(arrow_options) else {
+                return Err(duckdb_failure_from_message(
+                    "Could not retrieve Arrow options for result",
+                ));
+            };
+            Ok(Self { ptr: arrow_options })
+        }
+    }
+
+    fn as_ptr(&self) -> ffi::duckdb_arrow_options {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for ArrowOptionsHandle {
+    fn drop(&mut self) {
+        let mut arrow_options = self.ptr.as_ptr();
+        unsafe {
+            ffi::duckdb_destroy_arrow_options(&mut arrow_options);
+        }
+    }
+}

--- a/crates/duckdb/src/executed_result.rs
+++ b/crates/duckdb/src/executed_result.rs
@@ -1,8 +1,7 @@
 use std::{
-    cell::{OnceCell, UnsafeCell},
+    cell::{Cell, OnceCell, UnsafeCell},
     collections::HashMap,
     ffi::{CStr, CString},
-    ops::Deref,
     os::raw::c_char,
     ptr::NonNull,
     sync::Arc,
@@ -28,31 +27,28 @@ use polars_core::utils::arrow as polars_arrow;
 
 #[derive(Debug)]
 pub(crate) struct ExecutedResult {
-    // Keep Arrow options before the result to match the old manual teardown
-    // order, even though DuckDB returns an independent options handle.
     arrow_options: ArrowOptionsHandle,
     result: DuckdbResultHandle,
     schema: SchemaRef,
     columns: Box<[ResultColumn]>,
-    arrow_schema: OnceCell<FFI_ArrowSchema>,
+    arrow_schema: FFI_ArrowSchema,
+    exhausted: Cell<bool>,
     column_name_cache: OnceCell<HashMap<Box<str>, usize>>,
     #[cfg(feature = "polars")]
     polars_arrow_field: OnceCell<polars_arrow::datatypes::Field>,
 }
 
-// SAFETY: `ExecutedResult` is Send but not Sync. It owns its DuckDB result and
-// Arrow options handles, and OnceCell keeps cache mutation local to the
-// statement. Moving the owner to another thread transfers the only access path
-// to those handles; concurrent access is not promised.
+// SAFETY: `ExecutedResult` is Send but not Sync. It owns its DuckDB result in an
+// UnsafeCell because fetching mutates DuckDB's result cursor through `&self`.
+// Cell and OnceCell keep cache/cursor mutation local to the statement. Moving
+// the owner to another thread transfers the only access path to the result and
+// Arrow options handles; concurrent access is not promised.
 unsafe impl Send for ExecutedResult {}
 
 #[derive(Debug)]
 struct ResultColumn {
     name: CString,
     logical_type: LogicalTypeHandle,
-    // DuckDB logical metadata disambiguates Arrow carrier types that are shared
-    // by GEOMETRY/BLOB and HUGEINT/UHUGEINT/DECIMAL.
-    logical_id: LogicalTypeId,
 }
 
 impl ExecutedResult {
@@ -66,13 +62,14 @@ impl ExecutedResult {
     pub(crate) unsafe fn new(result: ffi::duckdb_result) -> Result<Self> {
         let result = DuckdbResultHandle::new(result);
         let arrow_options = unsafe { ArrowOptionsHandle::new(&result)? };
-        let (schema, columns) = unsafe { Self::load_schema_and_columns(&result, &arrow_options)? };
+        let (schema, columns, arrow_schema) = unsafe { Self::load_schema_and_columns(&result, &arrow_options)? };
         Ok(Self {
             arrow_options,
             result,
             schema,
             columns,
-            arrow_schema: OnceCell::new(),
+            arrow_schema,
+            exhausted: Cell::new(false),
             column_name_cache: OnceCell::new(),
             #[cfg(feature = "polars")]
             polars_arrow_field: OnceCell::new(),
@@ -88,7 +85,7 @@ impl ExecutedResult {
             let Some(chunk) = self.next_chunk()? else {
                 return Ok(None);
             };
-            self.data_chunk_to_struct_array(chunk)
+            self.data_chunk_to_struct_array(chunk).map(Some)
         }
     }
 
@@ -101,15 +98,10 @@ impl ExecutedResult {
 
             let mut ffi_arrow_array = polars_arrow::ffi::ArrowArray::empty();
             self.chunk_to_arrow(chunk, &mut ffi_arrow_array as *mut _ as *mut ffi::ArrowArray)?;
-            if Self::polars_arrow_array_is_empty(&ffi_arrow_array) {
-                return Ok(None);
-            }
 
             let field = self.polars_arrow_field()?;
-            let array =
-                polars_arrow::ffi::import_array_from_c(ffi_arrow_array, field.dtype.clone()).map_err(|err| {
-                    duckdb_failure_from_message(format!("Failed to import Polars Arrow array from C: {err}"))
-                })?;
+            let array = polars_arrow::ffi::import_array_from_c(ffi_arrow_array, field.dtype.clone())
+                .map_err(|err| arrow_conversion_failure("Could not import Polars Arrow array from C", err))?;
             let struct_array = array
                 .as_any()
                 .downcast_ref::<polars_arrow::array::StructArray>()
@@ -120,24 +112,16 @@ impl ExecutedResult {
         }
     }
 
-    #[cfg(feature = "polars")]
-    fn polars_arrow_array_is_empty(array: &polars_arrow::ffi::ArrowArray) -> bool {
-        // Polars and libduckdb-sys both use the Arrow C Data Interface layout;
-        // the release callback being null is the structural empty marker.
-        let array = unsafe { &*(array as *const _ as *const ffi::ArrowArray) };
-        array.release.is_none()
-    }
-
     pub(crate) fn schema_ref(&self) -> &SchemaRef {
         &self.schema
     }
 
     pub(crate) fn result_column_logical_id(&self, idx: usize) -> LogicalTypeId {
-        assert!(
-            idx < self.columns.len(),
-            "result column logical-id cache is shorter than the result schema"
-        );
-        self.columns[idx].logical_id
+        self.columns
+            .get(idx)
+            .unwrap_or_else(|| panic!("result column logical-type index {idx} is out of bounds"))
+            .logical_type
+            .id()
     }
 
     pub(crate) fn try_column_logical_type(&self, idx: usize) -> Result<LogicalTypeHandle> {
@@ -167,17 +151,17 @@ impl ExecutedResult {
     unsafe fn load_schema_and_columns(
         result: &DuckdbResultHandle,
         arrow_options: &ArrowOptionsHandle,
-    ) -> Result<(SchemaRef, Box<[ResultColumn]>)> {
+    ) -> Result<(SchemaRef, Box<[ResultColumn]>, FFI_ArrowSchema)> {
         unsafe {
-            let mut c_schema = FFI_ArrowSchema::empty();
+            let mut arrow_schema = FFI_ArrowSchema::empty();
             let columns = Self::load_result_columns(result.as_mut_ptr())?;
             Self::export_arrow_schema(
                 arrow_options,
                 &columns,
-                &mut c_schema as *mut _ as *mut ffi::ArrowSchema,
+                &mut arrow_schema as *mut _ as *mut ffi::ArrowSchema,
             )?;
             let schema = Arc::new(
-                Schema::try_from(&c_schema)
+                Schema::try_from(&arrow_schema)
                     .map_err(|err| arrow_conversion_failure("Could not import DuckDB Arrow schema", err))?,
             );
             debug_assert_eq!(
@@ -186,7 +170,7 @@ impl ExecutedResult {
                 "result schema and column cache are built from the same DuckDB column count"
             );
 
-            Ok((schema, columns))
+            Ok((schema, columns, arrow_schema))
         }
     }
 
@@ -198,7 +182,6 @@ impl ExecutedResult {
             for idx in 0..column_count {
                 let logical_type = Self::try_result_column_logical_type(result, idx)?;
                 reject_unsupported_result_logical_type(idx, &logical_type)?;
-                let logical_id = logical_type.id();
 
                 let name = ffi::duckdb_column_name(result, idx as u64);
                 if name.is_null() {
@@ -208,11 +191,7 @@ impl ExecutedResult {
                 }
                 let name = CStr::from_ptr(name).to_owned();
 
-                columns.push(ResultColumn {
-                    name,
-                    logical_type,
-                    logical_id,
-                });
+                columns.push(ResultColumn { name, logical_type });
             }
 
             Ok(columns.into_boxed_slice())
@@ -222,12 +201,7 @@ impl ExecutedResult {
     unsafe fn try_result_column_logical_type(result: *mut ffi::duckdb_result, idx: usize) -> Result<LogicalTypeHandle> {
         unsafe {
             let ptr = ffi::duckdb_column_logical_type(result, idx as u64);
-            if ptr.is_null() {
-                return Err(duckdb_failure_from_message(format!(
-                    "Could not retrieve logical type for result column at index {idx}"
-                )));
-            }
-            Ok(LogicalTypeHandle::new(ptr))
+            logical_type_from_duckdb_column(ptr, idx)
         }
     }
 
@@ -255,13 +229,29 @@ impl ExecutedResult {
 
     unsafe fn next_chunk(&self) -> Result<Option<ffi::duckdb_data_chunk>> {
         unsafe {
-            let chunk = ffi::duckdb_fetch_chunk(self.result.as_handle());
-            if !chunk.is_null() {
-                Ok(Some(chunk))
-            } else {
-                self.check_result_error()?;
-                Ok(None)
+            if self.exhausted.get() {
+                return Ok(None);
             }
+
+            // duckdb_fetch_chunk is the non-deprecated fetcher for both
+            // materialized and streaming results. That matters for CALL, which
+            // can produce a materialized result even after execute_streaming.
+            let chunk = ffi::duckdb_fetch_chunk(self.result.as_handle());
+            if chunk.is_null() {
+                self.check_result_error()?;
+                self.exhausted.set(true);
+                return Ok(None);
+            }
+
+            if ffi::duckdb_data_chunk_get_size(chunk) == 0 {
+                let mut chunk = chunk;
+                ffi::duckdb_destroy_data_chunk(&mut chunk);
+                self.check_result_error()?;
+                self.exhausted.set(true);
+                return Ok(None);
+            }
+
+            Ok(Some(chunk))
         }
     }
 
@@ -274,32 +264,15 @@ impl ExecutedResult {
         }
     }
 
-    unsafe fn data_chunk_to_struct_array(&self, chunk: ffi::duckdb_data_chunk) -> Result<Option<StructArray>> {
+    unsafe fn data_chunk_to_struct_array(&self, chunk: ffi::duckdb_data_chunk) -> Result<StructArray> {
         unsafe {
             let mut arrays = FFI_ArrowArray::empty();
             self.chunk_to_arrow(chunk, &mut arrays as *mut _ as *mut ffi::ArrowArray)?;
 
-            if arrays.is_empty() {
-                return Ok(None);
-            }
-
-            let schema = self.arrow_schema()?;
-            let array_data = from_ffi(arrays, schema)
+            let array_data = from_ffi(arrays, &self.arrow_schema)
                 .map_err(|err| arrow_conversion_failure("Could not import DuckDB Arrow array", err))?;
-            Ok(Some(StructArray::from(array_data)))
+            Ok(StructArray::from(array_data))
         }
-    }
-
-    fn arrow_schema(&self) -> Result<&FFI_ArrowSchema> {
-        if self.arrow_schema.get().is_none() {
-            let schema = FFI_ArrowSchema::try_from(self.schema.deref())
-                .map_err(|err| arrow_conversion_failure("Could not export Arrow schema", err))?;
-            let _ = self.arrow_schema.set(schema);
-        }
-        Ok(self
-            .arrow_schema
-            .get()
-            .expect("Arrow schema cache was just initialized"))
     }
 
     unsafe fn chunk_to_arrow(&self, mut chunk: ffi::duckdb_data_chunk, dst: *mut ffi::ArrowArray) -> Result<()> {
@@ -333,9 +306,21 @@ impl ExecutedResult {
             )?;
 
             polars_arrow::ffi::import_field_from_c(&schema)
-                .map_err(|err| duckdb_failure_from_message(format!("Failed to import Polars Arrow field: {err}")))
+                .map_err(|err| arrow_conversion_failure("Could not import Polars Arrow field", err))
         }
     }
+}
+
+pub(crate) unsafe fn logical_type_from_duckdb_column(
+    ptr: ffi::duckdb_logical_type,
+    idx: usize,
+) -> Result<LogicalTypeHandle> {
+    if ptr.is_null() {
+        return Err(duckdb_failure_from_message(format!(
+            "Could not retrieve logical type for result column at index {idx}"
+        )));
+    }
+    Ok(unsafe { LogicalTypeHandle::new(ptr) })
 }
 
 pub(crate) fn reject_unsupported_result_logical_type(idx: usize, logical_type: &LogicalTypeHandle) -> Result<()> {
@@ -350,6 +335,11 @@ pub(crate) fn reject_unsupported_result_logical_type(idx: usize, logical_type: &
     Ok(())
 }
 
+/// Owned DuckDB result handle.
+///
+/// DuckDB advances result state while fetching chunks, so the raw result lives
+/// in an `UnsafeCell` and fetch methods take `&self`. The owner is `Send` but
+/// not `Sync`, which keeps that interior mutation single-threaded.
 #[derive(Debug)]
 struct DuckdbResultHandle {
     result: UnsafeCell<ffi::duckdb_result>,

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -107,6 +107,7 @@ mod arrow_batch;
 mod cache;
 mod column;
 mod config;
+mod executed_result;
 mod inner_connection;
 mod params;
 

--- a/crates/duckdb/src/polars_dataframe.rs
+++ b/crates/duckdb/src/polars_dataframe.rs
@@ -94,6 +94,17 @@ mod tests {
     }
 
     #[test]
+    fn test_query_polars_empty_result() -> Result<()> {
+        let db = checked_memory_handle();
+        let mut stmt = db.prepare("SELECT 1 AS x WHERE false")?;
+        let mut polars = stmt.query_polars([])?;
+
+        assert!(polars.next().is_none());
+
+        Ok(())
+    }
+
+    #[test]
     fn test_query_polars_cached_ddl_uses_executed_metadata() -> Result<()> {
         let db = checked_memory_handle();
         db.execute_batch(

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -1,23 +1,16 @@
-use std::{
-    cell::{Cell, OnceCell},
-    collections::HashMap,
-    ffi::CStr,
-    ops::Deref,
-    sync::Arc,
-};
+use std::{ffi::CStr, sync::Arc};
 
 use arrow::{
     array::StructArray,
-    datatypes::{DataType, Schema, SchemaRef},
-    ffi::{FFI_ArrowArray, FFI_ArrowSchema, from_ffi},
+    datatypes::{DataType, SchemaRef},
 };
 
 use super::{Result, ffi};
 use crate::{
     Error,
     core::{LogicalTypeHandle, LogicalTypeId},
-    error::result_from_duckdb_result,
-    types::Type,
+    error::{duckdb_failure_from_message, result_from_duckdb_result},
+    executed_result::{ExecutedResult, reject_unsupported_result_logical_type},
 };
 #[cfg(feature = "polars")]
 use polars_core::utils::arrow as polars_arrow;
@@ -32,21 +25,7 @@ use polars_core::utils::arrow as polars_arrow;
 #[derive(Debug)]
 pub struct RawStatement {
     ptr: ffi::duckdb_prepared_statement,
-    duckdb_result: Option<ffi::duckdb_result>,
-    schema: Option<SchemaRef>,
-    // Cached DuckDB logical ids for result columns. Arrow reports HUGEINT,
-    // UHUGEINT, and DECIMAL(38,0) through the same decimal shape, and
-    // GEOMETRY through a binary shape.
-    result_column_logical_ids: Option<Box<[LogicalTypeId]>>,
-    #[cfg(feature = "polars")]
-    polars_arrow_field: OnceCell<polars_arrow::datatypes::Field>,
-    result_chunk_idx: Cell<usize>,
-    arrow_options: Cell<ffi::duckdb_arrow_options>,
-    column_name_cache: OnceCell<HashMap<Box<str>, usize>>,
-    // Tracks whether the duckdb_result is truly streaming or materialized.
-    // This is needed because some statements (like CALL) return materialized
-    // results even when execute_streaming is called.
-    is_streaming: bool,
+    result: Option<ExecutedResult>,
     // Cached SQL (trimmed) that we use as the key when we're in the statement
     // cache. This is None for statements which didn't come from the statement
     // cache.
@@ -65,15 +44,7 @@ impl RawStatement {
     pub unsafe fn new(stmt: ffi::duckdb_prepared_statement) -> Self {
         Self {
             ptr: stmt,
-            schema: None,
-            result_column_logical_ids: None,
-            #[cfg(feature = "polars")]
-            polars_arrow_field: OnceCell::new(),
-            result_chunk_idx: Cell::new(0),
-            arrow_options: Cell::new(std::ptr::null_mut()),
-            column_name_cache: OnceCell::new(),
-            duckdb_result: None,
-            is_streaming: false,
+            result: None,
             statement_cache_key: None,
         }
     }
@@ -105,99 +76,23 @@ impl RawStatement {
 
     #[inline]
     pub fn row_count(&self) -> usize {
-        unsafe {
-            let mut result = self.duckdb_result.expect("The statement was not executed yet");
-            ffi::duckdb_row_count(&mut result) as usize
-        }
+        self.executed().row_count()
     }
 
     #[inline]
     pub fn step(&self) -> Result<Option<StructArray>> {
-        let Some(result) = self.duckdb_result else {
-            return Ok(None);
-        };
-        let Some(schema) = self.schema.clone() else {
-            return Ok(None);
-        };
-        unsafe {
-            let Some(chunk) = self.next_result_chunk(result)? else {
-                return Ok(None);
-            };
-            self.data_chunk_to_struct_array(result, chunk, schema)
-        }
-    }
-
-    #[inline]
-    pub fn streaming_step(&self, schema: SchemaRef) -> Result<Option<StructArray>> {
-        if let Some(result) = self.duckdb_result {
-            unsafe {
-                // Use duckdb_stream_fetch_chunk for truly streaming results,
-                // or duckdb_fetch_chunk for materialized results (e.g., from CALL statements)
-                let out = if self.is_streaming {
-                    ffi::duckdb_stream_fetch_chunk(result)
-                } else {
-                    ffi::duckdb_fetch_chunk(result)
-                };
-
-                if out.is_null() {
-                    return Ok(None);
-                }
-
-                return self.data_chunk_to_struct_array(result, out, schema);
-            }
-        }
-
-        Ok(None)
+        self.result.as_ref().map_or(Ok(None), ExecutedResult::step)
     }
 
     #[cfg(feature = "polars")]
     #[inline]
     pub(crate) fn step_polars(&self) -> Result<Option<polars_arrow::array::StructArray>> {
-        let Some(result) = self.duckdb_result else {
-            return Ok(None);
-        };
-
-        unsafe {
-            let Some(chunk) = self.next_result_chunk(result)? else {
-                return Ok(None);
-            };
-
-            let mut ffi_arrow_array = polars_arrow::ffi::ArrowArray::empty();
-            self.chunk_to_arrow(result, chunk, &mut ffi_arrow_array as *mut _ as *mut ffi::ArrowArray)?;
-
-            let field = self.polars_arrow_field(result)?;
-            let import_array = polars_arrow::ffi::import_array_from_c(ffi_arrow_array, field.dtype.clone());
-
-            let array = match import_array {
-                Ok(array) => array,
-                // When array is empty, import_array_from_c returns ComputeError with message
-                // "An ArrowArray of type X must have non-null children".
-                Err(polars::error::PolarsError::ComputeError(msg)) if msg.to_string().contains("non-null children") => {
-                    return Ok(None);
-                }
-                Err(err) => {
-                    return Err(Self::duckdb_failure(format!(
-                        "Failed to import Polars Arrow array from C: {err}"
-                    )));
-                }
-            };
-            let struct_array = array
-                .as_any()
-                .downcast_ref::<polars_arrow::array::StructArray>()
-                .ok_or_else(|| Self::duckdb_failure("Failed to downcast Polars Arrow array to StructArray"))?
-                .to_owned();
-
-            Ok(Some(struct_array))
-        }
+        self.result.as_ref().map_or(Ok(None), ExecutedResult::step_polars)
     }
 
     #[inline]
     pub fn column_count(&self) -> usize {
-        self.schema
-            .as_ref()
-            .expect("The statement was not executed yet")
-            .fields()
-            .len()
+        self.schema_ref().fields().len()
     }
 
     #[inline]
@@ -213,19 +108,16 @@ impl RawStatement {
 
     #[inline]
     pub(crate) fn try_column_logical_type(&self, idx: usize) -> Result<LogicalTypeHandle> {
-        if let Some(mut result) = self.duckdb_result {
-            return unsafe { Self::try_result_column_logical_type(&mut result, idx) };
+        if let Some(result) = &self.result {
+            return result.try_column_logical_type(idx);
         }
 
         unsafe {
             let ptr = ffi::duckdb_prepared_statement_column_logical_type(self.ptr, idx as u64);
             if ptr.is_null() {
-                return Err(Error::DuckDBFailure(
-                    ffi::Error::new(ffi::DuckDBError),
-                    Some(format!(
-                        "Could not retrieve logical type for result column at index {idx}"
-                    )),
-                ));
+                return Err(duckdb_failure_from_message(format!(
+                    "Could not retrieve logical type for result column at index {idx}"
+                )));
             }
             Ok(LogicalTypeHandle::new(ptr))
         }
@@ -233,42 +125,32 @@ impl RawStatement {
 
     #[inline]
     pub(crate) fn result_column_logical_id(&self, idx: usize) -> Option<LogicalTypeId> {
-        let logical_ids = self.result_column_logical_ids.as_ref()?;
-        assert!(
-            idx < logical_ids.len(),
-            "result column logical-id cache is shorter than the result schema"
-        );
-        Some(logical_ids[idx])
+        self.result.as_ref().map(|result| result.result_column_logical_id(idx))
     }
 
     #[inline]
     pub fn schema(&self) -> SchemaRef {
-        self.schema.clone().unwrap()
+        self.schema_ref().clone()
+    }
+
+    #[inline]
+    fn schema_ref(&self) -> &SchemaRef {
+        self.executed().schema_ref()
+    }
+
+    #[inline]
+    fn executed(&self) -> &ExecutedResult {
+        self.result.as_ref().expect("The statement was not executed yet")
     }
 
     #[inline]
     pub fn column_name(&self, idx: usize) -> Option<&String> {
-        if idx >= self.column_count() {
-            return None;
-        }
-        Some(self.schema.as_ref().unwrap().field(idx).name())
+        self.executed().column_name(idx)
     }
 
     #[inline]
     pub fn column_index(&self, name: &str) -> Option<usize> {
-        let cache = self.column_name_cache.get_or_init(|| self.build_column_name_cache());
-        cache.get(&*name.to_ascii_lowercase()).copied()
-    }
-
-    fn build_column_name_cache(&self) -> HashMap<Box<str>, usize> {
-        let schema = self.schema.as_ref().expect("The statement was not executed yet");
-        let mut cache = HashMap::with_capacity(schema.fields().len());
-        for (index, field) in schema.fields().iter().enumerate() {
-            cache
-                .entry(field.name().to_ascii_lowercase().into_boxed_str())
-                .or_insert(index);
-        }
-        cache
+        self.executed().column_index(name)
     }
 
     /// NOTE: if execute failed, we shouldn't call any other methods which depends on result
@@ -281,18 +163,7 @@ impl RawStatement {
             result_from_duckdb_result(rc, &mut out)?;
 
             let rows_changed = ffi::duckdb_rows_changed(&mut out);
-            let (schema, result_column_logical_ids) = match self.load_result_schema_and_logical_ids(&mut out) {
-                Ok(result) => result,
-                Err(err) => {
-                    self.destroy_arrow_options();
-                    ffi::duckdb_destroy_result(&mut out);
-                    return Err(err);
-                }
-            };
-
-            self.schema = Some(schema);
-            self.duckdb_result = Some(out);
-            self.result_column_logical_ids = Some(result_column_logical_ids);
+            self.result = Some(ExecutedResult::new(out)?);
             Ok(rows_changed as usize)
         }
     }
@@ -305,23 +176,7 @@ impl RawStatement {
 
             let rc = ffi::duckdb_execute_prepared_streaming(self.ptr, &mut out);
             result_from_duckdb_result(rc, &mut out)?;
-            let result_column_logical_ids = match Self::load_result_column_logical_ids(&mut out) {
-                Ok(result) => result,
-                Err(err) => {
-                    self.destroy_arrow_options();
-                    ffi::duckdb_destroy_result(&mut out);
-                    return Err(err);
-                }
-            };
-
-            // Check if the result is truly streaming or materialized
-            // Some statements (like CALL) return materialized results even when streaming is requested
-            self.is_streaming = ffi::duckdb_result_is_streaming(out);
-
-            self.duckdb_result = Some(out);
-            // Streaming does not use the ids directly, but loading them
-            // rejects unsupported Variant columns before streaming begins.
-            self.result_column_logical_ids = Some(result_column_logical_ids);
+            self.result = Some(ExecutedResult::new(out)?);
 
             Ok(())
         }
@@ -329,22 +184,7 @@ impl RawStatement {
 
     #[inline]
     pub fn reset_result(&mut self) {
-        self.schema = None;
-        self.result_column_logical_ids = None;
-        #[cfg(feature = "polars")]
-        {
-            self.polars_arrow_field = OnceCell::new();
-        }
-        self.result_chunk_idx.set(0);
-        self.destroy_arrow_options();
-        self.column_name_cache = OnceCell::new();
-        self.is_streaming = false;
-        if let Some(mut result) = self.duckdb_result {
-            unsafe {
-                ffi::duckdb_destroy_result(&mut result);
-            }
-            self.duckdb_result = None;
-        }
+        self.result = None;
     }
 
     #[inline]
@@ -386,7 +226,7 @@ impl RawStatement {
         let column_count = unsafe { ffi::duckdb_prepared_statement_column_count(self.ptr) as usize };
         for idx in 0..column_count {
             let logical_type = self.try_column_logical_type(idx)?;
-            Self::reject_unsupported_result_logical_type(idx, &logical_type)?;
+            reject_unsupported_result_logical_type(idx, &logical_type)?;
         }
 
         Ok(())
@@ -401,258 +241,6 @@ impl RawStatement {
         )
     }
 
-    unsafe fn load_result_schema_and_logical_ids(
-        &self,
-        result: *mut ffi::duckdb_result,
-    ) -> Result<(SchemaRef, Box<[LogicalTypeId]>)> {
-        unsafe {
-            let mut c_schema = FFI_ArrowSchema::empty();
-            let logical_ids = self.result_to_arrow_schema(result, &mut c_schema as *mut _ as *mut ffi::ArrowSchema)?;
-            let schema = Arc::new(
-                Schema::try_from(&c_schema)
-                    .map_err(|err| Self::arrow_failure("Could not import DuckDB Arrow schema", err))?,
-            );
-            debug_assert_eq!(
-                schema.fields().len(),
-                logical_ids.len(),
-                "result schema and logical-id cache are built from the same DuckDB column count"
-            );
-
-            Ok((schema, logical_ids))
-        }
-    }
-
-    unsafe fn load_result_column_logical_ids(result: *mut ffi::duckdb_result) -> Result<Box<[LogicalTypeId]>> {
-        unsafe {
-            let logical_ids = Self::result_column_logical_types(result)?
-                .iter()
-                .map(LogicalTypeHandle::id)
-                .collect::<Vec<_>>();
-            Ok(logical_ids.into_boxed_slice())
-        }
-    }
-
-    unsafe fn result_column_logical_types(result: *mut ffi::duckdb_result) -> Result<Vec<LogicalTypeHandle>> {
-        unsafe {
-            let column_count = ffi::duckdb_column_count(result) as usize;
-            let mut logical_types = Vec::with_capacity(column_count);
-
-            for idx in 0..column_count {
-                let logical_type = Self::try_result_column_logical_type(result, idx)?;
-                Self::reject_unsupported_result_logical_type(idx, &logical_type)?;
-                logical_types.push(logical_type);
-            }
-
-            Ok(logical_types)
-        }
-    }
-
-    fn reject_unsupported_result_logical_type(idx: usize, logical_type: &LogicalTypeHandle) -> Result<()> {
-        if logical_type.contains_type_id(LogicalTypeId::Variant) {
-            return Err(Error::FromSqlConversionFailure(
-                idx,
-                Type::Variant,
-                "decoding Variant columns is not supported".into(),
-            ));
-        }
-
-        Ok(())
-    }
-
-    unsafe fn try_result_column_logical_type(result: *mut ffi::duckdb_result, idx: usize) -> Result<LogicalTypeHandle> {
-        unsafe {
-            let ptr = ffi::duckdb_column_logical_type(result, idx as u64);
-            if ptr.is_null() {
-                return Err(Error::DuckDBFailure(
-                    ffi::Error::new(ffi::DuckDBError),
-                    Some(format!(
-                        "Could not retrieve logical type for result column at index {idx}"
-                    )),
-                ));
-            }
-            Ok(LogicalTypeHandle::new(ptr))
-        }
-    }
-
-    unsafe fn result_to_arrow_schema(
-        &self,
-        result: *mut ffi::duckdb_result,
-        dst: *mut ffi::ArrowSchema,
-    ) -> Result<Box<[LogicalTypeId]>> {
-        unsafe {
-            let column_count = ffi::duckdb_column_count(result) as usize;
-            let logical_types = Self::result_column_logical_types(result)?;
-            let logical_ids = logical_types.iter().map(LogicalTypeHandle::id).collect::<Vec<_>>();
-            let mut names = Vec::with_capacity(column_count);
-
-            for idx in 0..column_count {
-                let name = ffi::duckdb_column_name(result, idx as u64);
-                if name.is_null() {
-                    return Err(Error::DuckDBFailure(
-                        ffi::Error::new(ffi::DuckDBError),
-                        Some(format!("Could not retrieve name for result column at index {idx}")),
-                    ));
-                }
-                names.push(name);
-            }
-
-            let mut type_ptrs = logical_types
-                .iter()
-                .map(|logical_type| logical_type.ptr)
-                .collect::<Vec<_>>();
-            let arrow_options = self.arrow_options_for_result(*result)?;
-            let error_data = ffi::duckdb_to_arrow_schema(
-                arrow_options,
-                type_ptrs.as_mut_ptr(),
-                names.as_mut_ptr(),
-                column_count as u64,
-                dst,
-            );
-            Self::result_from_duckdb_error_data(error_data)?;
-
-            Ok(logical_ids.into_boxed_slice())
-        }
-    }
-
-    unsafe fn next_result_chunk(&self, result: ffi::duckdb_result) -> Result<Option<ffi::duckdb_data_chunk>> {
-        unsafe {
-            let chunk_idx = self.result_chunk_idx.get();
-            if chunk_idx >= ffi::duckdb_result_chunk_count(result) as usize {
-                return Ok(None);
-            }
-            let chunk = ffi::duckdb_result_get_chunk(result, chunk_idx as u64);
-            self.result_chunk_idx.set(chunk_idx + 1);
-            if chunk.is_null() {
-                Err(Self::duckdb_failure(format!(
-                    "Could not fetch result chunk at index {chunk_idx}"
-                )))
-            } else {
-                Ok(Some(chunk))
-            }
-        }
-    }
-
-    unsafe fn data_chunk_to_struct_array(
-        &self,
-        result: ffi::duckdb_result,
-        chunk: ffi::duckdb_data_chunk,
-        schema: SchemaRef,
-    ) -> Result<Option<StructArray>> {
-        unsafe {
-            let mut arrays = FFI_ArrowArray::empty();
-            self.chunk_to_arrow(result, chunk, &mut arrays as *mut _ as *mut ffi::ArrowArray)?;
-
-            if arrays.is_empty() {
-                return Ok(None);
-            }
-
-            let schema = FFI_ArrowSchema::try_from(schema.deref())
-                .map_err(|err| Self::arrow_failure("Could not export Arrow schema", err))?;
-            let array_data = from_ffi(arrays, &schema)
-                .map_err(|err| Self::arrow_failure("Could not import DuckDB Arrow array", err))?;
-            Ok(Some(StructArray::from(array_data)))
-        }
-    }
-
-    unsafe fn chunk_to_arrow(
-        &self,
-        result: ffi::duckdb_result,
-        mut chunk: ffi::duckdb_data_chunk,
-        dst: *mut ffi::ArrowArray,
-    ) -> Result<()> {
-        unsafe {
-            let arrow_options = match self.arrow_options_for_result(result) {
-                Ok(arrow_options) => arrow_options,
-                Err(err) => {
-                    ffi::duckdb_destroy_data_chunk(&mut chunk);
-                    return Err(err);
-                }
-            };
-            let error_data = ffi::duckdb_data_chunk_to_arrow(arrow_options, chunk, dst);
-            ffi::duckdb_destroy_data_chunk(&mut chunk);
-            Self::result_from_duckdb_error_data(error_data)
-        }
-    }
-
-    unsafe fn arrow_options_for_result(&self, mut result: ffi::duckdb_result) -> Result<ffi::duckdb_arrow_options> {
-        unsafe {
-            let arrow_options = self.arrow_options.get();
-            if !arrow_options.is_null() {
-                return Ok(arrow_options);
-            }
-
-            let arrow_options = ffi::duckdb_result_get_arrow_options(&mut result);
-            if arrow_options.is_null() {
-                return Err(Self::duckdb_failure("Could not retrieve Arrow options for result"));
-            }
-            self.arrow_options.set(arrow_options);
-            Ok(arrow_options)
-        }
-    }
-
-    fn destroy_arrow_options(&self) {
-        let mut arrow_options = self.arrow_options.replace(std::ptr::null_mut());
-        if !arrow_options.is_null() {
-            unsafe {
-                ffi::duckdb_destroy_arrow_options(&mut arrow_options);
-            }
-        }
-    }
-
-    unsafe fn result_from_duckdb_error_data(mut error_data: ffi::duckdb_error_data) -> Result<()> {
-        unsafe {
-            if error_data.is_null() {
-                return Ok(());
-            }
-            if !ffi::duckdb_error_data_has_error(error_data) {
-                ffi::duckdb_destroy_error_data(&mut error_data);
-                return Ok(());
-            }
-
-            let msg = {
-                let c_err = ffi::duckdb_error_data_message(error_data);
-                if c_err.is_null() {
-                    None
-                } else {
-                    Some(CStr::from_ptr(c_err).to_string_lossy().to_string())
-                }
-            };
-            ffi::duckdb_destroy_error_data(&mut error_data);
-            Err(Error::DuckDBFailure(ffi::Error::new(ffi::DuckDBError), msg))
-        }
-    }
-
-    #[cfg(feature = "polars")]
-    fn polars_arrow_field(&self, result: ffi::duckdb_result) -> Result<&polars_arrow::datatypes::Field> {
-        if self.polars_arrow_field.get().is_none() {
-            let field = unsafe { self.load_polars_arrow_field(result)? };
-            let _ = self.polars_arrow_field.set(field);
-        }
-        Ok(self
-            .polars_arrow_field
-            .get()
-            .expect("polars Arrow field cache was just initialized"))
-    }
-
-    #[cfg(feature = "polars")]
-    unsafe fn load_polars_arrow_field(&self, result: ffi::duckdb_result) -> Result<polars_arrow::datatypes::Field> {
-        unsafe {
-            let mut result = result;
-            let mut schema = polars_arrow::ffi::ArrowSchema::empty();
-            let _ = self.result_to_arrow_schema(&mut result, &mut schema as *mut _ as *mut ffi::ArrowSchema)?;
-
-            polars_arrow::ffi::import_field_from_c(&schema)
-                .map_err(|err| Self::duckdb_failure(format!("Failed to import Polars Arrow field: {err}")))
-        }
-    }
-
-    fn arrow_failure(context: &str, err: impl std::fmt::Display) -> Error {
-        Self::duckdb_failure(format!("{context}: {err}"))
-    }
-
-    fn duckdb_failure(message: impl Into<String>) -> Error {
-        Error::DuckDBFailure(ffi::Error::new(ffi::DuckDBError), Some(message.into()))
-    }
     #[inline]
     pub fn sql(&self) -> Option<&CStr> {
         panic!("not supported")

--- a/crates/duckdb/src/raw_statement.rs
+++ b/crates/duckdb/src/raw_statement.rs
@@ -9,8 +9,8 @@ use super::{Result, ffi};
 use crate::{
     Error,
     core::{LogicalTypeHandle, LogicalTypeId},
-    error::{duckdb_failure_from_message, result_from_duckdb_result},
-    executed_result::{ExecutedResult, reject_unsupported_result_logical_type},
+    error::result_from_duckdb_result,
+    executed_result::{ExecutedResult, logical_type_from_duckdb_column, reject_unsupported_result_logical_type},
 };
 #[cfg(feature = "polars")]
 use polars_core::utils::arrow as polars_arrow;
@@ -114,12 +114,7 @@ impl RawStatement {
 
         unsafe {
             let ptr = ffi::duckdb_prepared_statement_column_logical_type(self.ptr, idx as u64);
-            if ptr.is_null() {
-                return Err(duckdb_failure_from_message(format!(
-                    "Could not retrieve logical type for result column at index {idx}"
-                )));
-            }
-            Ok(LogicalTypeHandle::new(ptr))
+            logical_type_from_duckdb_column(ptr, idx)
         }
     }
 

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -407,9 +407,24 @@ impl Statement<'_> {
 
     /// Get next batch records in arrow-rs.
     ///
-    /// Returns `Err` if DuckDB cannot convert the next result chunk to Arrow.
+    /// Returns `Err` if DuckDB cannot fetch the next result chunk or convert
+    /// it to Arrow.
     #[inline]
     pub fn step(&self) -> Result<Option<StructArray>> {
+        self.stmt.step()
+    }
+
+    /// Get next batch records in arrow-rs in a streaming way.
+    ///
+    /// The `schema` argument is kept for source compatibility. Decoding uses
+    /// the schema reported by DuckDB after execution.
+    ///
+    /// Returns `Err` if DuckDB cannot fetch the next result chunk or convert
+    /// it to Arrow.
+    #[deprecated(note = "use step(); result decoding now uses DuckDB's executed schema")]
+    #[inline]
+    pub fn stream_step(&self, schema: SchemaRef) -> Result<Option<StructArray>> {
+        let _ = schema;
         self.stmt.step()
     }
 
@@ -1642,10 +1657,9 @@ mod test {
 
         let db = Connection::open_in_memory()?;
         let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int64, true)]));
-        let batches = db
-            .prepare("SELECT i FROM range(3000) AS t(i) ORDER BY i")?
-            .stream_arrow([], schema)?
-            .collect::<Vec<_>>();
+        let mut stmt = db.prepare("SELECT i FROM range(3000) AS t(i) ORDER BY i")?;
+        let mut stream = stmt.stream_arrow([], schema)?;
+        let batches = stream.by_ref().collect::<Vec<_>>();
 
         assert!(batches.len() > 1);
         assert_eq!(3000, batches.iter().map(|batch| batch.num_rows()).sum::<usize>());
@@ -1665,6 +1679,8 @@ mod test {
         assert_eq!(0, values[0]);
         assert_eq!(2048, values[2048]);
         assert_eq!(2999, values[2999]);
+        assert!(stream.next().is_none());
+        assert!(stream.next().is_none());
 
         Ok(())
     }
@@ -1695,6 +1711,7 @@ mod test {
         let mut stream = stmt.stream_arrow([], std::sync::Arc::new(arrow::datatypes::Schema::empty()))?;
 
         assert_eq!(1, stream.get_schema().fields().len());
+        assert!(stream.next().is_none());
         assert!(stream.next().is_none());
         Ok(())
     }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -142,7 +142,11 @@ impl Statement<'_> {
     ///
     /// # Failure
     ///
-    /// Will return `Err` if binding parameters fails.
+    /// Will return `Err` if binding parameters fails, execution fails, or
+    /// DuckDB reports unsupported executed-result metadata.
+    ///
+    /// The returned iterator panics if fetching or Arrow conversion fails
+    /// after execution has started.
     #[inline]
     pub fn stream_arrow<P: Params>(&mut self, params: P, schema: SchemaRef) -> Result<ArrowStream<'_>> {
         // Kept for API compatibility; executed result metadata is authoritative.
@@ -1661,6 +1665,84 @@ mod test {
         assert_eq!(0, values[0]);
         assert_eq!(2048, values[2048]);
         assert_eq!(2999, values[2999]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_streaming_step_surfaces_fetch_error_after_interrupt() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let interrupt = db.interrupt_handle();
+        let mut stmt = db.prepare("SELECT i FROM range(100000000) AS t(i)")?;
+
+        stmt.stmt.execute_streaming()?;
+        assert!(stmt.stmt.step()?.is_some());
+        interrupt.interrupt();
+
+        let err = stmt.stmt.step().unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("Interrupted"),
+            "expected interrupted fetch error, got: {message}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_stream_arrow_empty_result_reaches_clean_eof() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let mut stmt = db.prepare("SELECT 1 AS x WHERE false")?;
+        let mut stream = stmt.stream_arrow([], std::sync::Arc::new(arrow::datatypes::Schema::empty()))?;
+
+        assert_eq!(1, stream.get_schema().fields().len());
+        assert!(stream.next().is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_stream_arrow_then_query_arrow_replaces_result() -> Result<()> {
+        use std::sync::Arc;
+
+        use arrow::{array::Int64Array, datatypes::Schema};
+
+        fn assert_range_batches(batches: &[arrow::record_batch::RecordBatch]) {
+            assert!(batches.len() > 1);
+            assert_eq!(3000, batches.iter().map(|batch| batch.num_rows()).sum::<usize>());
+
+            let values = batches
+                .iter()
+                .flat_map(|batch| {
+                    batch
+                        .column(0)
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .unwrap()
+                        .iter()
+                        .map(Option::unwrap)
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(0, values[0]);
+            assert_eq!(2048, values[2048]);
+            assert_eq!(2999, values[2999]);
+        }
+
+        let db = Connection::open_in_memory()?;
+        let mut stmt = db.prepare("SELECT i FROM range(3000) AS t(i) ORDER BY i")?;
+
+        {
+            let batches = stmt.stream_arrow([], Arc::new(Schema::empty()))?.collect::<Vec<_>>();
+            assert_range_batches(&batches);
+        }
+
+        {
+            let batches = stmt.query_arrow([])?.collect::<Vec<_>>();
+            assert_range_batches(&batches);
+        }
+
+        {
+            let batches = stmt.stream_arrow([], Arc::new(Schema::empty()))?.collect::<Vec<_>>();
+            assert_range_batches(&batches);
+        }
 
         Ok(())
     }

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -125,6 +125,10 @@ impl Statement<'_> {
     /// Execute the prepared statement, returning a handle to the resulting
     /// vector of arrow RecordBatch in streaming way
     ///
+    /// The `schema` argument is kept for source compatibility. Decoding uses
+    /// the schema reported by DuckDB after execution, so callers do not need to
+    /// pass a matching schema.
+    ///
     /// ## Example
     ///
     /// ```rust,no_run
@@ -141,9 +145,11 @@ impl Statement<'_> {
     /// Will return `Err` if binding parameters fails.
     #[inline]
     pub fn stream_arrow<P: Params>(&mut self, params: P, schema: SchemaRef) -> Result<ArrowStream<'_>> {
+        // Kept for API compatibility; executed result metadata is authoritative.
+        let _ = schema;
         params.__bind_in(self)?;
         self.stmt.execute_streaming()?;
-        Ok(ArrowStream::new(self, schema))
+        Ok(ArrowStream::new(self))
     }
 
     /// Execute the prepared statement, returning a handle to the resulting
@@ -401,14 +407,6 @@ impl Statement<'_> {
     #[inline]
     pub fn step(&self) -> Result<Option<StructArray>> {
         self.stmt.step()
-    }
-
-    /// Get next batch records in arrow-rs in a streaming way.
-    ///
-    /// Returns `Err` if DuckDB cannot convert the next result chunk to Arrow.
-    #[inline]
-    pub fn stream_step(&self, schema: SchemaRef) -> Result<Option<StructArray>> {
-        self.stmt.streaming_step(schema)
     }
 
     #[cfg(feature = "polars")]
@@ -1156,7 +1154,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
+    #[should_panic(expected = "The statement was not executed yet")]
     fn test_unexecuted_schema_panics() {
         let db = Connection::open_in_memory().unwrap();
         let sql = "BEGIN;
@@ -1597,7 +1595,9 @@ mod test {
     }
 
     #[test]
-    fn test_step_after_streaming_materialized_result_returns_none() -> Result<()> {
+    fn test_step_after_streaming_materialized_result_fetches_data() -> Result<()> {
+        use arrow::array::Int32Array;
+
         let db = Connection::open_in_memory()?;
         db.execute_batch(
             "CREATE TABLE test_data(id INTEGER);
@@ -1608,7 +1608,9 @@ mod test {
         let mut stmt = db.prepare("CALL test_func()")?;
         stmt.stmt.execute_streaming()?;
 
-        assert!(stmt.stmt.step()?.is_none());
+        let batch = stmt.stmt.step()?.expect("expected result batch");
+        let values = batch.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(1, values.value(0));
         Ok(())
     }
 


### PR DESCRIPTION
Worthwhile refactoring after landing #800 and #801.

- Move DuckDB result lifetime, Arrow options, schema/logical metadata, chunk decoding, and column-name caching into RAII `ExecutedResult`.
- Use the executed result's cached schema/logical metadata for both materialized and streaming Arrow paths while keeping the existing `stream_arrow` API shape for compatibility.
- Cache DuckDB's exported Arrow schema for chunk decoding instead of round-tripping through an Arrow `Schema`.
- Add focused coverage for Polars empty-result handling and DuckDB result error ownership.