### PR TITLE
Remove ignored schema parameter from Arrow streaming API

### DIFF
--- a/crates/duckdb/src/arrow_batch.rs
+++ b/crates/duckdb/src/arrow_batch.rs
@@ -3,7 +3,13 @@ use super::{
     arrow::{datatypes::SchemaRef, record_batch::RecordBatch},
 };
 
-/// A handle for the resulting RecordBatch of a query.
+/// A handle for iterating the [`RecordBatch`]es of a query result.
+///
+/// The iterator is lazy: each batch is fetched only as the iterator is
+/// advanced. Whether the full result is materialized up front or fetched
+/// lazily in chunks depends on how the statement was executed — see
+/// [`query_arrow`](Statement::query_arrow) and
+/// [`stream_arrow`](Statement::stream_arrow).
 ///
 /// The iterator panics if DuckDB fails to fetch a result chunk or convert it
 /// to Arrow.
@@ -42,42 +48,8 @@ impl<'stmt> Iterator for Arrow<'stmt> {
     }
 }
 
-/// A handle for the resulting RecordBatch of a query in streaming.
+/// A handle for the resulting RecordBatch of a streaming query.
 ///
-/// The iterator panics if DuckDB fails to fetch a result chunk or convert it
-/// to Arrow.
-#[must_use = "Arrow stream is lazy and will not fetch data unless consumed"]
-#[allow(clippy::needless_lifetimes)]
-pub struct ArrowStream<'stmt> {
-    pub(crate) stmt: Option<&'stmt Statement<'stmt>>,
-}
-
-#[allow(clippy::needless_lifetimes)]
-impl<'stmt> ArrowStream<'stmt> {
-    #[inline]
-    pub(crate) fn new(stmt: &'stmt Statement<'stmt>) -> Self {
-        ArrowStream { stmt: Some(stmt) }
-    }
-
-    /// Return the Arrow schema reported by DuckDB after execution.
-    #[inline]
-    pub fn get_schema(&self) -> SchemaRef {
-        self.stmt
-            .expect("ArrowStream iterator always holds a statement")
-            .stmt
-            .schema()
-    }
-}
-
-#[allow(clippy::needless_lifetimes)]
-impl<'stmt> Iterator for ArrowStream<'stmt> {
-    type Item = RecordBatch;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.stmt?.step() {
-            Ok(Some(array)) => Some(RecordBatch::from(&array)),
-            Ok(None) => None,
-            Err(err) => panic!("Failed to fetch streaming Arrow record batch: {err}"),
-        }
-    }
-}
+/// Identical to [`Arrow`]: the streaming behavior comes from how the
+/// statement was executed, not from the iterator type.
+pub type ArrowStream<'stmt> = Arrow<'stmt>;

--- a/crates/duckdb/src/cache.rs
+++ b/crates/duckdb/src/cache.rs
@@ -176,12 +176,8 @@ impl StatementCache {
 mod test {
     use super::StatementCache;
     use crate::{Connection, Result, core::LogicalTypeId, types::Value};
-    use arrow::{
-        array::Int32Array,
-        datatypes::{DataType, Field, Schema},
-    };
+    use arrow::array::Int32Array;
     use fallible_iterator::FallibleIterator;
-    use std::sync::Arc;
 
     impl StatementCache {
         fn clear(&self) {
@@ -486,8 +482,7 @@ mod test {
 
         {
             let mut stmt = db.prepare_cached(sql)?;
-            let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, true)]));
-            let batches = stmt.stream_arrow([], schema)?.collect::<Vec<_>>();
+            let batches = stmt.stream_arrow([])?.collect::<Vec<_>>();
             assert_eq!(1, batches.len());
 
             let values = batches[0].column(0).as_any().downcast_ref::<Int32Array>().unwrap();

--- a/crates/duckdb/src/lib.rs
+++ b/crates/duckdb/src/lib.rs
@@ -1511,9 +1511,6 @@ mod test {
 
     #[test]
     fn test_stream_arrow_with_call() -> Result<()> {
-        use arrow::datatypes::{DataType, Field, Schema};
-        use std::sync::Arc;
-
         let db = checked_memory_handle();
 
         db.execute_batch(
@@ -1523,13 +1520,8 @@ mod test {
 
         db.execute_batch("CREATE MACRO test_func() AS TABLE SELECT * FROM test_data;")?;
 
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Int32, true),
-            Field::new("name", DataType::Utf8, true),
-        ]));
-
         let mut stmt = db.prepare("CALL test_func()")?;
-        let rbs: Vec<RecordBatch> = stmt.stream_arrow([], schema)?.collect();
+        let rbs: Vec<RecordBatch> = stmt.stream_arrow([])?.collect();
 
         // Verify we got results
         assert!(!rbs.is_empty(), "Expected at least one record batch");

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -129,7 +129,7 @@ impl Statement<'_> {
     /// as the iterator is consumed instead of buffering the full result on
     /// the client side. Note that DuckDB may still materialize the result
     /// internally for some statements (e.g. CALL). The schema is available
-    /// via [`ArrowStream::get_schema`].
+    /// via [`Arrow::get_schema`].
     ///
     /// ## Example
     ///

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -125,18 +125,19 @@ impl Statement<'_> {
     /// Execute the prepared statement, returning a handle to the resulting
     /// vector of arrow RecordBatch in streaming way
     ///
-    /// The `schema` argument is kept for source compatibility. Decoding uses
-    /// the schema reported by DuckDB after execution, so callers do not need to
-    /// pass a matching schema.
+    /// Unlike [`query_arrow`](Self::query_arrow), chunks are fetched lazily
+    /// as the iterator is consumed instead of buffering the full result on
+    /// the client side. Note that DuckDB may still materialize the result
+    /// internally for some statements (e.g. CALL). The schema is available
+    /// via [`ArrowStream::get_schema`].
     ///
     /// ## Example
     ///
     /// ```rust,no_run
     /// # use duckdb::{Result, Connection};
     /// # use arrow::record_batch::RecordBatch;
-    /// # use arrow::datatypes::SchemaRef;
-    /// fn get_arrow_data(conn: &Connection, schema: SchemaRef) -> Result<Vec<RecordBatch>> {
-    ///     Ok(conn.prepare("SELECT * FROM test")?.stream_arrow([], schema)?.collect())
+    /// fn get_arrow_data(conn: &Connection) -> Result<Vec<RecordBatch>> {
+    ///     Ok(conn.prepare("SELECT * FROM test")?.stream_arrow([])?.collect())
     /// }
     /// ```
     ///
@@ -148,9 +149,7 @@ impl Statement<'_> {
     /// The returned iterator panics if fetching or Arrow conversion fails
     /// after execution has started.
     #[inline]
-    pub fn stream_arrow<P: Params>(&mut self, params: P, schema: SchemaRef) -> Result<ArrowStream<'_>> {
-        // Kept for API compatibility; executed result metadata is authoritative.
-        let _ = schema;
+    pub fn stream_arrow<P: Params>(&mut self, params: P) -> Result<ArrowStream<'_>> {
         params.__bind_in(self)?;
         self.stmt.execute_streaming()?;
         Ok(ArrowStream::new(self))
@@ -411,20 +410,6 @@ impl Statement<'_> {
     /// it to Arrow.
     #[inline]
     pub fn step(&self) -> Result<Option<StructArray>> {
-        self.stmt.step()
-    }
-
-    /// Get next batch records in arrow-rs in a streaming way.
-    ///
-    /// The `schema` argument is kept for source compatibility. Decoding uses
-    /// the schema reported by DuckDB after execution.
-    ///
-    /// Returns `Err` if DuckDB cannot fetch the next result chunk or convert
-    /// it to Arrow.
-    #[deprecated(note = "use step(); result decoding now uses DuckDB's executed schema")]
-    #[inline]
-    pub fn stream_step(&self, schema: SchemaRef) -> Result<Option<StructArray>> {
-        let _ = schema;
         self.stmt.step()
     }
 
@@ -1648,17 +1633,11 @@ mod test {
 
     #[test]
     fn test_stream_arrow_large_result() -> Result<()> {
-        use std::sync::Arc;
-
-        use arrow::{
-            array::Int64Array,
-            datatypes::{DataType, Field, Schema},
-        };
+        use arrow::array::Int64Array;
 
         let db = Connection::open_in_memory()?;
-        let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int64, true)]));
         let mut stmt = db.prepare("SELECT i FROM range(3000) AS t(i) ORDER BY i")?;
-        let mut stream = stmt.stream_arrow([], schema)?;
+        let mut stream = stmt.stream_arrow([])?;
         let batches = stream.by_ref().collect::<Vec<_>>();
 
         assert!(batches.len() > 1);
@@ -1686,6 +1665,17 @@ mod test {
     }
 
     #[test]
+    fn test_stream_arrow_with_params() -> Result<()> {
+        let db = Connection::open_in_memory()?;
+        let mut stmt = db.prepare("SELECT i FROM range(3000) AS t(i) WHERE i < ? ORDER BY i")?;
+        let batches = stmt.stream_arrow([2500_i64])?.collect::<Vec<_>>();
+
+        assert!(batches.len() > 1);
+        assert_eq!(2500, batches.iter().map(|batch| batch.num_rows()).sum::<usize>());
+        Ok(())
+    }
+
+    #[test]
     fn test_streaming_step_surfaces_fetch_error_after_interrupt() -> Result<()> {
         let db = Connection::open_in_memory()?;
         let interrupt = db.interrupt_handle();
@@ -1708,9 +1698,12 @@ mod test {
     fn test_stream_arrow_empty_result_reaches_clean_eof() -> Result<()> {
         let db = Connection::open_in_memory()?;
         let mut stmt = db.prepare("SELECT 1 AS x WHERE false")?;
-        let mut stream = stmt.stream_arrow([], std::sync::Arc::new(arrow::datatypes::Schema::empty()))?;
+        let mut stream = stmt.stream_arrow([])?;
 
-        assert_eq!(1, stream.get_schema().fields().len());
+        let schema = stream.get_schema();
+        assert_eq!(1, schema.fields().len());
+        assert_eq!("x", schema.field(0).name());
+        assert_eq!(&arrow::datatypes::DataType::Int32, schema.field(0).data_type());
         assert!(stream.next().is_none());
         assert!(stream.next().is_none());
         Ok(())
@@ -1718,9 +1711,7 @@ mod test {
 
     #[test]
     fn test_stream_arrow_then_query_arrow_replaces_result() -> Result<()> {
-        use std::sync::Arc;
-
-        use arrow::{array::Int64Array, datatypes::Schema};
+        use arrow::array::Int64Array;
 
         fn assert_range_batches(batches: &[arrow::record_batch::RecordBatch]) {
             assert!(batches.len() > 1);
@@ -1747,7 +1738,7 @@ mod test {
         let mut stmt = db.prepare("SELECT i FROM range(3000) AS t(i) ORDER BY i")?;
 
         {
-            let batches = stmt.stream_arrow([], Arc::new(Schema::empty()))?.collect::<Vec<_>>();
+            let batches = stmt.stream_arrow([])?.collect::<Vec<_>>();
             assert_range_batches(&batches);
         }
 
@@ -1757,7 +1748,7 @@ mod test {
         }
 
         {
-            let batches = stmt.stream_arrow([], Arc::new(Schema::empty()))?.collect::<Vec<_>>();
+            let batches = stmt.stream_arrow([])?.collect::<Vec<_>>();
             assert_range_batches(&batches);
         }
 
@@ -2034,14 +2025,10 @@ mod test {
 
     #[test]
     fn test_variant_streaming_result_decode_unsupported() -> Result<()> {
-        use std::sync::Arc;
-
-        use arrow::datatypes::Schema;
-
         let db = Connection::open_in_memory()?;
         let err = match db
             .prepare("SELECT 1 AS id, {'a': 42}::VARIANT AS variant_col")?
-            .stream_arrow([], Arc::new(Schema::empty()))
+            .stream_arrow([])
         {
             Ok(_) => panic!("expected Variant streaming query to fail"),
             Err(err) => err,
@@ -2069,16 +2056,12 @@ mod test {
 
     #[test]
     fn test_variant_returning_streaming_rejected_before_mutation() -> Result<()> {
-        use std::sync::Arc;
-
-        use arrow::datatypes::Schema;
-
         let db = Connection::open_in_memory()?;
         db.execute_batch("CREATE TABLE t(id INTEGER, v VARIANT);")?;
 
         let err = match db
             .prepare("INSERT INTO t VALUES (1, {'a': 42}::VARIANT) RETURNING v")?
-            .stream_arrow([], Arc::new(Schema::empty()))
+            .stream_arrow([])
         {
             Ok(_) => panic!("expected Variant RETURNING streaming execute to fail"),
             Err(err) => err,

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -103,6 +103,10 @@ impl Statement<'_> {
     /// Execute the prepared statement, returning a handle to the resulting
     /// vector of arrow RecordBatch
     ///
+    /// The result is fully materialized on execution, so memory usage is
+    /// proportional to the size of the result set. For large results, see
+    /// [`stream_arrow`](Self::stream_arrow).
+    ///
     /// ## Example
     ///
     /// ```rust,no_run
@@ -115,7 +119,8 @@ impl Statement<'_> {
     ///
     /// # Failure
     ///
-    /// Will return `Err` if binding parameters fails.
+    /// Will return `Err` if binding parameters fails, execution fails, or
+    /// DuckDB reports unsupported executed-result metadata.
     #[inline]
     pub fn query_arrow<P: Params>(&mut self, params: P) -> Result<Arrow<'_>> {
         self.execute(params)?;
@@ -143,10 +148,8 @@ impl Statement<'_> {
     ///
     /// # Failure
     ///
-    /// Will return `Err` if binding parameters fails, execution fails, or
-    /// DuckDB reports unsupported executed-result metadata.
-    ///
-    /// The returned iterator panics if fetching or Arrow conversion fails
+    /// Same failure modes as [`query_arrow`](Self::query_arrow). In addition,
+    /// the returned iterator panics if fetching or Arrow conversion fails
     /// after execution has started.
     #[inline]
     pub fn stream_arrow<P: Params>(&mut self, params: P) -> Result<ArrowStream<'_>> {


### PR DESCRIPTION
Since #800, streaming decode uses the schema DuckDB reports for the executed result, and the caller-supplied schema is ignored. Remove the parameter so callers no longer have to construct one.

Also, since they carried the same ignored-schema shim:

- Remove the deprecated `stream_step` (no callers)
- Collapse `ArrowStream` into a type alias of `Arrow` (iterators were byte-for-byte duplicates; streaming comes from how the statement is executed). `stream_arrow`'s signature stays source-compatible.

Docs now note that `query_arrow` materializes the full result (use `stream_arrow` for large results), and that streaming can't promise bounded memory since DuckDB may materialize internally (e.g. `CALL`).

Fixes #418