### PR TITLE
Support narrow Arrow decimals

### DIFF
--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -286,6 +286,12 @@ pub struct Row<'stmt> {
     current_row: usize,
 }
 
+fn decimal_value_ref(width: u8, scale: i8, value: i128) -> ValueRef<'static> {
+    let scale = Decimal::validate_signed_scale(width, scale)
+        .unwrap_or_else(|err| panic!("Invalid Arrow decimal metadata for width {width} scale {scale}: {err}"));
+    ValueRef::Decimal(Decimal::from_chunk(width, scale, value))
+}
+
 #[allow(clippy::needless_lifetimes)]
 impl<'stmt> Row<'stmt> {
     /// Get the value of a particular column of the result row.
@@ -382,7 +388,7 @@ impl<'stmt> Row<'stmt> {
                 Some(LogicalTypeId::UHugeint) => ValueRef::UHugeInt(value as u128),
                 Some(LogicalTypeId::Decimal) => {
                     if let DataType::Decimal128(width, 0) = column.data_type() {
-                        ValueRef::Decimal(Decimal::from_chunk(*width, 0, value))
+                        decimal_value_ref(*width, 0, value)
                     } else {
                         ValueRef::HugeInt(value)
                     }
@@ -468,14 +474,23 @@ impl<'stmt> Row<'stmt> {
                 let array = column.as_any().downcast_ref::<array::Float64Array>().unwrap();
                 ValueRef::Double(array.value(row))
             }
+            DataType::Decimal32(width, scale) => {
+                let array = column.as_any().downcast_ref::<array::Decimal32Array>().unwrap();
+                let value = i128::from(array.value(row));
+                decimal_value_ref(*width, *scale, value)
+            }
+            DataType::Decimal64(width, scale) => {
+                let array = column.as_any().downcast_ref::<array::Decimal64Array>().unwrap();
+                let value = i128::from(array.value(row));
+                decimal_value_ref(*width, *scale, value)
+            }
             DataType::Decimal128(width, scale) => {
                 let array = column.as_any().downcast_ref::<array::Decimal128Array>().unwrap();
                 let value = array.value(row);
-                let scale = u8::try_from(*scale).expect("Arrow decimal scale must be non-negative");
-                if scale == 0 && *width == Decimal::MAX_WIDTH {
+                if *scale == 0 && *width == Decimal::MAX_WIDTH {
                     ValueRef::HugeInt(value)
                 } else {
-                    ValueRef::Decimal(Decimal::from_chunk(*width, scale, value))
+                    decimal_value_ref(*width, *scale, value)
                 }
             }
             DataType::Timestamp(unit, _) if *unit == TimeUnit::Second => {
@@ -953,6 +968,33 @@ mod tests {
             row.get::<_, Decimal>(0)
         })?;
         assert_eq!(decimal, Decimal::new(38, 2, WIDE_DECIMAL_MANTISSA)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn narrow_arrow_decimal_columns_use_native_decimal_carrier() -> Result<()> {
+        use arrow::datatypes::DataType;
+
+        let db = Connection::open_in_memory()?;
+        db.execute_batch("SET arrow_output_version = '1.5'")?;
+
+        {
+            let mut stmt = db.prepare("SELECT 1.23::DECIMAL(9,2) AS d32, 1.23::DECIMAL(18,2) AS d64")?;
+            let batch = stmt.query_arrow([])?.next().expect("no record batch");
+            assert_eq!(batch.column(0).data_type(), &DataType::Decimal32(9, 2));
+            assert_eq!(batch.column(1).data_type(), &DataType::Decimal64(18, 2));
+        }
+
+        let value = db.query_row("SELECT 1.23::DECIMAL(9,2)", [], |row| {
+            row.get_ref(0).map(|value| value.to_owned())
+        })?;
+        assert_eq!(value, Value::Decimal(Decimal::new(9, 2, 123)?));
+
+        let value = db.query_row("SELECT 1.23::DECIMAL(18,2)", [], |row| {
+            row.get_ref(0).map(|value| value.to_owned())
+        })?;
+        assert_eq!(value, Value::Decimal(Decimal::new(18, 2, 123)?));
 
         Ok(())
     }

--- a/crates/duckdb/src/types/decimal.rs
+++ b/crates/duckdb/src/types/decimal.rs
@@ -106,6 +106,12 @@ impl Decimal {
         Ok(Self { width, scale, value })
     }
 
+    pub(crate) fn validate_signed_scale(width: u8, scale: i8) -> std::result::Result<u8, String> {
+        let scale = u8::try_from(scale).map_err(|_| format!("negative decimal scale is not supported: {scale}"))?;
+        Self::new(width, scale, 0).map_err(|err| err.to_string())?;
+        Ok(scale)
+    }
+
     /// Builds a decimal value from trusted DuckDB output.
     ///
     /// The caller must ensure `width`, `scale`, and `value` are a valid DuckDB
@@ -427,6 +433,19 @@ mod test {
         assert_eq!(
             Decimal::new(38, 0, i128::MAX).unwrap_err(),
             DecimalError::ValueExceedsWidth { digits: 39, width: 38 }
+        );
+    }
+
+    #[test]
+    fn decimal_signed_scale_helper_validates_arrow_metadata() {
+        assert_eq!(Decimal::validate_signed_scale(9, 2).unwrap(), 2);
+        assert_eq!(
+            Decimal::validate_signed_scale(9, -1).unwrap_err(),
+            "negative decimal scale is not supported: -1"
+        );
+        assert_eq!(
+            Decimal::validate_signed_scale(9, 10).unwrap_err(),
+            "decimal scale 10 exceeds width 9"
         );
     }
 

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -225,8 +225,11 @@ impl From<&DataType> for Type {
             }
             DataType::LargeList(inner) => Self::List(Box::new(Self::from(inner.data_type()))),
             DataType::Union(_, _) => Self::Union,
-            DataType::Decimal128(..) => Self::Decimal,
-            DataType::Decimal256(..) => Self::Decimal,
+            // Type is a broad value category: Decimal256 is decimal-shaped
+            // metadata, even though DuckDB value paths only carry widths <= 38.
+            DataType::Decimal32(..) | DataType::Decimal64(..) | DataType::Decimal128(..) | DataType::Decimal256(..) => {
+                Self::Decimal
+            }
             DataType::Map(field, ..) => {
                 let data_type = field.data_type();
                 match data_type {
@@ -287,8 +290,9 @@ impl fmt::Display for Type {
 
 #[cfg(test)]
 mod test {
-    use super::Value;
+    use super::{Type, Value};
     use crate::{Connection, Result};
+    use arrow::datatypes::DataType;
 
     fn checked_memory_handle() -> Result<Connection> {
         let db = Connection::open_in_memory()?;
@@ -381,6 +385,14 @@ mod test {
 
         assert_eq!(10i64, db.query_row::<i64, _, _>("SELECT i FROM foo", [], |r| r.get(0))?);
         Ok(())
+    }
+
+    #[test]
+    fn arrow_decimal_types_match_duckdb_decimal_classification() {
+        assert_eq!(Type::from(&DataType::Decimal32(9, 2)), Type::Decimal);
+        assert_eq!(Type::from(&DataType::Decimal64(18, 2)), Type::Decimal);
+        assert_eq!(Type::from(&DataType::Decimal128(38, 2)), Type::Decimal);
+        assert_eq!(Type::from(&DataType::Decimal256(76, 10)), Type::Decimal);
     }
 
     #[test]

--- a/crates/duckdb/src/vtab/arrow.rs
+++ b/crates/duckdb/src/vtab/arrow.rs
@@ -8,12 +8,11 @@ use crate::{
 
 use arrow::{
     array::{
-        Array, ArrayData, AsArray, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Decimal128Array,
-        FixedSizeBinaryArray, FixedSizeListArray, GenericBinaryBuilder, GenericListArray, GenericStringArray,
-        IntervalMonthDayNanoArray, LargeBinaryArray, LargeStringArray, OffsetSizeTrait, PrimitiveArray, StringArray,
-        StringViewArray, StructArray, TimestampMicrosecondArray, TimestampNanosecondArray, as_boolean_array,
-        as_generic_binary_array, as_large_list_array, as_list_array, as_map_array, as_primitive_array, as_string_array,
-        as_struct_array,
+        Array, ArrayData, AsArray, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, FixedSizeBinaryArray,
+        FixedSizeListArray, GenericBinaryBuilder, GenericListArray, GenericStringArray, IntervalMonthDayNanoArray,
+        LargeBinaryArray, LargeStringArray, OffsetSizeTrait, PrimitiveArray, StringArray, StringViewArray, StructArray,
+        TimestampMicrosecondArray, TimestampNanosecondArray, as_boolean_array, as_generic_binary_array,
+        as_large_list_array, as_list_array, as_map_array, as_primitive_array, as_string_array, as_struct_array,
     },
     buffer::{BooleanBuffer, NullBuffer},
     compute::cast,
@@ -258,7 +257,9 @@ pub fn to_duckdb_type_id(data_type: &DataType) -> Result<LogicalTypeId, Box<dyn 
         DataType::Struct(_) => Struct,
         DataType::Union(_, _) => Union,
         // DataType::Dictionary(_, _) => todo!(),
-        DataType::Decimal128(_, _) => Decimal,
+        DataType::Decimal32(_, _) | DataType::Decimal64(_, _) | DataType::Decimal128(_, _) => Decimal,
+        // Decimal256 binds as DOUBLE, but primitive_array_to_vector rejects it
+        // at execution because ArrowVTab has no Decimal256 write path.
         DataType::Decimal256(_, _) => Double,
         DataType::Map(_, _) => Map,
         _ => {
@@ -302,17 +303,9 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalTypeHandle,
             &to_duckdb_logical_type(child.data_type())?,
             *array_size as u64,
         )),
-        DataType::Decimal128(width, scale) => {
-            if *scale < 0 {
-                return Err(
-                    format!("Unsupported data type: {data_type}, negative decimal scale is not supported").into(),
-                );
-            }
-            let scale = (*scale).try_into().unwrap();
-            Decimal::new(*width, scale, 0)
-                .map_err(|err| format!("Unsupported data type: {data_type}, invalid decimal type: {err}"))?;
-            Ok(LogicalTypeHandle::decimal(*width, scale))
-        }
+        DataType::Decimal32(width, scale) => to_duckdb_decimal_logical_type::<Decimal32Type>(*width, *scale),
+        DataType::Decimal64(width, scale) => to_duckdb_decimal_logical_type::<Decimal64Type>(*width, *scale),
+        DataType::Decimal128(width, scale) => to_duckdb_decimal_logical_type::<Decimal128Type>(*width, *scale),
         DataType::Map(field, _) => arrow_map_to_duckdb_logical_type(field),
         DataType::Boolean
         | DataType::Utf8
@@ -328,6 +321,30 @@ pub fn to_duckdb_logical_type(data_type: &DataType) -> Result<LogicalTypeHandle,
         )
         .into()),
     }
+}
+
+fn to_duckdb_decimal_logical_type<T>(width: u8, scale: i8) -> Result<LogicalTypeHandle, Box<dyn std::error::Error>>
+where
+    T: DecimalType,
+{
+    let scale = validate_arrow_decimal_metadata::<T>(width, scale)?;
+    Ok(LogicalTypeHandle::decimal(width, scale))
+}
+
+fn validate_arrow_decimal_metadata<T>(width: u8, scale: i8) -> Result<u8, Box<dyn std::error::Error>>
+where
+    T: DecimalType,
+{
+    let data_type = T::TYPE_CONSTRUCTOR(width, scale);
+    if width > T::MAX_PRECISION {
+        return Err(format!(
+            "Unsupported data type: {data_type}, decimal width {width} exceeds {}",
+            T::MAX_PRECISION
+        )
+        .into());
+    }
+    Decimal::validate_signed_scale(width, scale)
+        .map_err(|err| format!("Unsupported data type: {data_type}, invalid decimal type: {err}").into())
 }
 
 fn arrow_map_to_duckdb_logical_type(field: &FieldRef) -> Result<LogicalTypeHandle, Box<dyn std::error::Error>> {
@@ -842,8 +859,14 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut FlatVector<'_>) -> Res
         DataType::Float64 => {
             primitive_array_to_flat_vector::<Float64Type>(as_primitive_array(array), out);
         }
+        DataType::Decimal32(width, scale) => {
+            decimal_array_to_vector::<Decimal32Type>(as_primitive_array(array), out, *width, *scale)?;
+        }
+        DataType::Decimal64(width, scale) => {
+            decimal_array_to_vector::<Decimal64Type>(as_primitive_array(array), out, *width, *scale)?;
+        }
         DataType::Decimal128(width, scale) => {
-            decimal_array_to_vector(as_primitive_array(array), out, *width, *scale)?;
+            decimal_array_to_vector::<Decimal128Type>(as_primitive_array(array), out, *width, *scale)?;
         }
         DataType::Interval(_) | DataType::Duration(_) => {
             let array = IntervalMonthDayNanoArray::from(
@@ -890,20 +913,20 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut FlatVector<'_>) -> Res
     Ok(())
 }
 
-/// Convert Arrow [Decimal128Array] to a duckdb vector.
-fn decimal_array_to_vector(
-    array: &Decimal128Array,
+/// Convert Arrow decimal arrays to a DuckDB vector.
+fn decimal_array_to_vector<T>(
+    array: &PrimitiveArray<T>,
     out: &mut FlatVector<'_>,
     width: u8,
     scale: i8,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let scale = u8::try_from(scale).map_err(|_| {
-        format!(
-            "Unsupported data type: {}, negative decimal scale is not supported",
-            array.data_type()
-        )
-    })?;
-    Decimal::new(width, scale, 0).map_err(|err| format!("invalid Arrow decimal type {}: {err}", array.data_type()))?;
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: DecimalType,
+    T::Native: Into<i128>,
+{
+    assert!(array.len() <= out.capacity());
+
+    let scale = validate_arrow_decimal_metadata::<T>(width, scale)?;
 
     match width {
         1..=4 => {
@@ -943,17 +966,22 @@ fn decimal_array_to_vector(
     Ok(())
 }
 
-fn arrow_decimal_value(
-    array: &Decimal128Array,
+fn arrow_decimal_value<T>(
+    array: &PrimitiveArray<T>,
     width: u8,
     scale: u8,
     row: usize,
-) -> Result<i128, Box<dyn std::error::Error>> {
+) -> Result<i128, Box<dyn std::error::Error>>
+where
+    T: DecimalType,
+    T::Native: Into<i128>,
+{
     if array.is_null(row) {
+        // Placeholder only; decimal_array_to_vector applies the validity mask.
         return Ok(0);
     }
 
-    let value = array.value(row);
+    let value: i128 = array.value(row).into();
     Decimal::new(width, scale, value).map_err(|err| format!("invalid Arrow decimal value at row {row}: {err}"))?;
     Ok(value)
 }
@@ -1271,7 +1299,7 @@ fn set_nulls_in_list_vector(array: &dyn Array, out_vector: &mut ListVector<'_>) 
 mod test {
     use super::{
         ArrowInitData, ArrowVTab, RowSlice, arrow_arraydata_to_query_params, arrow_ffi_to_query_params,
-        arrow_recordbatch_to_query_params, data_chunk_to_arrow,
+        arrow_recordbatch_to_query_params, data_chunk_to_arrow, to_duckdb_logical_type,
     };
     use crate::{
         Connection, Result,
@@ -1280,17 +1308,17 @@ mod test {
     use arrow::{
         array::{
             Array, ArrayRef, AsArray, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array,
-            Decimal128Array, Decimal256Array, DurationSecondArray, FixedSizeBinaryArray, FixedSizeListArray,
-            FixedSizeListBuilder, GenericByteArray, GenericListArray, Int32Array, Int32Builder, IntervalDayTimeArray,
-            IntervalMonthDayNanoArray, IntervalYearMonthArray, LargeStringArray, ListArray, ListBuilder, MapArray,
-            OffsetSizeTrait, PrimitiveArray, StringArray, StringViewArray, StructArray, Time32SecondArray,
-            Time64MicrosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-            TimestampSecondArray, UInt32Array,
+            Decimal32Array, Decimal64Array, Decimal128Array, Decimal256Array, DurationSecondArray,
+            FixedSizeBinaryArray, FixedSizeListArray, FixedSizeListBuilder, GenericByteArray, GenericListArray,
+            Int32Array, Int32Builder, IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray,
+            LargeStringArray, ListArray, ListBuilder, MapArray, OffsetSizeTrait, PrimitiveArray, StringArray,
+            StringViewArray, StructArray, Time32SecondArray, Time64MicrosecondArray, TimestampMicrosecondArray,
+            TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt32Array,
         },
         buffer::{OffsetBuffer, ScalarBuffer},
         datatypes::{
-            ArrowPrimitiveType, ByteArrayType, DataType, DurationSecondType, Field, IntervalDayTimeType,
-            IntervalMonthDayNanoType, IntervalYearMonthType, Schema, i256,
+            ArrowPrimitiveType, ByteArrayType, DataType, Decimal32Type, Decimal64Type, DurationSecondType, Field,
+            IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType, Schema, i256,
         },
         ffi::{FFI_ArrowArray, FFI_ArrowSchema},
         record_batch::RecordBatch,
@@ -2092,6 +2120,78 @@ mod test {
         check_rust_primitive_array_roundtrip(array.clone(), array)?;
 
         Ok(())
+    }
+
+    #[test]
+    fn test_decimal32_roundtrip() -> Result<(), Box<dyn Error>> {
+        let array: PrimitiveArray<Decimal32Type> =
+            Decimal32Array::from(vec![1234, -1234]).with_data_type(DataType::Decimal32(4, 2));
+        let expected = Decimal128Array::from(vec![1234_i128, -1234]).with_data_type(DataType::Decimal128(4, 2));
+        check_rust_primitive_array_roundtrip(array, expected)?;
+
+        let array: PrimitiveArray<Decimal32Type> =
+            Decimal32Array::from(vec![Some(123456789_i32), None, Some(-123456789_i32)])
+                .with_data_type(DataType::Decimal32(9, 2));
+        let expected = Decimal128Array::from(vec![Some(123456789_i128), None, Some(-123456789_i128)])
+            .with_data_type(DataType::Decimal128(9, 2));
+        check_rust_primitive_array_roundtrip(array, expected)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_decimal64_roundtrip() -> Result<(), Box<dyn Error>> {
+        let array: PrimitiveArray<Decimal64Type> =
+            Decimal64Array::from(vec![1234, -1234]).with_data_type(DataType::Decimal64(4, 2));
+        let expected = Decimal128Array::from(vec![1234_i128, -1234]).with_data_type(DataType::Decimal128(4, 2));
+        check_rust_primitive_array_roundtrip(array, expected)?;
+
+        let array: PrimitiveArray<Decimal64Type> =
+            Decimal64Array::from(vec![123456789, -123456789]).with_data_type(DataType::Decimal64(9, 2));
+        let expected =
+            Decimal128Array::from(vec![123456789_i128, -123456789]).with_data_type(DataType::Decimal128(9, 2));
+        check_rust_primitive_array_roundtrip(array, expected)?;
+
+        let array: PrimitiveArray<Decimal64Type> =
+            Decimal64Array::from(vec![Some(123456789012345678_i64), None, Some(-123456789012345678_i64)])
+                .with_data_type(DataType::Decimal64(18, 2));
+        let expected = Decimal128Array::from(vec![
+            Some(123456789012345678_i128),
+            None,
+            Some(-123456789012345678_i128),
+        ])
+        .with_data_type(DataType::Decimal128(18, 2));
+        check_rust_primitive_array_roundtrip(array, expected)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_narrow_decimal_logical_type_rejects_invalid_width_and_scale() {
+        fn logical_type_error(data_type: DataType) -> String {
+            match to_duckdb_logical_type(&data_type) {
+                Ok(_) => panic!("expected {data_type} to be rejected"),
+                Err(err) => err.to_string(),
+            }
+        }
+
+        let err = logical_type_error(DataType::Decimal32(10, 2));
+        assert!(err.contains("decimal width 10 exceeds 9"), "unexpected error: {err}");
+
+        let err = logical_type_error(DataType::Decimal64(19, 2));
+        assert!(err.contains("decimal width 19 exceeds 18"), "unexpected error: {err}");
+
+        let err = logical_type_error(DataType::Decimal32(4, -1));
+        assert!(
+            err.contains("negative decimal scale is not supported"),
+            "unexpected error: {err}"
+        );
+
+        let err = logical_type_error(DataType::Decimal64(4, -1));
+        assert!(
+            err.contains("negative decimal scale is not supported"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Fix `Decimal32`/`Decimal64` row decoding for Arrow result batches.
- Add ArrowVTab input support for `Decimal32`/`Decimal64`.
- Keep `Decimal256` classified as decimal metadata, but unsupported for value paths.
- Add focused decoding, roundtrip, and invalid metadata tests.

Refs https://github.com/duckdb/duckdb-rs/issues/305