### PR TITLE
Improve rustdoc accuracy and coverage

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -76,6 +76,13 @@ jobs:
           CXX: "sccache c++"
         run: cargo clippy --all-targets --features "buildtime_bindgen extensions-full loadable-extension modern-full vscalar vscalar-arrow vtab-full" --locked -- -D warnings
 
+      - name: Check rustdoc
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          RUSTDOCFLAGS: -D warnings
+        # Keep this feature list in sync with crates/duckdb/Cargo.toml [package.metadata.docs.rs].
+        run: cargo doc --workspace --no-deps --features "modern-full vscalar vscalar-arrow vtab-full"
+
       - name: Dry-run release of crates
         if: matrix.os == 'ubuntu-latest'
         run: cargo publish --workspace --dry-run

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -81,10 +81,11 @@ tempfile = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [package.metadata.docs.rs]
-features = ["vtab-full", "modern-full", "vscalar", "vscalar-arrow", "rust_decimal"]
+features = ["modern-full", "vscalar", "vscalar-arrow", "vtab-full"]
 all-features = false
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"
+targets = []
 
 [package.metadata.playground]
 features = []

--- a/crates/duckdb/src/appender_params.rs
+++ b/crates/duckdb/src/appender_params.rs
@@ -1,120 +1,48 @@
 use crate::{Appender, Result, ToSql};
 
 mod sealed {
-    /// This trait exists just to ensure that the only impls of `trait Params`
-    /// that are allowed are ones in this crate.
+    /// This trait exists just to ensure that the only impls of
+    /// `trait AppenderParams` that are allowed are ones in this crate.
     pub trait Sealed {}
 }
 use sealed::Sealed;
 
-/// Trait used for [sets of parameter][params] passed into SQL
-/// statements/queries.
-///
-/// [params]: https://duckdb.org/docs/stable/clients/c/prepared.html
+/// Trait used for rows passed to [`Appender::append_row`] and
+/// [`Appender::append_rows`].
 ///
 /// Note: Currently, this trait can only be implemented inside this crate.
 /// Additionally, its methods (which are `doc(hidden)`) should currently not be
 /// considered part of the stable API, although it's possible they will
 /// stabilize in the future.
 ///
-/// # Passing parameters to DuckDB
+/// `AppenderParams` normalizes the row values accepted by the appender API into
+/// the positional values DuckDB appends to one table row. It is separate from
+/// [`Params`](crate::Params), which is used for prepared statements and
+/// queries.
 ///
-/// Many functions in this library let you pass parameters to SQLite. Doing this
-/// lets you avoid any risk of SQL injection, and is simpler than escaping
-/// things manually. Aside from deprecated functions and a few helpers, this is
-/// indicated by the function taking a generic argument that implements `Params`
-/// (this trait).
+/// Supported forms include:
 ///
-/// ## Positional parameters
+/// - tuples of mixed types, up to 16 elements;
+/// - arrays and references to arrays, up to 32 elements;
+/// - [`duckdb::params!`](crate::params!) or `&[&dyn ToSql]` for heterogeneous
+///   rows or rows assembled dynamically;
+/// - [`appender_params_from_iter`] for iterators over one concrete
+///   [`ToSql`] item type.
 ///
-/// For cases where you want to pass a list of parameters where the number of
-/// parameters is known at compile time, this can be done in one of the
-/// following ways:
-///
-/// - Using the [`duckdb::params!`](crate::params!) macro, e.g.
-///   `thing.query(duckdb::params![1, "foo", bar])`. This is mostly useful for
-///   heterogeneous lists of parameters, or lists where the number of parameters
-///   exceeds 32.
-///
-/// - For small heterogeneous lists of parameters, they can either be passed as:
-///
-///     - an array, as in `thing.query([1i32, 2, 3, 4])` or `thing.query(["foo",
-///       "bar", "baz"])`.
-///
-///     - a reference to an array of references, as in `thing.query(&["foo",
-///       "bar", "baz"])` or `thing.query(&[&1i32, &2, &3])`.
-///
-///       (Note: in this case we don't implement this for slices for coherence
-///       reasons, so it really is only for the "reference to array" types —
-///       hence why the number of parameters must be <= 32 or you need to
-///       reach for `duckdb::params!`)
-///
-///   Unfortunately, in the current design it's not possible to allow this for
-///   references to arrays of non-references (e.g. `&[1i32, 2, 3]`). Code like
-///   this should instead either use `params!`, an array literal, a `&[&dyn
-///   ToSql]` or if none of those work, [`ParamsFromIter`].
-///
-/// - As a slice of `ToSql` trait object references, e.g. `&[&dyn ToSql]`. This
-///   is mostly useful for passing parameter lists around as arguments without
-///   having every function take a generic `P: Params`.
-///
-/// ### Example (positional)
+/// # Example
 ///
 /// ```rust,no_run
 /// # use duckdb::{Connection, Result, params};
-/// fn update_rows(conn: &Connection) -> Result<()> {
-///     let mut stmt = conn.prepare("INSERT INTO test (a, b) VALUES (?, ?)")?;
+/// fn append_rows(conn: &Connection) -> Result<()> {
+///     conn.execute_batch("CREATE TABLE people (id INTEGER, name TEXT)")?;
+///     let mut appender = conn.appender("people")?;
 ///
-///     // Using `duckdb::params!`:
-///     stmt.execute(params![1i32, "blah"])?;
+///     appender.append_row((1i32, "Alice"))?;
+///     appender.append_row(params![2i32, "Bob"])?;
 ///
-///     // array literal — non-references
-///     stmt.execute([2i32, 3i32])?;
-///
-///     // array literal — references
-///     stmt.execute(["foo", "bar"])?;
-///
-///     // Slice literal, references:
-///     stmt.execute(&[&2i32, &3i32])?;
-///
-///     // Note: The types behind the references don't have to be `Sized`
-///     stmt.execute(&["foo", "bar"])?;
-///
-///     // However, this doesn't work (see above):
-///     // stmt.execute(&[1i32, 2i32])?;
-///     Ok(())
+///     appender.flush()
 /// }
 /// ```
-///
-/// ## No parameters
-///
-/// You can just use an empty array literal for no params. The
-/// `duckdb::NO_PARAMS` constant which was so common in previous versions of
-/// this library is no longer needed (and is now deprecated).
-///
-/// ### Example (no parameters)
-///
-/// ```rust,no_run
-/// # use duckdb::{Connection, Result, params};
-/// fn delete_all_users(conn: &Connection) -> Result<()> {
-///     // Just use an empty array (e.g. `[]`) for no params.
-///     conn.execute("DELETE FROM users", [])?;
-///     Ok(())
-/// }
-/// ```
-///
-/// ## Dynamic parameter list
-///
-/// If you have a number of parameters which is unknown at compile time (for
-/// example, building a dynamic query at runtime), you have two choices:
-///
-/// - Use a `&[&dyn ToSql]`, which is nice if you have one otherwise might be
-///   annoying.
-/// - Use the [`ParamsFromIter`] type. This essentially lets you wrap an
-///   iterator some `T: ToSql` with something that implements `Params`.
-///
-/// A lot of the considerations here are similar either way, so you should see
-/// the [`ParamsFromIter`] documentation for more info / examples.
 pub trait AppenderParams: Sealed {
     // XXX not public api, might not need to expose.
     //
@@ -217,105 +145,37 @@ impl_appender_params_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
 impl_appender_params_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);
 
 /// Adapter type which allows any iterator over [`ToSql`] values to implement
-/// [`Params`].
+/// [`AppenderParams`].
 ///
-/// This struct is created by the [`params_from_iter`] function.
+/// This struct is created by the [`appender_params_from_iter`] function.
 ///
-/// This can be useful if you have something like an `&[String]` (of unknown
-/// length), and you want to use them with an API that wants something
-/// implementing `Params`. This way, you can avoid having to allocate storage
-/// for something like a `&[&dyn ToSql]`.
+/// This can be useful when the values for one appended row are already stored
+/// in a collection or produced by an iterator. It avoids allocating storage for
+/// something like a `Vec<&dyn ToSql>`.
 ///
-/// This essentially is only ever actually needed when dynamically generating
-/// SQL — static SQL (by definition) has the number of parameters known
-/// statically. As dynamically generating SQL is itself pretty advanced, this
-/// API is itself for advanced use cases (See "Realistic use case" in the
-/// examples).
+/// The iterator must yield one concrete item type that implements [`ToSql`].
+/// For heterogeneous rows, use a tuple, [`duckdb::params!`](crate::params!), or
+/// a `&[&dyn ToSql]`. As with every [`Appender::append_row`] call, the number
+/// of values must match the target table's column count.
 ///
 /// # Example
 ///
-/// ## Basic usage
-///
 /// ```rust,no_run
-/// use duckdb::{Connection, Result, params_from_iter};
-/// use std::collections::BTreeSet;
+/// use duckdb::{Connection, Result, appender_params_from_iter};
 ///
-/// fn query(conn: &Connection, ids: &BTreeSet<String>) -> Result<()> {
-///     assert_eq!(ids.len(), 3, "Unrealistic sample code");
+/// fn append_scores(conn: &Connection, scores: Vec<i32>) -> Result<()> {
+///     conn.execute_batch("CREATE TABLE scores (a INTEGER, b INTEGER, c INTEGER)")?;
+///     let mut appender = conn.appender("scores")?;
 ///
-///     let mut stmt = conn.prepare("SELECT * FROM users WHERE id IN (?, ?, ?)")?;
-///     let _rows = stmt.query(params_from_iter(ids.iter()))?;
-///
-///     // use _rows...
-///     Ok(())
+///     appender.append_row(appender_params_from_iter(scores))?;
+///     appender.flush()
 /// }
 /// ```
-///
-/// ## Realistic use case
-///
-/// Here's how you'd use `ParamsFromIter` to call [`Statement::exists`] with a
-/// dynamic number of parameters.
-///
-/// ```rust,no_run
-/// use duckdb::{Connection, Result};
-///
-/// pub fn any_active_users(conn: &Connection, usernames: &[String]) -> Result<bool> {
-///     if usernames.is_empty() {
-///         return Ok(false);
-///     }
-///
-///     // Note: `repeat_vars` never returns anything attacker-controlled, so
-///     // it's fine to use it in a dynamically-built SQL string.
-///     let vars = repeat_vars(usernames.len());
-///
-///     let sql = format!(
-///         // In practice this would probably be better as an `EXISTS` query.
-///         "SELECT 1 FROM user WHERE is_active AND name IN ({}) LIMIT 1",
-///         vars,
-///     );
-///     let mut stmt = conn.prepare(&sql)?;
-///     stmt.exists(duckdb::params_from_iter(usernames))
-/// }
-///
-/// // Helper function to return a comma-separated sequence of `?`.
-/// // - `repeat_vars(0) => panic!(...)`
-/// // - `repeat_vars(1) => "?"`
-/// // - `repeat_vars(2) => "?,?"`
-/// // - `repeat_vars(3) => "?,?,?"`
-/// // - ...
-/// fn repeat_vars(count: usize) -> String {
-///     assert_ne!(count, 0);
-///     let mut s = "?,".repeat(count);
-///     // Remove trailing comma
-///     s.pop();
-///     s
-/// }
-/// ```
-///
-/// That is fairly complex, and even so would need even more work to be fully
-/// production-ready:
-///
-/// - production code should ensure `usernames` isn't so large that it will
-///   surpass [`conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)`][limits]),
-///   chunking if too large. (Note that the limits api requires duckdb to have
-///   the "limits" feature).
-///
-/// - `repeat_vars` can be implemented in a way that avoids needing to allocate
-///   a String.
-///
-/// - Etc...
-///
-/// [limits]: crate::Connection::limit
-///
-/// This complexity reflects the fact that `ParamsFromIter` is mainly intended
-/// for advanced use cases — most of the time you should know how many
-/// parameters you have statically (and if you don't, you're either doing
-/// something tricky, or should take a moment to think about the design).
 #[derive(Clone, Debug)]
 pub struct AppenderParamsFromIter<I>(I);
 
-/// Constructor function for a [`ParamsFromIter`]. See its documentation for
-/// more.
+/// Constructor function for an [`AppenderParamsFromIter`]. See its
+/// documentation for more.
 #[inline]
 pub fn appender_params_from_iter<I>(iter: I) -> AppenderParamsFromIter<I>
 where

--- a/crates/duckdb/src/config.rs
+++ b/crates/duckdb/src/config.rs
@@ -60,7 +60,7 @@ impl Config {
         Ok(self)
     }
 
-    /// Access mode of the database ([AUTOMATIC], READ_ONLY or READ_WRITE)
+    /// Access mode of the database (`AUTOMATIC`, `READ_ONLY` or `READ_WRITE`)
     pub fn access_mode(mut self, mode: AccessMode) -> Result<Self> {
         self.set("access_mode", mode)?;
         Ok(self)
@@ -72,13 +72,13 @@ impl Config {
         Ok(self)
     }
 
-    /// The order type used when none is specified ([ASC] or DESC)
+    /// The order type used when none is specified (`ASC` or `DESC`)
     pub fn default_order(mut self, order: DefaultOrder) -> Result<Self> {
         self.set("default_order", order)?;
         Ok(self)
     }
 
-    /// Null ordering used when none is specified ([NULLS_FIRST] or NULLS_LAST)
+    /// Null ordering used when none is specified (`NULLS_FIRST` or `NULLS_LAST`)
     pub fn default_null_order(mut self, null_order: DefaultNullOrder) -> Result<Self> {
         self.set("default_null_order", null_order)?;
         Ok(self)

--- a/crates/duckdb/src/core/data_chunk.rs
+++ b/crates/duckdb/src/core/data_chunk.rs
@@ -12,7 +12,7 @@ pub struct DataChunkHandle {
     /// Pointer to the DataChunk in duckdb C API.
     ptr: duckdb_data_chunk,
 
-    /// Whether this [DataChunkHandle] own the [DataChunk::ptr].
+    /// Whether this `DataChunkHandle` owns `ptr`.
     owned: bool,
 }
 

--- a/crates/duckdb/src/error.rs
+++ b/crates/duckdb/src/error.rs
@@ -53,7 +53,8 @@ pub enum Error {
     QueryReturnedNoRows,
 
     /// Error when a query that was expected to return only one row (e.g.,
-    /// for [`query_one`](crate::Connection::query_one)) did return more than one.
+    /// for [`Statement::query_one`](crate::Statement::query_one)) did return
+    /// more than one.
     QueryReturnedMoreThanOneRow,
 
     /// Error when the value of a particular column is requested, but the index

--- a/crates/duckdb/src/params.rs
+++ b/crates/duckdb/src/params.rs
@@ -354,17 +354,10 @@ impl_params_for_tuple!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T
 /// That is fairly complex, and even so would need even more work to be fully
 /// production-ready:
 ///
-/// - production code should ensure `usernames` isn't so large that it will
-///   surpass [`conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER)`][limits]),
-///   chunking if too large. (Note that the limits api requires duckdb to have
-///   the "limits" feature).
-///
 /// - `repeat_vars` can be implemented in a way that avoids needing to allocate
 ///   a String.
 ///
 /// - Etc...
-///
-/// [limits]: crate::Connection::limit
 ///
 /// This complexity reflects the fact that `ParamsFromIter` is mainly intended
 /// for advanced use cases — most of the time you should know how many

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -243,7 +243,8 @@ impl Statement<'_> {
     /// }
     /// ```
     ///
-    /// Or, equivalently (but without the [`params!`] macro).
+    /// Or, equivalently (but without the [`duckdb::params!`](crate::params!)
+    /// macro).
     ///
     /// ```rust,no_run
     /// # use duckdb::{Connection, Result};

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -72,7 +72,8 @@ impl ToSql for ToSqlOutput<'_> {
 }
 
 /// A trait for types that can be converted into DuckDB values. Returns
-/// [`Error::ToSqlConversionFailure`] if the conversion fails.
+/// [`Error::ToSqlConversionFailure`](crate::Error::ToSqlConversionFailure) if
+/// the conversion fails.
 pub trait ToSql {
     /// Converts Rust value to DuckDB value
     fn to_sql(&self) -> Result<ToSqlOutput<'_>>;

--- a/crates/libduckdb-sys/src/lib.rs
+++ b/crates/libduckdb-sys/src/lib.rs
@@ -10,6 +10,10 @@ pub use arrow_c_data::{ArrowArray, ArrowSchema};
 
 #[allow(clippy::all, unsafe_op_in_unsafe_fn)]
 mod bindings {
+    // Bindgen preserves DuckDB's C API comments verbatim. Some of those comments
+    // contain C snippets and prose that rustdoc parses as Rust links or HTML.
+    #![allow(rustdoc::broken_intra_doc_links, rustdoc::invalid_html_tags)]
+
     // Bindgen references these blocklisted forward declarations unqualified.
     use crate::arrow_c_data::{ArrowArray, ArrowSchema};
 


### PR DESCRIPTION
- Fix misleading and stale parameter documentation
- Clean up rustdoc links so public docs resolve correctly
- Align docs.rs metadata with the intended Linux target and feature set
- Add CI coverage for rustdoc