### PR TITLE
Add modern Arrow API examples and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following [examples](crates/duckdb/examples) demonstrate various features an
 
 - **basic** - Basic usage including creating tables, inserting data, and querying with and without Arrow.
 - **appender** - Bulk data insertion using the appender API with transactions.
+- **arrow_vtab** - Querying an in-memory Arrow RecordBatch from DuckDB SQL (requires the `vtab-arrow` feature).
 - **parquet** - Reading Parquet files directly using DuckDB's Parquet extension.
 - **vscalar** - Defining and registering a custom scalar function (requires the `vscalar` feature).
 - **vtab** - Defining a custom table function returning primitive, LIST, and STRUCT columns (requires the `vtab` feature).

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -102,3 +102,7 @@ required-features = ["vscalar"]
 [[example]]
 name = "vtab"
 required-features = ["vtab"]
+
+[[example]]
+name = "arrow_vtab"
+required-features = ["vtab-arrow"]

--- a/crates/duckdb/examples/arrow_vtab.rs
+++ b/crates/duckdb/examples/arrow_vtab.rs
@@ -1,0 +1,56 @@
+// Query an in-memory Arrow RecordBatch from DuckDB SQL.
+//
+// Run with: cargo run --example arrow_vtab --features bundled,vtab-arrow
+
+use std::{error::Error, sync::Arc};
+
+use duckdb::{
+    Connection,
+    arrow::{
+        array::{ArrayRef, BooleanArray, Int32Array, StringArray},
+        datatypes::{DataType, Field, Schema},
+        record_batch::RecordBatch,
+        util::pretty::print_batches,
+    },
+    vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params},
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let conn = Connection::open_in_memory()?;
+    conn.register_table_function::<ArrowVTab>("arrow")?;
+
+    let params = arrow_recordbatch_to_query_params(cities_batch()?);
+    let batches: Vec<RecordBatch> = conn
+        .prepare(
+            "
+            SELECT city, population
+            FROM arrow(?, ?)
+            WHERE coastal AND population >= 500000
+            ORDER BY population DESC
+            ",
+        )?
+        .query_arrow(params)?
+        .collect();
+
+    print_batches(&batches)?;
+    Ok(())
+}
+
+fn cities_batch() -> Result<RecordBatch, Box<dyn Error>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("city", DataType::Utf8, false),
+        Field::new("population", DataType::Int32, false),
+        Field::new("coastal", DataType::Boolean, false),
+    ]));
+
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3, 4])) as ArrayRef,
+            Arc::new(StringArray::from(vec!["Amsterdam", "Berlin", "Lisbon", "Madrid"])) as ArrayRef,
+            Arc::new(Int32Array::from(vec![921_402, 3_755_251, 567_131, 3_332_035])) as ArrayRef,
+            Arc::new(BooleanArray::from(vec![true, false, true, false])) as ArrayRef,
+        ],
+    )?)
+}

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -1317,6 +1317,42 @@ mod test {
         .expect("failed to create record batch")
     }
 
+    #[test]
+    fn test_query_record_batch_with_arrow_vtab() -> Result<(), Box<dyn Error>> {
+        let db = Connection::open_in_memory()?;
+        db.register_table_function::<ArrowVTab>("arrow")?;
+
+        let params = arrow_recordbatch_to_query_params(example_record_batch());
+        let batches: Vec<RecordBatch> = db
+            .prepare(
+                "
+                SELECT id, upper(name) AS name, is_odd
+                FROM arrow(?, ?)
+                WHERE is_odd
+                ORDER BY id
+                ",
+            )?
+            .query_arrow(params)?
+            .collect();
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 2);
+
+        let ids = batch.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let names = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        let predicates = batch.column(2).as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        assert_eq!(ids.value(0), 1);
+        assert_eq!(ids.value(1), 3);
+        assert_eq!(names.value(0), "APPLE");
+        assert_eq!(names.value(1), "CHERRY");
+        assert!(predicates.value(0));
+        assert!(predicates.value(1));
+
+        Ok(())
+    }
+
     // Mark rows straddling vector-size slice boundaries as NULL so bitmap offsets
     // are exercised when the source batch is sliced.
     fn boundary_null(i: usize, vector_size: usize) -> bool {

--- a/crates/libduckdb-sys/src/lib.rs
+++ b/crates/libduckdb-sys/src/lib.rs
@@ -35,12 +35,13 @@ mod tests {
         mem,
         os::raw::c_char,
         ptr,
+        sync::Arc,
     };
 
     use arrow::{
-        array::{Array, Int32Array, StructArray},
-        datatypes::DataType,
-        ffi::{FFI_ArrowArray, FFI_ArrowSchema, from_ffi},
+        array::{Array, ArrayRef, Int32Array, StructArray},
+        datatypes::{DataType, Field},
+        ffi::{FFI_ArrowArray, FFI_ArrowSchema, from_ffi, to_ffi},
     };
 
     unsafe fn print_int_result(result: &mut duckdb_result) {
@@ -60,60 +61,264 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_query_arrow() {
-        unsafe {
-            // open db
+    struct TestDb {
+        db: duckdb_database,
+        con: duckdb_connection,
+    }
+
+    impl TestDb {
+        unsafe fn open() -> Self {
             let mut db: duckdb_database = ptr::null_mut();
             let mut con: duckdb_connection = ptr::null_mut();
-            if duckdb_open(ptr::null_mut(), &mut db) != duckdb_state_DuckDBSuccess {
-                panic!("duckdb_open error")
+            unsafe {
+                if duckdb_open(ptr::null_mut(), &mut db) != duckdb_state_DuckDBSuccess {
+                    panic!("duckdb_open error")
+                }
+                if duckdb_connect(db, &mut con) != duckdb_state_DuckDBSuccess {
+                    duckdb_close(&mut db);
+                    panic!("duckdb_connect error")
+                }
             }
-            if duckdb_connect(db, &mut con) != duckdb_state_DuckDBSuccess {
-                panic!("duckdb_connect error")
+            Self { db, con }
+        }
+
+        fn connection(&self) -> duckdb_connection {
+            self.con
+        }
+
+        unsafe fn query_result(&self, sql: &str) -> duckdb_result {
+            unsafe {
+                let sql = CString::new(sql).unwrap();
+                let mut result: duckdb_result = mem::zeroed();
+                if duckdb_query(self.con, sql.as_ptr() as *const c_char, &mut result) != duckdb_state_DuckDBSuccess {
+                    let message = result_error_message(&mut result).unwrap_or_else(|| "unknown error".to_string());
+                    duckdb_destroy_result(&mut result);
+                    panic!("DuckDB query failed: {message}");
+                }
+                result
             }
-            // create a table
-            let sql = CString::new("CREATE TABLE integers(i INTEGER, j INTEGER);").unwrap();
-            if duckdb_query(con, sql.as_ptr() as *const c_char, ptr::null_mut()) != duckdb_state_DuckDBSuccess {
-                panic!("CREATE TABLE error")
+        }
+
+        unsafe fn create_integers_table(&self) {
+            unsafe {
+                let mut create_result = self.query_result("CREATE TABLE integers(i INTEGER, j INTEGER);");
+                duckdb_destroy_result(&mut create_result);
+
+                let mut insert_result = self.query_result("INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL);");
+                assert_eq!(duckdb_rows_changed(&mut insert_result), 3);
+                duckdb_destroy_result(&mut insert_result);
+            }
+        }
+    }
+
+    impl Drop for TestDb {
+        fn drop(&mut self) {
+            unsafe {
+                duckdb_disconnect(&mut self.con);
+                duckdb_close(&mut self.db);
+            }
+        }
+    }
+
+    unsafe fn result_error_message(result: &mut duckdb_result) -> Option<String> {
+        unsafe {
+            let message = duckdb_result_error(result);
+            if message.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(message).to_string_lossy().into_owned())
+            }
+        }
+    }
+
+    unsafe fn assert_no_arrow_error(error_data: duckdb_error_data) {
+        unsafe {
+            if let Some((error_type, message)) = take_arrow_error(error_data) {
+                panic!("DuckDB Arrow C Data Interface conversion failed with type {error_type}: {message}");
+            }
+        }
+    }
+
+    unsafe fn take_arrow_error(mut error_data: duckdb_error_data) -> Option<(duckdb_error_type, String)> {
+        unsafe {
+            if error_data.is_null() {
+                return None;
             }
 
-            // insert three rows into the table
-            let sql = CString::new("INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL);").unwrap();
-            let mut result: duckdb_arrow = ptr::null_mut();
-            if duckdb_query_arrow(con, sql.as_ptr() as *const c_char, &mut result) != duckdb_state_DuckDBSuccess {
-                panic!("INSERT error")
+            if !duckdb_error_data_has_error(error_data) {
+                duckdb_destroy_error_data(&mut error_data);
+                return None;
             }
-            assert_eq!(duckdb_arrow_rows_changed(result), 3);
-            duckdb_destroy_arrow(&mut result);
 
-            // query rows again
-            let mut result: duckdb_arrow = ptr::null_mut();
-            let sql = CString::new("select i, j from integers order by i desc").unwrap();
-            if duckdb_query_arrow(con, sql.as_ptr() as *const c_char, &mut result) != duckdb_state_DuckDBSuccess {
-                panic!("SELECT error")
-            }
-            assert_eq!(duckdb_arrow_row_count(result), 3);
-            assert_eq!(duckdb_arrow_column_count(result), 2);
+            let error_type = duckdb_error_data_error_type(error_data);
+            let message = duckdb_error_data_message(error_data);
+            let message = if message.is_null() {
+                "<no error message>".to_string()
+            } else {
+                CStr::from_ptr(message).to_string_lossy().into_owned()
+            };
+            duckdb_destroy_error_data(&mut error_data);
+            Some((error_type, message))
+        }
+    }
 
-            let mut arrays = FFI_ArrowArray::empty();
+    #[test]
+    fn test_arrow_c_data_interface_to_data_chunk() {
+        unsafe {
+            let db = TestDb::open();
+            let con = db.connection();
+            let vector_size = duckdb_vector_size() as usize;
+            let row_count = vector_size + 3;
+            let ids: Vec<i32> = (0..row_count as i32).collect();
+            let scores: Vec<Option<i32>> = (0..row_count)
+                .map(|i| if i == vector_size { None } else { Some(i as i32 * 2) })
+                .collect();
+
+            let struct_array = StructArray::from(vec![
+                (
+                    Arc::new(Field::new("id", DataType::Int32, false)),
+                    Arc::new(Int32Array::from(ids)) as ArrayRef,
+                ),
+                (
+                    Arc::new(Field::new("score", DataType::Int32, true)),
+                    Arc::new(Int32Array::from(scores)) as ArrayRef,
+                ),
+            ]);
+            let (mut arrow_array, mut arrow_schema) = to_ffi(&struct_array.to_data()).expect("export Arrow array");
+
+            let mut converted_schema: duckdb_arrow_converted_schema = ptr::null_mut();
+            assert_no_arrow_error(duckdb_schema_from_arrow(
+                con,
+                &mut arrow_schema as *mut FFI_ArrowSchema as *mut ArrowSchema,
+                &mut converted_schema,
+            ));
+            assert!(!converted_schema.is_null());
+
+            let mut chunk: duckdb_data_chunk = ptr::null_mut();
+            assert_no_arrow_error(duckdb_data_chunk_from_arrow(
+                con,
+                &mut arrow_array as *mut FFI_ArrowArray as *mut ArrowArray,
+                converted_schema,
+                &mut chunk,
+            ));
+            assert!(!chunk.is_null());
+
+            assert_eq!(duckdb_data_chunk_get_column_count(chunk), 2);
+            assert_eq!(duckdb_data_chunk_get_size(chunk), row_count as idx_t);
+
+            let id_vector = duckdb_data_chunk_get_vector(chunk, 0);
+            let id_data = duckdb_vector_get_data(id_vector) as *const i32;
+            assert_eq!(*id_data, 0);
+            assert_eq!(*id_data.add(vector_size), vector_size as i32);
+            assert_eq!(*id_data.add(row_count - 1), row_count as i32 - 1);
+
+            let score_vector = duckdb_data_chunk_get_vector(chunk, 1);
+            let score_data = duckdb_vector_get_data(score_vector) as *const i32;
+            assert_eq!(*score_data, 0);
+            assert_eq!(*score_data.add(row_count - 1), (row_count as i32 - 1) * 2);
+
+            let score_validity = duckdb_vector_get_validity(score_vector);
+            assert!(!score_validity.is_null());
+            assert!(duckdb_validity_row_is_valid(score_validity, 0));
+            assert!(!duckdb_validity_row_is_valid(score_validity, vector_size as idx_t));
+            assert!(duckdb_validity_row_is_valid(score_validity, vector_size as idx_t + 1));
+
+            duckdb_destroy_data_chunk(&mut chunk);
+            duckdb_destroy_arrow_converted_schema(&mut converted_schema);
+        }
+    }
+
+    unsafe extern "C" fn noop_arrow_schema_release(_schema: *mut ArrowSchema) {}
+
+    #[test]
+    fn test_arrow_c_data_interface_reports_schema_errors() {
+        unsafe {
+            let db = TestDb::open();
+            let con = db.connection();
+
+            let root_format = CString::new("+s").unwrap();
+            let child_format = CString::new("?").unwrap();
+            let child_name = CString::new("unsupported").unwrap();
+            let mut child_schema = ArrowSchema::empty();
+            child_schema.format = child_format.as_ptr();
+            child_schema.name = child_name.as_ptr();
+            child_schema.release = Some(noop_arrow_schema_release);
+
+            let mut child_schema_ptr = &mut child_schema as *mut ArrowSchema;
+            let mut root_schema = ArrowSchema::empty();
+            root_schema.format = root_format.as_ptr();
+            root_schema.n_children = 1;
+            root_schema.children = &mut child_schema_ptr;
+            root_schema.release = Some(noop_arrow_schema_release);
+
+            let mut converted_schema: duckdb_arrow_converted_schema = ptr::null_mut();
+            let (error_type, message) =
+                take_arrow_error(duckdb_schema_from_arrow(con, &mut root_schema, &mut converted_schema))
+                    .expect("expected DuckDB Arrow C Data Interface conversion to fail");
+            assert_eq!(error_type, duckdb_error_type_DUCKDB_ERROR_INVALID_INPUT);
+            assert!(message.contains("Unsupported Internal Arrow Type"));
+            assert!(converted_schema.is_null());
+        }
+    }
+
+    #[test]
+    fn test_result_data_chunk_to_arrow() {
+        unsafe {
+            let db = TestDb::open();
+            db.create_integers_table();
+
+            // Query rows and export the resulting data chunks to Arrow.
+            let mut result = db.query_result("select i, j from integers order by i desc");
+            assert_eq!(duckdb_column_count(&mut result), 2);
+
             let mut schema = FFI_ArrowSchema::empty();
-            if duckdb_query_arrow_schema(
-                result,
-                &mut std::ptr::addr_of_mut!(schema) as *mut _ as *mut duckdb_arrow_schema,
-            ) != duckdb_state_DuckDBSuccess
-            {
-                panic!("SELECT error")
+            let mut arrow_options = duckdb_result_get_arrow_options(&mut result);
+            assert!(!arrow_options.is_null());
+
+            let mut column_types = Vec::new();
+            let mut column_names = Vec::new();
+            for column in 0..duckdb_column_count(&mut result) {
+                let logical_type = duckdb_column_logical_type(&mut result, column);
+                assert!(!logical_type.is_null());
+                column_types.push(logical_type);
+
+                let name = duckdb_column_name(&mut result, column);
+                assert!(!name.is_null());
+                column_names.push(name);
             }
-            if duckdb_query_arrow_array(
-                result,
-                &mut std::ptr::addr_of_mut!(arrays) as *mut _ as *mut duckdb_arrow_array,
-            ) != duckdb_state_DuckDBSuccess
-            {
-                panic!("SELECT error")
+
+            assert_no_arrow_error(duckdb_to_arrow_schema(
+                arrow_options,
+                column_types.as_mut_ptr(),
+                column_names.as_mut_ptr(),
+                column_types.len() as idx_t,
+                &mut schema as *mut FFI_ArrowSchema as *mut ArrowSchema,
+            ));
+
+            let mut chunks = Vec::new();
+            loop {
+                let mut chunk = duckdb_fetch_chunk(result);
+                if chunk.is_null() {
+                    break;
+                }
+
+                let mut arrays = FFI_ArrowArray::empty();
+                assert_no_arrow_error(duckdb_data_chunk_to_arrow(
+                    arrow_options,
+                    chunk,
+                    &mut arrays as *mut FFI_ArrowArray as *mut ArrowArray,
+                ));
+                duckdb_destroy_data_chunk(&mut chunk);
+
+                let array_data = from_ffi(arrays, &schema).expect("ok");
+                chunks.push(StructArray::from(array_data));
             }
-            let array_data = from_ffi(arrays, &schema).expect("ok");
-            let struct_array = StructArray::from(array_data);
+            if let Some(message) = result_error_message(&mut result) {
+                panic!("DuckDB result error while fetching chunks: {message}");
+            }
+
+            assert_eq!(chunks.len(), 1);
+            let struct_array = &chunks[0];
             assert_eq!(struct_array.len(), 3);
             assert_eq!(struct_array.columns().len(), 2);
             assert_eq!(struct_array.column(0).data_type(), &DataType::Int32);
@@ -127,48 +332,23 @@ mod tests {
             assert_eq!(arr_j.value(1), 6);
             assert_eq!(arr_j.value(2), 4);
 
-            let mut arrays: duckdb_arrow_array = ptr::null_mut();
-            if duckdb_query_arrow_array(result, &mut arrays) != duckdb_state_DuckDBSuccess {
-                panic!("SELECT error")
+            for logical_type in &mut column_types {
+                duckdb_destroy_logical_type(logical_type);
             }
-            assert!(arrays.is_null());
-            duckdb_destroy_arrow(&mut result);
-            duckdb_disconnect(&mut con);
-            duckdb_close(&mut db);
+            duckdb_destroy_arrow_options(&mut arrow_options);
+            duckdb_destroy_result(&mut result);
         }
     }
 
     #[test]
     fn basic_api_usage() {
         unsafe {
-            // open db
-            let mut db: duckdb_database = ptr::null_mut();
-            let mut con: duckdb_connection = ptr::null_mut();
-            if duckdb_open(ptr::null_mut(), &mut db) != duckdb_state_DuckDBSuccess {
-                panic!("duckdb_open error")
-            }
-            if duckdb_connect(db, &mut con) != duckdb_state_DuckDBSuccess {
-                panic!("duckdb_connect error")
-            }
-            // create a table
-            let sql = CString::new("CREATE TABLE integers(i INTEGER, j INTEGER);").unwrap();
-            if duckdb_query(con, sql.as_ptr() as *const c_char, ptr::null_mut()) != duckdb_state_DuckDBSuccess {
-                panic!("CREATE TABLE error")
-            }
-            // insert three rows into the table
-            let sql = CString::new("INSERT INTO integers VALUES (3, 4), (5, 6), (7, NULL);").unwrap();
-            if duckdb_query(con, sql.as_ptr() as *const c_char, ptr::null_mut()) != duckdb_state_DuckDBSuccess {
-                panic!("INSERT error")
-            }
-            // query rows again
-            let mut result: duckdb_result = mem::zeroed();
-            let sql = CString::new("select * from integers").unwrap();
-            if duckdb_query(con, sql.as_ptr() as *const c_char, &mut result) != duckdb_state_DuckDBSuccess {
-                panic!(
-                    "SELECT error: {}",
-                    CStr::from_ptr(duckdb_result_error(&mut result)).to_string_lossy()
-                )
-            }
+            let db = TestDb::open();
+            let con = db.connection();
+            db.create_integers_table();
+
+            // query rows
+            let mut result = db.query_result("select * from integers");
             assert_eq!(duckdb_row_count(&mut result), 3);
             assert_eq!(duckdb_column_count(&mut result), 2);
             print_int_result(&mut result);
@@ -203,10 +383,6 @@ mod tests {
             print_int_result(&mut result);
             duckdb_destroy_result(&mut result);
             duckdb_destroy_prepare(&mut stmt);
-
-            // clean up
-            duckdb_disconnect(&mut con);
-            duckdb_close(&mut db);
         }
     }
 }

--- a/crates/libduckdb-sys/wrapper_ext.h
+++ b/crates/libduckdb-sys/wrapper_ext.h
@@ -1,6 +1,6 @@
 // FIXME: remove this once C EXTENSION API is stable (expected for DuckDB v1.2.0 release)
 #define DUCKDB_EXTENSION_API_VERSION_DEV 1
 
-// We need to allow unstable API for now to get the deprecated arrow functions
+// Matches build.rs bindgen setup for currently ungated unstable extension API symbols.
 #define DUCKDB_EXTENSION_API_VERSION_UNSTABLE
 #include "duckdb/duckdb_extension.h"


### PR DESCRIPTION
- Add an `ArrowVTab` example showing Arrow `RecordBatch` data queried from DuckDB.
- Add `duckdb` test coverage for querying Arrow-backed virtual tables.
- Add `libduckdb-sys` coverage for Arrow C Data Interface to/from data chunk conversion APIs.
- Replace deprecated DuckDB Arrow result API usage in `libduckdb-sys` tests with current data chunk to Arrow conversion APIs.

The only deprecated Arrow symbols left are in generated bindings and vendored DuckDB sources.

Closes #79