### PR TITLE
Unify recursive Arrow-to-DuckDB vector writes

### DIFF
--- a/crates/duckdb/src/arrow_interop/tests/fixed_size_binary.rs
+++ b/crates/duckdb/src/arrow_interop/tests/fixed_size_binary.rs
@@ -1,0 +1,131 @@
+use super::*;
+
+#[test]
+fn test_fixed_size_binary_in_struct() -> Result<(), Box<dyn Error>> {
+    let fixed_size_binary_data = FixedSizeBinaryArray::try_from_iter(
+        vec![
+            vec![1u8, 2, 3, 4, 5, 6, 7, 8],
+            vec![9u8, 10, 11, 12, 13, 14, 15, 16],
+            vec![17u8, 18, 19, 20, 21, 22, 23, 24],
+        ]
+        .into_iter(),
+    )
+    .unwrap();
+
+    let int_data = Int32Array::from(vec![100, 200, 300]);
+
+    let struct_array = StructArray::from(vec![
+        (
+            Arc::new(Field::new("binary_field", DataType::FixedSizeBinary(8), false)),
+            Arc::new(fixed_size_binary_data) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("int_field", DataType::Int32, false)),
+            Arc::new(int_data) as ArrayRef,
+        ),
+    ]);
+
+    let output = roundtrip_single_array(Arc::new(struct_array))?;
+    let struct_column = output.as_any().downcast_ref::<StructArray>().unwrap();
+    assert_eq!(struct_column.len(), 3);
+
+    let binary_field = struct_column.column(0).as_any().downcast_ref::<BinaryArray>().unwrap();
+    assert_eq!(binary_field.value(0), &[1u8, 2, 3, 4, 5, 6, 7, 8]);
+    assert_eq!(binary_field.value(1), &[9u8, 10, 11, 12, 13, 14, 15, 16]);
+    assert_eq!(binary_field.value(2), &[17u8, 18, 19, 20, 21, 22, 23, 24]);
+
+    let int_field = struct_column.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(int_field.value(0), 100);
+    assert_eq!(int_field.value(1), 200);
+    assert_eq!(int_field.value(2), 300);
+
+    Ok(())
+}
+
+#[test]
+fn test_fixed_size_binary_in_fixed_size_list() -> Result<(), Box<dyn Error>> {
+    let values = FixedSizeBinaryArray::try_from_iter(
+        vec![
+            vec![1u8, 2, 3, 4],
+            vec![5u8, 6, 7, 8],
+            vec![9u8, 10, 11, 12],
+            vec![13u8, 14, 15, 16],
+        ]
+        .into_iter(),
+    )
+    .unwrap();
+
+    let field = Arc::new(Field::new("item", DataType::FixedSizeBinary(4), false));
+    let fixed_size_list = FixedSizeListArray::new(field, 2, Arc::new(values), None);
+
+    let output = roundtrip_single_array(Arc::new(fixed_size_list))?;
+    let list_column = output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    assert_eq!(list_column.len(), 2);
+
+    let first_list = list_column.value(0);
+    let first_binary = first_list.as_any().downcast_ref::<BinaryArray>().unwrap();
+    assert_eq!(first_binary.len(), 2);
+    assert_eq!(first_binary.value(0), &[1u8, 2, 3, 4]);
+    assert_eq!(first_binary.value(1), &[5u8, 6, 7, 8]);
+
+    let second_list = list_column.value(1);
+    let second_binary = second_list.as_any().downcast_ref::<BinaryArray>().unwrap();
+    assert_eq!(second_binary.len(), 2);
+    assert_eq!(second_binary.value(0), &[9u8, 10, 11, 12]);
+    assert_eq!(second_binary.value(1), &[13u8, 14, 15, 16]);
+
+    Ok(())
+}
+
+#[test]
+fn test_fixed_size_binary_with_nulls_in_list() -> Result<(), Box<dyn Error>> {
+    let values = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+        vec![Some(vec![1u8, 2, 3, 4]), None, Some(vec![5u8, 6, 7, 8])].into_iter(),
+        4,
+    )
+    .unwrap();
+
+    let list_array = ListArray::new(
+        Arc::new(Field::new("item", DataType::FixedSizeBinary(4), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 3])),
+        Arc::new(values),
+        None,
+    );
+
+    let output = roundtrip_single_array(Arc::new(list_array))?;
+    let list_column = output.as_any().downcast_ref::<ListArray>().unwrap();
+    let first_list = list_column.value(0);
+    let binary_field = first_list.as_any().downcast_ref::<BinaryArray>().unwrap();
+
+    assert_eq!(binary_field.len(), 3);
+    assert_eq!(binary_field.value(0), &[1u8, 2, 3, 4]);
+    assert!(binary_field.is_null(1));
+    assert_eq!(binary_field.value(2), &[5u8, 6, 7, 8]);
+
+    Ok(())
+}
+
+#[test]
+fn test_fixed_size_binary_with_nulls_in_struct() -> Result<(), Box<dyn Error>> {
+    let fixed_size_binary_data = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+        vec![Some(vec![1u8, 2, 3, 4]), None, Some(vec![5u8, 6, 7, 8])].into_iter(),
+        4,
+    )
+    .unwrap();
+
+    let struct_array = StructArray::from(vec![(
+        Arc::new(Field::new("binary_field", DataType::FixedSizeBinary(4), true)),
+        Arc::new(fixed_size_binary_data) as ArrayRef,
+    )]);
+
+    let output = roundtrip_single_array(Arc::new(struct_array))?;
+    let struct_column = output.as_any().downcast_ref::<StructArray>().unwrap();
+    let binary_field = struct_column.column(0).as_any().downcast_ref::<BinaryArray>().unwrap();
+
+    assert_eq!(binary_field.len(), 3);
+    assert_eq!(binary_field.value(0), &[1u8, 2, 3, 4]);
+    assert!(binary_field.is_null(1));
+    assert_eq!(binary_field.value(2), &[5u8, 6, 7, 8]);
+
+    Ok(())
+}

--- a/crates/duckdb/src/arrow_interop/tests/mod.rs
+++ b/crates/duckdb/src/arrow_interop/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::{
-    UUID_BYTE_WIDTH, UUID_EXTENSION_NAME, data_chunk_to_arrow, to_duckdb_logical_type, to_duckdb_logical_type_for_field,
+    UUID_BYTE_WIDTH, UUID_EXTENSION_NAME, data_chunk_to_arrow, record_batch_to_duckdb_data_chunk,
+    to_duckdb_logical_type, to_duckdb_logical_type_for_field,
 };
 use crate::{
     Connection, Result,
@@ -10,21 +11,25 @@ use crate::{
 use arrow::{
     array::{
         Array, ArrayRef, AsArray, BinaryArray, BinaryViewArray, BooleanArray, Date32Array, Date64Array, Decimal32Array,
-        Decimal64Array, Decimal128Array, Decimal256Array, DurationSecondArray, FixedSizeBinaryArray,
-        FixedSizeListArray, FixedSizeListBuilder, GenericByteArray, GenericListArray, Int32Array, Int32Builder,
-        IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray, LargeBinaryArray, LargeStringArray,
-        ListArray, ListBuilder, MapArray, OffsetSizeTrait, PrimitiveArray, StringArray, StringViewArray, StructArray,
-        Time32SecondArray, Time64MicrosecondArray, TimestampMicrosecondArray, TimestampMillisecondArray,
-        TimestampNanosecondArray, TimestampSecondArray, UInt32Array,
+        Decimal64Array, Decimal128Array, Decimal256Array, DictionaryArray, DurationSecondArray, FixedSizeBinaryArray,
+        FixedSizeListArray, FixedSizeListBuilder, GenericByteArray, GenericListArray, Int8Array, Int32Array,
+        Int32Builder, Int64Array, IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray,
+        LargeBinaryArray, LargeListArray, LargeStringArray, ListArray, ListBuilder, MapArray, OffsetSizeTrait,
+        PrimitiveArray, StringArray, StringViewArray, StructArray, Time32SecondArray, Time64MicrosecondArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
+        UInt32Array,
     },
-    buffer::{OffsetBuffer, ScalarBuffer},
+    buffer::{NullBuffer, OffsetBuffer, ScalarBuffer},
     datatypes::{
         ArrowPrimitiveType, ByteArrayType, DataType, Decimal32Type, Decimal64Type, DurationSecondType, Field, Fields,
-        IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType, Schema, i256,
+        Int8Type, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType, Schema, i256,
     },
     record_batch::RecordBatch,
 };
 use std::{collections::HashMap, error::Error, sync::Arc};
+
+mod fixed_size_binary;
+mod nested;
 
 #[test]
 fn test_field_aware_logical_type_preserves_nested_shape() -> Result<(), Box<dyn Error>> {
@@ -328,6 +333,19 @@ where
     }
 
     Ok(())
+}
+
+fn roundtrip_single_array(array: ArrayRef) -> Result<ArrayRef, Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+
+    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
+    let rb = RecordBatch::try_new(Arc::new(schema), vec![array])?;
+    let param = arrow_recordbatch_to_query_params(rb);
+    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
+    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+
+    Ok(rb.column(0).clone())
 }
 
 #[test]
@@ -944,339 +962,6 @@ fn test_large_binary_nulls_roundtrip() -> Result<(), Box<dyn Error>> {
     assert!(output_array.is_valid(2));
     assert_eq!(output_array.value(0), b"hello");
     assert_eq!(output_array.value(2), b"!");
-
-    Ok(())
-}
-
-#[test]
-fn test_list_of_fixed_size_lists_roundtrip() -> Result<(), Box<dyn Error>> {
-    // field name must be empty to match `query_arrow` behavior, otherwise record batches will not match
-    let field = Field::new("", DataType::Int32, true);
-    let mut list_builder = ListBuilder::new(FixedSizeListBuilder::new(Int32Builder::new(), 2).with_field(field));
-
-    // Append first list of FixedSizeList items
-    {
-        let fixed_size_list_builder = list_builder.values();
-        fixed_size_list_builder.values().append_value(1);
-        fixed_size_list_builder.values().append_value(2);
-        fixed_size_list_builder.append(true);
-
-        // Append NULL fixed-size list item
-        fixed_size_list_builder.values().append_null();
-        fixed_size_list_builder.values().append_null();
-        fixed_size_list_builder.append(false);
-
-        fixed_size_list_builder.values().append_value(3);
-        fixed_size_list_builder.values().append_value(4);
-        fixed_size_list_builder.append(true);
-
-        list_builder.append(true);
-    }
-
-    // Append NULL list
-    list_builder.append_null();
-
-    check_generic_array_roundtrip(list_builder.finish())?;
-
-    Ok(())
-}
-
-#[test]
-fn test_list_of_lists_roundtrip() -> Result<(), Box<dyn Error>> {
-    // field name must be 'l' to match `query_arrow` behavior, otherwise record batches will not match
-    let field = Field::new("l", DataType::Int32, true);
-    let mut list_builder = ListBuilder::new(ListBuilder::new(Int32Builder::new()).with_field(field.clone()));
-
-    // Append first list of items
-    {
-        let list_item_builder = list_builder.values();
-        list_item_builder.append_value(vec![Some(1), Some(2)]);
-
-        // Append NULL list item
-        list_item_builder.append_null();
-
-        list_item_builder.append_value(vec![Some(3), None, Some(5)]);
-
-        list_builder.append(true);
-    }
-
-    // Append NULL list
-    list_builder.append_null();
-
-    check_generic_array_roundtrip(list_builder.finish())?;
-
-    Ok(())
-}
-
-#[test]
-fn test_list_of_structs_roundtrip() -> Result<(), Box<dyn Error>> {
-    let field_i = Arc::new(Field::new("i", DataType::Int32, true));
-    let field_s = Arc::new(Field::new("s", DataType::Utf8, true));
-
-    let int32_array = Int32Array::from(vec![Some(1), Some(2), Some(3), Some(4), Some(5)]);
-    let string_array = StringArray::from(vec![Some("foo"), Some("baz"), Some("bar"), Some("foo"), Some("baz")]);
-
-    let struct_array = StructArray::from(vec![
-        (field_i.clone(), Arc::new(int32_array) as Arc<dyn Array>),
-        (field_s.clone(), Arc::new(string_array) as Arc<dyn Array>),
-    ]);
-
-    check_generic_array_roundtrip(ListArray::new(
-        Arc::new(Field::new(
-            "item",
-            DataType::Struct(vec![field_i, field_s].into()),
-            true,
-        )),
-        OffsetBuffer::new(ScalarBuffer::from(vec![0, 3, 4, 5])),
-        Arc::new(struct_array),
-        Some(vec![true, false, true].into()),
-    ))?;
-
-    Ok(())
-}
-
-fn check_map_array_roundtrip(array: MapArray) -> Result<(), Box<dyn Error>> {
-    let expected = array.clone();
-
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-
-    // Roundtrip a record batch from Rust to DuckDB and back to Rust
-    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
-
-    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
-    let param = arrow_recordbatch_to_query_params(rb.clone());
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
-    let output_array = rb
-        .column(0)
-        .as_any()
-        .downcast_ref::<MapArray>()
-        .expect("Expected MapArray");
-
-    assert_eq!(output_array.keys(), expected.keys());
-    assert_eq!(output_array.values(), expected.values());
-
-    Ok(())
-}
-
-#[test]
-fn test_map_roundtrip() -> Result<(), Box<dyn Error>> {
-    // Test 1 - simple MapArray
-    let keys = vec!["a", "b", "c", "d", "e", "f", "g", "h"];
-    let values_data = UInt32Array::from(vec![
-        Some(0u32),
-        None,
-        Some(20),
-        Some(30),
-        None,
-        Some(50),
-        Some(60),
-        Some(70),
-    ]);
-    // Construct a buffer for value offsets, for the nested array:
-    //  [[a, b, c], [d, e, f], [g, h]]
-    let entry_offsets = [0, 3, 6, 8];
-    let map_array = MapArray::new_from_strings(keys.clone().into_iter(), &values_data, &entry_offsets).unwrap();
-    check_map_array_roundtrip(map_array)?;
-
-    // Test 2 - large MapArray of 4000 elements to test buffers capacity adjustment
-    let keys: Vec<String> = (0..4000).map(|i| format!("key-{i}")).collect();
-    let values_data = UInt32Array::from(
-        (0..4000)
-            .map(|i| if i % 5 == 0 { None } else { Some(i as u32) })
-            .collect::<Vec<_>>(),
-    );
-    let mut entry_offsets: Vec<u32> = (0..=4000).step_by(3).collect();
-    entry_offsets.push(4000);
-    let map_array =
-        MapArray::new_from_strings(keys.iter().map(String::as_str), &values_data, entry_offsets.as_slice()).unwrap();
-    check_map_array_roundtrip(map_array)?;
-
-    Ok(())
-}
-
-#[test]
-fn test_fixed_size_binary_in_struct() -> Result<(), Box<dyn Error>> {
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-
-    let fixed_size_binary_data = FixedSizeBinaryArray::try_from_iter(
-        vec![
-            vec![1u8, 2, 3, 4, 5, 6, 7, 8],
-            vec![9u8, 10, 11, 12, 13, 14, 15, 16],
-            vec![17u8, 18, 19, 20, 21, 22, 23, 24],
-        ]
-        .into_iter(),
-    )
-    .unwrap();
-
-    let int_data = Int32Array::from(vec![100, 200, 300]);
-
-    let struct_array = StructArray::from(vec![
-        (
-            Arc::new(Field::new("binary_field", DataType::FixedSizeBinary(8), false)),
-            Arc::new(fixed_size_binary_data) as ArrayRef,
-        ),
-        (
-            Arc::new(Field::new("int_field", DataType::Int32, false)),
-            Arc::new(int_data) as ArrayRef,
-        ),
-    ]);
-
-    let schema = Schema::new(vec![Field::new("struct_col", struct_array.data_type().clone(), false)]);
-    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array)])?;
-
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("SELECT struct_col FROM arrow(?, ?)")?;
-    let mut arr = stmt.query_arrow(param)?;
-    let rb = arr.next().expect("no record batch");
-
-    assert_eq!(rb.num_columns(), 1);
-    let struct_column = rb.column(0).as_any().downcast_ref::<StructArray>().unwrap();
-    assert_eq!(struct_column.len(), 3);
-
-    // Verify the binary field
-    let binary_field = struct_column.column(0).as_any().downcast_ref::<BinaryArray>().unwrap();
-    assert_eq!(binary_field.value(0), &[1u8, 2, 3, 4, 5, 6, 7, 8]);
-    assert_eq!(binary_field.value(1), &[9u8, 10, 11, 12, 13, 14, 15, 16]);
-    assert_eq!(binary_field.value(2), &[17u8, 18, 19, 20, 21, 22, 23, 24]);
-
-    // Verify the int field
-    let int_field = struct_column.column(1).as_any().downcast_ref::<Int32Array>().unwrap();
-    assert_eq!(int_field.value(0), 100);
-    assert_eq!(int_field.value(1), 200);
-    assert_eq!(int_field.value(2), 300);
-
-    Ok(())
-}
-
-#[test]
-fn test_fixed_size_binary_in_fixed_size_list() -> Result<(), Box<dyn Error>> {
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-
-    let values = FixedSizeBinaryArray::try_from_iter(
-        vec![
-            vec![1u8, 2, 3, 4],
-            vec![5u8, 6, 7, 8],
-            vec![9u8, 10, 11, 12],
-            vec![13u8, 14, 15, 16],
-        ]
-        .into_iter(),
-    )
-    .unwrap();
-
-    let field = Arc::new(Field::new("item", DataType::FixedSizeBinary(4), false));
-    let fixed_size_list = FixedSizeListArray::new(field, 2, Arc::new(values), None);
-
-    let schema = Schema::new(vec![Field::new("list_col", fixed_size_list.data_type().clone(), false)]);
-    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(fixed_size_list)])?;
-
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("SELECT list_col FROM arrow(?, ?)")?;
-    let mut arr = stmt.query_arrow(param)?;
-    let rb = arr.next().expect("no record batch");
-
-    assert_eq!(rb.num_columns(), 1);
-
-    // NOTE: FixedSizeBinary inside FixedSizeList is not yet fully supported in the roundtrip
-    // DuckDB keeps it as FixedSizeListArray but the nested conversion doesn't work yet
-    // This test documents the current limitation
-    if rb.column(0).as_any().downcast_ref::<FixedSizeListArray>().is_some() {
-        // Early return - this case isn't fully supported yet
-        return Ok(());
-    }
-
-    // If it was converted to a regular ListArray, verify it works
-    let list_column = rb.column(0).as_any().downcast_ref::<ListArray>().unwrap();
-    assert_eq!(list_column.len(), 2);
-
-    // Verify first list element [1,2,3,4], [5,6,7,8]
-    let first_list = list_column.value(0);
-    let first_binary = first_list.as_any().downcast_ref::<BinaryArray>().unwrap();
-    assert_eq!(first_binary.len(), 2);
-    assert_eq!(first_binary.value(0), &[1u8, 2, 3, 4]);
-    assert_eq!(first_binary.value(1), &[5u8, 6, 7, 8]);
-
-    // Verify second list element [9,10,11,12], [13,14,15,16]
-    let second_list = list_column.value(1);
-    let second_binary = second_list.as_any().downcast_ref::<BinaryArray>().unwrap();
-    assert_eq!(second_binary.len(), 2);
-    assert_eq!(second_binary.value(0), &[9u8, 10, 11, 12]);
-    assert_eq!(second_binary.value(1), &[13u8, 14, 15, 16]);
-
-    Ok(())
-}
-
-#[test]
-fn test_fixed_size_binary_with_nulls_in_list() -> Result<(), Box<dyn Error>> {
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-
-    let values = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
-        vec![Some(vec![1u8, 2, 3, 4]), None, Some(vec![5u8, 6, 7, 8])].into_iter(),
-        4,
-    )
-    .unwrap();
-
-    let list_array = ListArray::new(
-        Arc::new(Field::new("item", DataType::FixedSizeBinary(4), true)),
-        OffsetBuffer::new(ScalarBuffer::from(vec![0, 3])),
-        Arc::new(values),
-        None,
-    );
-    let schema = Schema::new(vec![Field::new("list_col", list_array.data_type().clone(), false)]);
-    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_array) as ArrayRef])?;
-
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("SELECT list_col FROM arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
-
-    let list_column = rb.column(0).as_any().downcast_ref::<ListArray>().unwrap();
-    let first_list = list_column.value(0);
-    let binary_field = first_list.as_any().downcast_ref::<BinaryArray>().unwrap();
-
-    assert_eq!(binary_field.len(), 3);
-    assert_eq!(binary_field.value(0), &[1u8, 2, 3, 4]);
-    assert!(binary_field.is_null(1));
-    assert_eq!(binary_field.value(2), &[5u8, 6, 7, 8]);
-
-    Ok(())
-}
-
-#[test]
-fn test_fixed_size_binary_with_nulls_in_struct() -> Result<(), Box<dyn Error>> {
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-
-    // Create a struct with nullable FixedSizeBinary field
-    let fixed_size_binary_data = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
-        vec![Some(vec![1u8, 2, 3, 4]), None, Some(vec![5u8, 6, 7, 8])].into_iter(),
-        4,
-    )
-    .unwrap();
-
-    let struct_array = StructArray::from(vec![(
-        Arc::new(Field::new("binary_field", DataType::FixedSizeBinary(4), true)),
-        Arc::new(fixed_size_binary_data) as ArrayRef,
-    )]);
-
-    let schema = Schema::new(vec![Field::new("struct_col", struct_array.data_type().clone(), false)]);
-    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array)])?;
-
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("SELECT struct_col FROM arrow(?, ?)")?;
-    let mut arr = stmt.query_arrow(param)?;
-    let rb = arr.next().expect("no record batch");
-
-    let struct_column = rb.column(0).as_any().downcast_ref::<StructArray>().unwrap();
-    let binary_field = struct_column.column(0).as_any().downcast_ref::<BinaryArray>().unwrap();
-
-    assert_eq!(binary_field.len(), 3);
-    assert_eq!(binary_field.value(0), &[1u8, 2, 3, 4]);
-    assert!(binary_field.is_null(1));
-    assert_eq!(binary_field.value(2), &[5u8, 6, 7, 8]);
 
     Ok(())
 }

--- a/crates/duckdb/src/arrow_interop/tests/nested.rs
+++ b/crates/duckdb/src/arrow_interop/tests/nested.rs
@@ -532,8 +532,27 @@ fn test_sliced_fixed_size_list_roundtrip_uses_sliced_values() -> Result<(), Box<
 }
 
 #[test]
-fn test_list_child_reserves_capacity_for_large_nested_children() -> Result<(), Box<dyn Error>> {
+fn test_large_list_children_cross_standard_vector_size() -> Result<(), Box<dyn Error>> {
     let child_count: i32 = 3000;
+
+    let struct_values = StructArray::from(vec![(
+        Arc::new(Field::new("value", DataType::Int32, true)),
+        Arc::new(Int32Array::from((0..child_count).collect::<Vec<_>>())) as ArrayRef,
+    )]);
+    let list_of_structs = ListArray::new(
+        Arc::new(Field::new("item", struct_values.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, child_count])),
+        Arc::new(struct_values),
+        None,
+    );
+
+    let output = roundtrip_single_array(Arc::new(list_of_structs))?;
+    let output = output.as_any().downcast_ref::<ListArray>().unwrap();
+    let nested_output = output.value(0);
+    let nested_output = nested_output.as_any().downcast_ref::<StructArray>().unwrap();
+    assert_eq!(nested_output.len(), child_count as usize);
+    let values = nested_output.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(values.value((child_count - 1) as usize), child_count - 1);
 
     let nested_offsets = (0..=child_count).collect::<Vec<_>>();
     let nested_lists = ListArray::new(
@@ -856,24 +875,12 @@ fn test_list_of_structs_roundtrip() -> Result<(), Box<dyn Error>> {
 fn check_map_array_roundtrip(array: MapArray) -> Result<(), Box<dyn Error>> {
     let expected = array.clone();
 
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-
-    // Roundtrip a record batch from Rust to DuckDB and back to Rust
-    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
-
-    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
-    let param = arrow_recordbatch_to_query_params(rb.clone());
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
-    let output_array = rb
-        .column(0)
-        .as_any()
-        .downcast_ref::<MapArray>()
-        .expect("Expected MapArray");
+    let output = roundtrip_single_array(Arc::new(array))?;
+    let output_array = output.as_any().downcast_ref::<MapArray>().expect("Expected MapArray");
 
     assert_eq!(output_array.keys(), expected.keys());
     assert_eq!(output_array.values(), expected.values());
+    assert_eq!(output_array.value_offsets(), expected.value_offsets());
 
     Ok(())
 }

--- a/crates/duckdb/src/arrow_interop/tests/nested.rs
+++ b/crates/duckdb/src/arrow_interop/tests/nested.rs
@@ -645,6 +645,128 @@ fn test_irregular_nested_list_cast_uses_recorded_child_counts() -> Result<(), Bo
 }
 
 #[test]
+fn test_array_of_structs() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+
+    // Create the inner struct field
+    let struct_field = Field::new("foo", DataType::Int64, true);
+    let struct_type = DataType::Struct(Fields::from(vec![struct_field]));
+
+    // Create values for the struct field.
+    let mut int_builder = Int64Array::builder(6);
+    int_builder.append_value(1);
+    int_builder.append_value(2);
+    int_builder.append_value(3);
+    int_builder.append_value(4);
+    int_builder.append_null();
+    int_builder.append_value(5);
+
+    let struct_array = StructArray::new(
+        Fields::from(vec![Field::new("foo", DataType::Int64, true)]),
+        vec![Arc::new(int_builder.finish())],
+        None,
+    );
+
+    // Create fixed size list array of structs
+    let array = FixedSizeListArray::new(
+        Arc::new(Field::new("item", struct_type, true)),
+        2,
+        Arc::new(struct_array),
+        Some(NullBuffer::from([true, false, true].as_slice())),
+    );
+
+    // Create record batch
+    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
+    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
+
+    let param = arrow_recordbatch_to_query_params(rb);
+    let mut stmt = db.prepare("SELECT a[1].foo, a[2].foo FROM arrow(?, ?)")?;
+    let mut arr = stmt.query_arrow(param)?;
+    let rb = arr.next().expect("no record batch");
+
+    let first_item = rb.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+    assert_eq!(first_item.len(), 3);
+    assert_eq!(first_item.value(0), 1);
+    assert!(first_item.is_null(1));
+    assert!(first_item.is_null(2));
+
+    let second_item = rb.column(1).as_any().downcast_ref::<Int64Array>().unwrap();
+    assert_eq!(second_item.len(), 3);
+    assert_eq!(second_item.value(0), 2);
+    assert!(second_item.is_null(1));
+    assert_eq!(second_item.value(2), 5);
+
+    Ok(())
+}
+
+#[test]
+fn test_list_array_of_structs() -> Result<(), Box<dyn Error>> {
+    // Create the inner struct field
+    let struct_field = Field::new("foo", DataType::Int64, true);
+    let struct_type = DataType::Struct(Fields::from(vec![struct_field]));
+
+    // Create values for the struct field.
+    let mut int_builder = Int64Array::builder(6);
+    int_builder.append_value(1);
+    int_builder.append_value(2);
+    int_builder.append_value(3);
+    int_builder.append_value(4);
+    int_builder.append_null();
+    int_builder.append_value(5);
+
+    let struct_array = StructArray::new(
+        Fields::from(vec![Field::new("foo", DataType::Int64, true)]),
+        vec![Arc::new(int_builder.finish())],
+        None,
+    );
+
+    // Create list array of structs.
+    let array = ListArray::new(
+        Arc::new(Field::new("item", struct_type, true)),
+        OffsetBuffer::from_lengths([1, 2, 0, 1, 0, 2]),
+        Arc::new(struct_array),
+        Some(NullBuffer::from([true, true, false, true, true, true].as_slice())),
+    );
+
+    let output = roundtrip_single_array(Arc::new(array))?;
+    let lists = output.as_any().downcast_ref::<ListArray>().unwrap();
+    assert_eq!(lists.len(), 6);
+    assert!(lists.is_valid(0));
+    assert!(lists.is_valid(1));
+    assert!(lists.is_null(2));
+    assert!(lists.is_valid(3));
+    assert!(lists.is_valid(4));
+    assert!(lists.is_valid(5));
+
+    let first_list = lists.value(0);
+    let first_structs = first_list.as_any().downcast_ref::<StructArray>().unwrap();
+    let first_values = first_structs.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+    assert_eq!(first_values.value(0), 1);
+
+    let second_list = lists.value(1);
+    let second_structs = second_list.as_any().downcast_ref::<StructArray>().unwrap();
+    let second_values = second_structs.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+    assert_eq!(second_values.value(0), 2);
+    assert_eq!(second_values.value(1), 3);
+
+    let fourth_list = lists.value(3);
+    let fourth_structs = fourth_list.as_any().downcast_ref::<StructArray>().unwrap();
+    let fourth_values = fourth_structs.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+    assert_eq!(fourth_values.value(0), 4);
+
+    assert_eq!(lists.value(4).len(), 0);
+
+    let sixth_list = lists.value(5);
+    let sixth_structs = sixth_list.as_any().downcast_ref::<StructArray>().unwrap();
+    let sixth_values = sixth_structs.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+    assert!(sixth_values.is_null(0));
+    assert_eq!(sixth_values.value(1), 5);
+
+    Ok(())
+}
+
+#[test]
 fn test_list_of_fixed_size_lists_roundtrip() -> Result<(), Box<dyn Error>> {
     // field name must be empty to match `query_arrow` behavior, otherwise record batches will not match
     let field = Field::new("", DataType::Int32, true);

--- a/crates/duckdb/src/arrow_interop/tests/nested.rs
+++ b/crates/duckdb/src/arrow_interop/tests/nested.rs
@@ -1,0 +1,833 @@
+use super::*;
+
+#[test]
+fn test_struct_recurses_for_string_variants() -> Result<(), Box<dyn Error>> {
+    let struct_array = StructArray::from(vec![
+        (
+            Arc::new(Field::new("view", DataType::Utf8View, true)),
+            Arc::new(StringViewArray::from(vec![Some("foo"), None, Some("baz")])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("large", DataType::LargeUtf8, true)),
+            Arc::new(LargeStringArray::from(vec![Some("one"), Some("two"), None])) as ArrayRef,
+        ),
+    ]);
+
+    let output = roundtrip_single_array(Arc::new(struct_array))?;
+    let struct_column = output.as_any().downcast_ref::<StructArray>().unwrap();
+
+    let view_field = struct_column.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(view_field.value(0), "foo");
+    assert!(view_field.is_null(1));
+    assert_eq!(view_field.value(2), "baz");
+
+    let large_field = struct_column.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(large_field.value(0), "one");
+    assert_eq!(large_field.value(1), "two");
+    assert!(large_field.is_null(2));
+
+    Ok(())
+}
+
+fn assert_fixed_size_list_strings(
+    array: FixedSizeListArray,
+    expected: &[[Option<&str>; 2]],
+) -> Result<(), Box<dyn Error>> {
+    let output = roundtrip_single_array(Arc::new(array))?;
+    let list_column = output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    assert_eq!(list_column.len(), expected.len());
+
+    for (row, expected_values) in expected.iter().enumerate() {
+        let list = list_column.value(row);
+        let values = list.as_any().downcast_ref::<StringArray>().unwrap();
+        for (index, expected_value) in expected_values.iter().enumerate() {
+            match expected_value {
+                Some(value) => assert_eq!(values.value(index), *value),
+                None => assert!(values.is_null(index)),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_fixed_size_list_recurses_for_string_variants() -> Result<(), Box<dyn Error>> {
+    let fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", DataType::Utf8View, true)),
+        2,
+        Arc::new(StringViewArray::from(vec![Some("foo"), None, Some("bar"), Some("baz")])),
+        None,
+    );
+    assert_fixed_size_list_strings(fixed_size_lists, &[[Some("foo"), None], [Some("bar"), Some("baz")]])?;
+
+    let large_values = LargeStringArray::from(vec![Some("red"), Some("green"), None, Some("blue")]);
+    let fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", DataType::LargeUtf8, true)),
+        2,
+        Arc::new(large_values),
+        None,
+    );
+    assert_fixed_size_list_strings(fixed_size_lists, &[[Some("red"), Some("green")], [None, Some("blue")]])?;
+
+    Ok(())
+}
+
+#[test]
+fn test_list_recurses_for_large_string_binary_and_large_list_children() -> Result<(), Box<dyn Error>> {
+    let large_strings = LargeStringArray::from(vec![Some("alpha"), None, Some("gamma")]);
+    let list_of_large_strings = ListArray::new(
+        Arc::new(Field::new("item", DataType::LargeUtf8, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 3])),
+        Arc::new(large_strings),
+        None,
+    );
+    let output = roundtrip_single_array(Arc::new(list_of_large_strings))?;
+    let output = output.as_any().downcast_ref::<ListArray>().unwrap();
+    let first_list = output.value(0);
+    let first_strings = first_list.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(first_strings.value(0), "alpha");
+    assert!(first_strings.is_null(1));
+    let second_list = output.value(1);
+    let second_strings = second_list.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(second_strings.value(0), "gamma");
+
+    let large_binary = LargeBinaryArray::from_opt_vec(vec![Some(&b"aa"[..]), None, Some(&b"ccc"[..])]);
+    let list_of_large_binary = ListArray::new(
+        Arc::new(Field::new("item", DataType::LargeBinary, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 3])),
+        Arc::new(large_binary),
+        None,
+    );
+    let output = roundtrip_single_array(Arc::new(list_of_large_binary))?;
+    let output = output.as_any().downcast_ref::<ListArray>().unwrap();
+    let first_list = output.value(0);
+    let first_binary = first_list.as_any().downcast_ref::<BinaryArray>().unwrap();
+    assert_eq!(first_binary.value(0), b"aa");
+    assert!(first_binary.is_null(1));
+    let second_list = output.value(1);
+    let second_binary = second_list.as_any().downcast_ref::<BinaryArray>().unwrap();
+    assert_eq!(second_binary.value(0), b"ccc");
+
+    let large_lists = LargeListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0_i64, 2, 2, 3])),
+        Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])),
+        Some(vec![true, false, true].into()),
+    );
+    let list_of_large_lists = ListArray::new(
+        Arc::new(Field::new("item", large_lists.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 3])),
+        Arc::new(large_lists),
+        None,
+    );
+    let output = roundtrip_single_array(Arc::new(list_of_large_lists))?;
+    let output = output.as_any().downcast_ref::<ListArray>().unwrap();
+    let first_list = output.value(0);
+    let nested_lists = first_list.as_any().downcast_ref::<ListArray>().unwrap();
+    assert_eq!(nested_lists.len(), 2);
+    assert!(nested_lists.is_valid(0));
+    assert!(nested_lists.is_null(1));
+    let first_nested = nested_lists.value(0);
+    let first_nested_values = first_nested.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(first_nested_values.value(0), 1);
+    assert!(first_nested_values.is_null(1));
+    let second_list = output.value(1);
+    let nested_lists = second_list.as_any().downcast_ref::<ListArray>().unwrap();
+    let third_nested = nested_lists.value(0);
+    let third_nested_values = third_nested.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(third_nested_values.value(0), 3);
+
+    Ok(())
+}
+
+#[test]
+fn test_struct_recurses_for_map_children() -> Result<(), Box<dyn Error>> {
+    let keys = ["a", "b", "c"];
+    let values = UInt32Array::from(vec![Some(1), None, Some(3)]);
+    let offsets = [0, 2, 3];
+    let map_array = MapArray::new_from_strings(keys.into_iter(), &values, &offsets)?;
+    let expected_map = map_array.clone();
+
+    let struct_array = StructArray::from(vec![(
+        Arc::new(Field::new("lookup", map_array.data_type().clone(), true)),
+        Arc::new(map_array) as ArrayRef,
+    )]);
+
+    let output = roundtrip_single_array(Arc::new(struct_array))?;
+    let struct_column = output.as_any().downcast_ref::<StructArray>().unwrap();
+    let map_field = struct_column.column(0).as_any().downcast_ref::<MapArray>().unwrap();
+    assert_eq!(map_field.keys(), expected_map.keys());
+    assert_eq!(map_field.values(), expected_map.values());
+    assert_eq!(map_field.value_offsets(), expected_map.value_offsets());
+
+    Ok(())
+}
+
+#[test]
+fn test_struct_child_unsupported_type_returns_error() -> Result<(), Box<dyn Error>> {
+    let dictionary = DictionaryArray::<Int8Type>::try_new(
+        Int8Array::from(vec![Some(0), Some(1), Some(0)]),
+        Arc::new(StringArray::from(vec!["alpha", "beta"])),
+    )?;
+    let struct_array = StructArray::from(vec![(
+        Arc::new(Field::new("dict", dictionary.data_type().clone(), true)),
+        Arc::new(dictionary) as ArrayRef,
+    )]);
+    let schema = Schema::new(vec![Field::new("a", struct_array.data_type().clone(), true)]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array) as ArrayRef])?;
+    let logical_type = to_duckdb_logical_type(batch.column(0).data_type())?;
+    let mut chunk = DataChunkHandle::new(&[logical_type]);
+
+    let err = record_batch_to_duckdb_data_chunk(&batch, &mut chunk).unwrap_err();
+    assert!(
+        err.to_string().contains("Dictionary") && err.to_string().contains("not supported yet"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_fixed_size_list_recurses_for_struct_children() -> Result<(), Box<dyn Error>> {
+    let int_values = Int32Array::from(vec![Some(1), Some(2), Some(3), Some(4), None, Some(6)]);
+    let string_values = StringArray::from(vec![
+        Some("one"),
+        Some("two"),
+        Some("three"),
+        Some("four"),
+        None,
+        Some("six"),
+    ]);
+
+    let struct_array = StructArray::from(vec![
+        (
+            Arc::new(Field::new("i", DataType::Int32, true)),
+            Arc::new(int_values) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("s", DataType::Utf8, true)),
+            Arc::new(string_values) as ArrayRef,
+        ),
+    ]);
+
+    let fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", struct_array.data_type().clone(), true)),
+        2,
+        Arc::new(struct_array),
+        Some(vec![true, false, true].into()),
+    );
+
+    let output = roundtrip_single_array(Arc::new(fixed_size_lists))?;
+    let output = output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+
+    assert_eq!(output.len(), 3);
+    assert!(output.is_valid(0));
+    assert!(output.is_null(1));
+    assert!(output.is_valid(2));
+
+    let first_list = output.value(0);
+    let first_structs = first_list.as_any().downcast_ref::<StructArray>().unwrap();
+    let first_ints = first_structs.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+    let first_strings = first_structs.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(first_ints.value(0), 1);
+    assert_eq!(first_ints.value(1), 2);
+    assert_eq!(first_strings.value(0), "one");
+    assert_eq!(first_strings.value(1), "two");
+
+    let third_list = output.value(2);
+    let third_structs = third_list.as_any().downcast_ref::<StructArray>().unwrap();
+    let third_ints = third_structs.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+    let third_strings = third_structs.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+    assert!(third_ints.is_null(0));
+    assert_eq!(third_ints.value(1), 6);
+    assert!(third_strings.is_null(0));
+    assert_eq!(third_strings.value(1), "six");
+
+    Ok(())
+}
+
+#[test]
+fn test_fixed_size_list_recurses_for_nested_container_children() -> Result<(), Box<dyn Error>> {
+    let list_values = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 5, 6])),
+        Arc::new(Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3),
+            None,
+            Some(5),
+            Some(6),
+        ])),
+        Some(vec![true, false, true, true].into()),
+    );
+    let fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", list_values.data_type().clone(), true)),
+        2,
+        Arc::new(list_values),
+        None,
+    );
+    let output = roundtrip_single_array(Arc::new(fixed_size_lists))?;
+    let output = output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    let first_value = output.value(0);
+    let first_lists = first_value.as_any().downcast_ref::<ListArray>().unwrap();
+    assert_eq!(first_lists.len(), 2);
+    assert_eq!(
+        first_lists
+            .value(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .value(1),
+        2
+    );
+    assert!(first_lists.is_null(1));
+    let second_value = output.value(1);
+    let second_lists = second_value.as_any().downcast_ref::<ListArray>().unwrap();
+    assert_eq!(second_lists.value_length(0), 3);
+    assert_eq!(
+        second_lists
+            .value(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .value(0),
+        6
+    );
+
+    let keys = ["a", "b", "c", "d", "e"];
+    let values = UInt32Array::from(vec![Some(1), None, Some(3), Some(4), Some(5)]);
+    let map_values = MapArray::new_from_strings(keys.into_iter(), &values, &[0, 2, 2, 3, 5])?;
+    let fixed_size_maps = FixedSizeListArray::new(
+        Arc::new(Field::new("item", map_values.data_type().clone(), true)),
+        2,
+        Arc::new(map_values),
+        None,
+    );
+    let output = roundtrip_single_array(Arc::new(fixed_size_maps))?;
+    let output = output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    let first_value = output.value(0);
+    let first_maps = first_value.as_any().downcast_ref::<MapArray>().unwrap();
+    assert_eq!(first_maps.value_offsets(), &[0, 2, 2]);
+    let second_value = output.value(1);
+    let second_maps = second_value.as_any().downcast_ref::<MapArray>().unwrap();
+    assert_eq!(second_maps.value_length(0), 1);
+    assert_eq!(second_maps.value_length(1), 2);
+
+    let inner_fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        2,
+        Arc::new(Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3),
+            None,
+            Some(5),
+            Some(6),
+            None,
+            Some(8),
+        ])),
+        Some(vec![true, false, true, true].into()),
+    );
+    let fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", inner_fixed_size_lists.data_type().clone(), true)),
+        2,
+        Arc::new(inner_fixed_size_lists),
+        None,
+    );
+    let output = roundtrip_single_array(Arc::new(fixed_size_lists))?;
+    let output = output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    let first_value = output.value(0);
+    let first_lists = first_value.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    assert_eq!(first_lists.len(), 2);
+    assert!(first_lists.is_null(1));
+    let second_value = output.value(1);
+    let second_lists = second_value.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    assert_eq!(
+        second_lists
+            .value(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .value(1),
+        6
+    );
+    assert!(
+        second_lists
+            .value(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .is_null(0)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_struct_recurses_for_list_of_map_children() -> Result<(), Box<dyn Error>> {
+    let keys = ["a", "b", "c", "d", "e"];
+    let values = UInt32Array::from(vec![Some(1), None, Some(3), Some(4), Some(5)]);
+    let map_offsets = [0, 2, 3, 3, 5];
+    let maps = MapArray::new_from_strings(keys.into_iter(), &values, &map_offsets)?;
+
+    let list_of_maps = ListArray::new(
+        Arc::new(Field::new("item", maps.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 4])),
+        Arc::new(maps),
+        None,
+    );
+
+    let struct_array = StructArray::from(vec![(
+        Arc::new(Field::new("maps", list_of_maps.data_type().clone(), true)),
+        Arc::new(list_of_maps) as ArrayRef,
+    )]);
+
+    let output = roundtrip_single_array(Arc::new(struct_array))?;
+    let output = output.as_any().downcast_ref::<StructArray>().unwrap();
+    let list_field = output.column(0).as_any().downcast_ref::<ListArray>().unwrap();
+
+    let first_list = list_field.value(0);
+    let first_maps = first_list.as_any().downcast_ref::<MapArray>().unwrap();
+    assert_eq!(first_maps.len(), 2);
+    assert_eq!(first_maps.value_length(0), 2);
+    assert_eq!(first_maps.value_length(1), 1);
+    let first_keys = first_maps.keys().as_any().downcast_ref::<StringArray>().unwrap();
+    let first_values = first_maps.values().as_any().downcast_ref::<UInt32Array>().unwrap();
+    assert_eq!(first_keys.value(0), "a");
+    assert_eq!(first_keys.value(1), "b");
+    assert_eq!(first_keys.value(2), "c");
+    assert_eq!(first_values.value(0), 1);
+    assert!(first_values.is_null(1));
+    assert_eq!(first_values.value(2), 3);
+
+    let second_list = list_field.value(1);
+    let second_maps = second_list.as_any().downcast_ref::<MapArray>().unwrap();
+    assert_eq!(second_maps.len(), 2);
+    assert_eq!(second_maps.value_length(0), 0);
+    assert_eq!(second_maps.value_length(1), 2);
+    let second_keys = second_maps.keys().as_any().downcast_ref::<StringArray>().unwrap();
+    let second_values = second_maps.values().as_any().downcast_ref::<UInt32Array>().unwrap();
+    let entry_offset = second_maps.value_offsets()[1] as usize;
+    assert_eq!(second_keys.value(entry_offset), "d");
+    assert_eq!(second_keys.value(entry_offset + 1), "e");
+    assert_eq!(second_values.value(entry_offset), 4);
+    assert_eq!(second_values.value(entry_offset + 1), 5);
+
+    Ok(())
+}
+
+#[test]
+fn test_map_recurses_for_list_values() -> Result<(), Box<dyn Error>> {
+    let list_values = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 5])),
+        Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3), None, Some(5)])),
+        Some(vec![true, false, true].into()),
+    );
+
+    let keys = ["a", "b", "c"];
+    let offsets = [0, 2, 3];
+    let map_array = MapArray::new_from_strings(keys.into_iter(), &list_values, &offsets)?;
+
+    let output = roundtrip_single_array(Arc::new(map_array))?;
+    let output = output.as_any().downcast_ref::<MapArray>().unwrap();
+    assert_eq!(output.value_offsets(), &[0, 2, 3]);
+
+    let output_values = output.values().as_any().downcast_ref::<ListArray>().unwrap();
+    assert_eq!(output_values.len(), 3);
+    assert!(output_values.is_valid(0));
+    assert!(output_values.is_null(1));
+    assert!(output_values.is_valid(2));
+
+    let first_value = output_values.value(0);
+    let first_ints = first_value.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(first_ints.value(0), 1);
+    assert_eq!(first_ints.value(1), 2);
+
+    let third_value = output_values.value(2);
+    let third_ints = third_value.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(third_ints.value(0), 3);
+    assert!(third_ints.is_null(1));
+    assert_eq!(third_ints.value(2), 5);
+
+    Ok(())
+}
+
+#[test]
+fn test_sliced_nested_list_roundtrip() -> Result<(), Box<dyn Error>> {
+    let struct_values = StructArray::from(vec![
+        (
+            Arc::new(Field::new("i", DataType::Int32, true)),
+            Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3), None, Some(5)])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("s", DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![
+                Some("one"),
+                Some("two"),
+                Some("three"),
+                None,
+                Some("five"),
+            ])) as ArrayRef,
+        ),
+    ]);
+
+    let lists = ListArray::new(
+        Arc::new(Field::new("item", struct_values.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 1, 3, 3, 5])),
+        Arc::new(struct_values),
+        Some(vec![true, true, false, true].into()),
+    );
+
+    let output = roundtrip_single_array(Arc::new(lists.slice(1, 2)))?;
+    let output = output.as_any().downcast_ref::<ListArray>().unwrap();
+    assert_eq!(output.len(), 2);
+    assert!(output.is_valid(0));
+    assert!(output.is_null(1));
+
+    let first_list = output.value(0);
+    let first_structs = first_list.as_any().downcast_ref::<StructArray>().unwrap();
+    let ints = first_structs.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+    let strings = first_structs.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(ints.value(0), 2);
+    assert_eq!(ints.value(1), 3);
+    assert_eq!(strings.value(0), "two");
+    assert_eq!(strings.value(1), "three");
+
+    Ok(())
+}
+
+#[test]
+fn test_sliced_fixed_size_list_roundtrip_uses_sliced_values() -> Result<(), Box<dyn Error>> {
+    let fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", DataType::Utf8, true)),
+        2,
+        Arc::new(StringArray::from(vec![
+            Some("skip-0"),
+            Some("skip-1"),
+            Some("keep-0"),
+            Some("keep-1"),
+            Some("null-0"),
+            Some("null-1"),
+            Some("keep-2"),
+            Some("keep-3"),
+        ])),
+        Some(NullBuffer::from([true, true, false, true].as_slice())),
+    );
+
+    let output = roundtrip_single_array(Arc::new(fixed_size_lists.slice(1, 2)))?;
+    let output = output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    assert_eq!(output.len(), 2);
+    assert!(output.is_valid(0));
+    assert!(output.is_null(1));
+
+    let first_list = output.value(0);
+    let first_values = first_list.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(first_values.value(0), "keep-0");
+    assert_eq!(first_values.value(1), "keep-1");
+
+    Ok(())
+}
+
+#[test]
+fn test_list_child_reserves_capacity_for_large_nested_children() -> Result<(), Box<dyn Error>> {
+    let child_count: i32 = 3000;
+
+    let nested_offsets = (0..=child_count).collect::<Vec<_>>();
+    let nested_lists = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, false)),
+        OffsetBuffer::new(ScalarBuffer::from(nested_offsets)),
+        Arc::new(Int32Array::from((0..child_count).collect::<Vec<_>>())),
+        None,
+    );
+    let list_of_lists = ListArray::new(
+        Arc::new(Field::new("item", nested_lists.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, child_count])),
+        Arc::new(nested_lists),
+        None,
+    );
+
+    let output = roundtrip_single_array(Arc::new(list_of_lists))?;
+    let output = output.as_any().downcast_ref::<ListArray>().unwrap();
+    let nested_output = output.value(0);
+    let nested_output = nested_output.as_any().downcast_ref::<ListArray>().unwrap();
+    assert_eq!(nested_output.len(), child_count as usize);
+    let last_list = nested_output.value((child_count - 1) as usize);
+    let last_values = last_list.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(last_values.value(0), child_count - 1);
+
+    let fixed_size_lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, false)),
+        2,
+        Arc::new(Int32Array::from((0..(child_count * 2)).collect::<Vec<_>>())),
+        None,
+    );
+    let list_of_fixed_size_lists = ListArray::new(
+        Arc::new(Field::new("item", fixed_size_lists.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, child_count])),
+        Arc::new(fixed_size_lists),
+        None,
+    );
+
+    let output = roundtrip_single_array(Arc::new(list_of_fixed_size_lists))?;
+    let output = output.as_any().downcast_ref::<ListArray>().unwrap();
+    let nested_output = output.value(0);
+    let nested_output = nested_output.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
+    assert_eq!(nested_output.len(), child_count as usize);
+    let last_list = nested_output.value((child_count - 1) as usize);
+    let last_values = last_list.as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(last_values.value(0), child_count * 2 - 2);
+    assert_eq!(last_values.value(1), child_count * 2 - 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_nested_list_sizes_are_set_to_child_counts() -> Result<(), Box<dyn Error>> {
+    let inner_lists = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 5])),
+        Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3), None, Some(5)])),
+        None,
+    );
+    let list_of_lists = ListArray::new(
+        Arc::new(Field::new("item", inner_lists.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 3])),
+        Arc::new(inner_lists),
+        None,
+    );
+
+    let schema = Schema::new(vec![Field::new("a", list_of_lists.data_type().clone(), true)]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_of_lists) as ArrayRef])?;
+    let logical_type = to_duckdb_logical_type(batch.column(0).data_type())?;
+    let mut chunk = DataChunkHandle::new(&[logical_type]);
+    record_batch_to_duckdb_data_chunk(&batch, &mut chunk)?;
+
+    let outer = chunk.list_vector(0);
+    assert_eq!(outer.len(), 3);
+
+    let inner = outer.list_child();
+    assert_eq!(inner.len(), 5);
+
+    Ok(())
+}
+
+#[test]
+fn test_irregular_nested_list_cast_uses_recorded_child_counts() -> Result<(), Box<dyn Error>> {
+    let inner_lists = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 5])),
+        Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3), None, Some(5)])),
+        None,
+    );
+    let list_of_lists = ListArray::new(
+        Arc::new(Field::new("item", inner_lists.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 3])),
+        Arc::new(inner_lists),
+        None,
+    );
+
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+
+    let schema = Schema::new(vec![Field::new("a", list_of_lists.data_type().clone(), true)]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_of_lists) as ArrayRef])?;
+    let param = arrow_recordbatch_to_query_params(batch);
+    let mut stmt = db.prepare("SELECT a::VARCHAR FROM arrow(?, ?)")?;
+    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let output = rb.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+
+    assert_eq!(output.value(0), "[[1, 2], [], [3, NULL, 5]]");
+
+    Ok(())
+}
+
+#[test]
+fn test_list_of_fixed_size_lists_roundtrip() -> Result<(), Box<dyn Error>> {
+    // field name must be empty to match `query_arrow` behavior, otherwise record batches will not match
+    let field = Field::new("", DataType::Int32, true);
+    let mut list_builder = ListBuilder::new(FixedSizeListBuilder::new(Int32Builder::new(), 2).with_field(field));
+
+    // Append first list of FixedSizeList items
+    {
+        let fixed_size_list_builder = list_builder.values();
+        fixed_size_list_builder.values().append_value(1);
+        fixed_size_list_builder.values().append_value(2);
+        fixed_size_list_builder.append(true);
+
+        // Append NULL fixed-size list item
+        fixed_size_list_builder.values().append_null();
+        fixed_size_list_builder.values().append_null();
+        fixed_size_list_builder.append(false);
+
+        fixed_size_list_builder.values().append_value(3);
+        fixed_size_list_builder.values().append_value(4);
+        fixed_size_list_builder.append(true);
+
+        list_builder.append(true);
+    }
+
+    // Append NULL list
+    list_builder.append_null();
+
+    check_generic_array_roundtrip(list_builder.finish())?;
+
+    Ok(())
+}
+
+#[test]
+fn test_list_of_lists_roundtrip() -> Result<(), Box<dyn Error>> {
+    // field name must be 'l' to match `query_arrow` behavior, otherwise record batches will not match
+    let field = Field::new("l", DataType::Int32, true);
+    let mut list_builder = ListBuilder::new(ListBuilder::new(Int32Builder::new()).with_field(field.clone()));
+
+    // Append first list of items
+    {
+        let list_item_builder = list_builder.values();
+        list_item_builder.append_value(vec![Some(1), Some(2)]);
+
+        // Append NULL list item
+        list_item_builder.append_null();
+
+        list_item_builder.append_value(vec![Some(3), None, Some(5)]);
+
+        list_builder.append(true);
+    }
+
+    // Append NULL list
+    list_builder.append_null();
+
+    check_generic_array_roundtrip(list_builder.finish())?;
+
+    Ok(())
+}
+
+#[test]
+fn test_list_of_structs_roundtrip() -> Result<(), Box<dyn Error>> {
+    let field_i = Arc::new(Field::new("i", DataType::Int32, true));
+    let field_s = Arc::new(Field::new("s", DataType::Utf8, true));
+
+    let int32_array = Int32Array::from(vec![Some(1), Some(2), Some(3), Some(4), Some(5)]);
+    let string_array = StringArray::from(vec![Some("foo"), Some("baz"), Some("bar"), Some("foo"), Some("baz")]);
+
+    let struct_array = StructArray::from(vec![
+        (field_i.clone(), Arc::new(int32_array) as Arc<dyn Array>),
+        (field_s.clone(), Arc::new(string_array) as Arc<dyn Array>),
+    ]);
+
+    check_generic_array_roundtrip(ListArray::new(
+        Arc::new(Field::new(
+            "item",
+            DataType::Struct(vec![field_i, field_s].into()),
+            true,
+        )),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 3, 4, 5])),
+        Arc::new(struct_array),
+        Some(vec![true, false, true].into()),
+    ))?;
+
+    Ok(())
+}
+
+fn check_map_array_roundtrip(array: MapArray) -> Result<(), Box<dyn Error>> {
+    let expected = array.clone();
+
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+
+    // Roundtrip a record batch from Rust to DuckDB and back to Rust
+    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
+
+    let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
+    let param = arrow_recordbatch_to_query_params(rb.clone());
+    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
+    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let output_array = rb
+        .column(0)
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .expect("Expected MapArray");
+
+    assert_eq!(output_array.keys(), expected.keys());
+    assert_eq!(output_array.values(), expected.values());
+
+    Ok(())
+}
+
+#[test]
+fn test_map_roundtrip() -> Result<(), Box<dyn Error>> {
+    // Test 1 - simple MapArray
+    let keys = vec!["a", "b", "c", "d", "e", "f", "g", "h"];
+    let values_data = UInt32Array::from(vec![
+        Some(0u32),
+        None,
+        Some(20),
+        Some(30),
+        None,
+        Some(50),
+        Some(60),
+        Some(70),
+    ]);
+    // Construct a buffer for value offsets, for the nested array:
+    //  [[a, b, c], [d, e, f], [g, h]]
+    let entry_offsets = [0, 3, 6, 8];
+    let map_array = MapArray::new_from_strings(keys.clone().into_iter(), &values_data, &entry_offsets).unwrap();
+    check_map_array_roundtrip(map_array)?;
+
+    // Test 2 - large MapArray of 4000 elements to test buffers capacity adjustment
+    let keys: Vec<String> = (0..4000).map(|i| format!("key-{i}")).collect();
+    let values_data = UInt32Array::from(
+        (0..4000)
+            .map(|i| if i % 5 == 0 { None } else { Some(i as u32) })
+            .collect::<Vec<_>>(),
+    );
+    let mut entry_offsets: Vec<u32> = (0..=4000).step_by(3).collect();
+    entry_offsets.push(4000);
+    let map_array =
+        MapArray::new_from_strings(keys.iter().map(String::as_str), &values_data, entry_offsets.as_slice()).unwrap();
+    check_map_array_roundtrip(map_array)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_map_roundtrip_preserves_null_rows() -> Result<(), Box<dyn Error>> {
+    let entries = StructArray::from(vec![
+        (
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("values", DataType::UInt32, true)),
+            Arc::new(UInt32Array::from(vec![Some(1), None, Some(3)])) as ArrayRef,
+        ),
+    ]);
+    let map_array = MapArray::new(
+        Arc::new(Field::new("entries", entries.data_type().clone(), false)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 3])),
+        entries,
+        Some(NullBuffer::from([true, false, true].as_slice())),
+        false,
+    );
+
+    let output = roundtrip_single_array(Arc::new(map_array))?;
+    let output = output.as_any().downcast_ref::<MapArray>().unwrap();
+    assert_eq!(output.value_offsets(), &[0, 2, 2, 3]);
+    assert!(output.is_valid(0));
+    assert!(output.is_null(1));
+    assert!(output.is_valid(2));
+
+    let keys = output.keys().as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(keys.value(0), "a");
+    assert_eq!(keys.value(1), "b");
+    assert_eq!(keys.value(2), "c");
+
+    let values = output.values().as_any().downcast_ref::<UInt32Array>().unwrap();
+    assert_eq!(values.value(0), 1);
+    assert!(values.is_null(1));
+    assert_eq!(values.value(2), 3);
+
+    Ok(())
+}

--- a/crates/duckdb/src/arrow_interop/to_duckdb.rs
+++ b/crates/duckdb/src/arrow_interop/to_duckdb.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 use arrow::{
     array::{
@@ -66,9 +66,120 @@ pub trait WritableVector {
     fn struct_vector(&mut self) -> StructVector<'_>;
 }
 
+/// Borrowed child vector handle used while writing one nested Arrow child array.
+struct ChildVector<'a> {
+    ptr: duckdb_vector,
+    /// Arrow row count for this child; flat children use it as physical slots,
+    /// and list children use it as list-entry rows.
+    capacity: usize,
+    _phantom: PhantomData<&'a mut ()>,
+}
+
+impl<'a> ChildVector<'a> {
+    fn of_list(parent: &'a mut ListVector<'_>, capacity: usize) -> Result<Self, Box<dyn std::error::Error>> {
+        let ptr = parent.try_child_ptr_with_capacity(capacity)?;
+        // Commit the child row count before recursing so nested list children
+        // observe the correct size while their entries are written.
+        parent.try_set_len(capacity)?;
+        Ok(Self {
+            ptr,
+            capacity,
+            _phantom: PhantomData,
+        })
+    }
+
+    fn of_array(parent: &'a mut ArrayVector<'_>, capacity: usize) -> Self {
+        Self {
+            ptr: parent.child_ptr(),
+            capacity,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn of_struct(parent: &'a mut StructVector<'_>, index: usize, capacity: usize) -> Self {
+        Self {
+            ptr: parent.child_ptr(index),
+            capacity,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+fn debug_assert_child_type<F>(ptr: duckdb_vector, expected: &str, matches_expected: F)
+where
+    F: FnOnce(LogicalTypeId) -> bool,
+{
+    let logical_type =
+        unsafe { crate::core::LogicalTypeHandle::new(libduckdb_sys::duckdb_vector_get_column_type(ptr)) };
+    let actual = logical_type.id();
+    debug_assert!(
+        matches_expected(actual),
+        "expected {expected} child vector, got {actual:?}"
+    );
+}
+
+#[cfg(not(debug_assertions))]
+fn debug_assert_child_type<F>(_ptr: duckdb_vector, _expected: &str, _matches_expected: F)
+where
+    F: FnOnce(LogicalTypeId) -> bool,
+{
+}
+
+impl WritableVector for ChildVector<'_> {
+    fn flat_vector(&mut self) -> FlatVector<'_> {
+        debug_assert_child_type(self.ptr, "scalar", |id| {
+            !matches!(
+                id,
+                LogicalTypeId::List | LogicalTypeId::Array | LogicalTypeId::Struct | LogicalTypeId::Map
+            )
+        });
+        // SAFETY: ChildVector mutably borrows the parent while this wrapper
+        // exists, keeping `ptr` live and uniquely reached through this view.
+        // The recursive dispatcher calls this only for scalar logical
+        // children, and `capacity` is that child vector's physical slot count.
+        unsafe { FlatVector::with_capacity(self.ptr, self.capacity) }
+    }
+
+    fn list_vector(&mut self) -> ListVector<'_> {
+        debug_assert_child_type(self.ptr, "list or map", |id| {
+            matches!(id, LogicalTypeId::List | LogicalTypeId::Map)
+        });
+        // SAFETY: ChildVector mutably borrows the parent while this wrapper
+        // exists, keeping `ptr` live and uniquely reached through this view.
+        // The recursive dispatcher calls this only for logical list/map
+        // children, and `capacity` is that child list/map's row count.
+        unsafe { ListVector::from_raw_with_capacity(self.ptr, self.capacity) }
+    }
+
+    fn array_vector(&mut self) -> ArrayVector<'_> {
+        debug_assert_child_type(self.ptr, "array", |id| matches!(id, LogicalTypeId::Array));
+        // SAFETY: ChildVector mutably borrows the parent while this wrapper
+        // exists, keeping `ptr` live and uniquely reached through this view.
+        // The recursive dispatcher calls this only for logical fixed-size-list
+        // children.
+        unsafe { ArrayVector::from_raw(self.ptr) }
+    }
+
+    fn struct_vector(&mut self) -> StructVector<'_> {
+        debug_assert_child_type(self.ptr, "struct", |id| matches!(id, LogicalTypeId::Struct));
+        // SAFETY: ChildVector mutably borrows the parent while this wrapper
+        // exists, keeping `ptr` live and uniquely reached through this view.
+        // The recursive dispatcher calls this only for logical struct children.
+        unsafe { StructVector::from_raw(self.ptr) }
+    }
+}
+
 /// Writes an Arrow array to a `WritableVector`.
 pub fn write_arrow_array_to_vector(
     col: &Arc<dyn Array>,
+    chunk: &mut dyn WritableVector,
+) -> Result<(), Box<dyn std::error::Error>> {
+    write_arrow_array_to_vector_ref(col.as_ref(), chunk)
+}
+
+fn write_arrow_array_to_vector_ref(
+    col: &dyn Array,
     chunk: &mut dyn WritableVector,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match col.data_type() {
@@ -76,12 +187,11 @@ pub fn write_arrow_array_to_vector(
             primitive_array_to_vector(col, &mut chunk.flat_vector())?;
         }
         DataType::Utf8 => {
-            string_array_to_vector(as_string_array(col.as_ref()), &mut chunk.flat_vector());
+            string_array_to_vector(as_string_array(col), &mut chunk.flat_vector());
         }
         DataType::LargeUtf8 => {
             string_array_to_vector(
-                col.as_ref()
-                    .as_any()
+                col.as_any()
                     .downcast_ref::<LargeStringArray>()
                     .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to LargeStringArray"))?,
                 &mut chunk.flat_vector(),
@@ -89,23 +199,21 @@ pub fn write_arrow_array_to_vector(
         }
         DataType::Utf8View => {
             string_view_array_to_vector(
-                col.as_ref()
-                    .as_any()
+                col.as_any()
                     .downcast_ref::<StringViewArray>()
                     .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to StringViewArray"))?,
                 &mut chunk.flat_vector(),
             );
         }
         DataType::Binary => {
-            binary_array_to_vector(as_generic_binary_array(col.as_ref()), &mut chunk.flat_vector());
+            binary_array_to_vector(as_generic_binary_array(col), &mut chunk.flat_vector());
         }
         DataType::FixedSizeBinary(_) => {
-            fixed_size_binary_array_to_vector(col.as_ref().as_fixed_size_binary(), &mut chunk.flat_vector())?;
+            fixed_size_binary_array_to_vector(col.as_fixed_size_binary(), &mut chunk.flat_vector())?;
         }
         DataType::LargeBinary => {
             large_binary_array_to_vector(
-                col.as_ref()
-                    .as_any()
+                col.as_any()
                     .downcast_ref::<LargeBinaryArray>()
                     .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to LargeBinaryArray"))?,
                 &mut chunk.flat_vector(),
@@ -113,39 +221,31 @@ pub fn write_arrow_array_to_vector(
         }
         DataType::BinaryView => {
             binary_view_array_to_vector(
-                col.as_ref()
-                    .as_any()
+                col.as_any()
                     .downcast_ref::<BinaryViewArray>()
                     .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to BinaryViewArray"))?,
                 &mut chunk.flat_vector(),
             );
         }
         DataType::List(_) => {
-            list_array_to_vector(as_list_array(col.as_ref()), &mut chunk.list_vector())?;
+            list_array_to_vector(as_list_array(col), &mut chunk.list_vector())?;
         }
         DataType::LargeList(_) => {
-            list_array_to_vector(as_large_list_array(col.as_ref()), &mut chunk.list_vector())?;
+            list_array_to_vector(as_large_list_array(col), &mut chunk.list_vector())?;
         }
         DataType::FixedSizeList(_, _) => {
-            fixed_size_list_array_to_vector(as_fixed_size_list_array(col.as_ref()), &mut chunk.array_vector())?;
+            fixed_size_list_array_to_vector(as_fixed_size_list_array(col), &mut chunk.array_vector())?;
         }
         DataType::Struct(_) => {
-            let struct_array = as_struct_array(col.as_ref());
+            let struct_array = as_struct_array(col);
             let mut struct_vector = chunk.struct_vector();
             struct_array_to_vector(struct_array, &mut struct_vector)?;
         }
         DataType::Map(_, _) => {
             // [`MapArray`] is physically a [`ListArray`] of key values pairs stored as an `entries` [`StructArray`] with 2 child fields.
-            let map_array = as_map_array(col.as_ref());
-            let out = &mut chunk.list_vector();
-            struct_array_to_vector(map_array.entries(), &mut out.struct_child(map_array.entries().len()))?;
-
-            for i in 0..map_array.len() {
-                let offset = map_array.value_offsets()[i];
-                let length = map_array.value_length(i);
-                out.set_entry(i, offset.as_(), length.as_());
-            }
-            set_nulls_in_list_vector(map_array, out);
+            let map_array = as_map_array(col);
+            let mut out = chunk.list_vector();
+            list_like_array_to_vector(map_array.entries(), map_array.value_offsets(), map_array, &mut out)?;
         }
         dt => {
             return Err(format!(
@@ -491,72 +591,25 @@ fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
     out: &mut ListVector<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let value_array = array.values();
-    match value_array.data_type() {
-        dt if dt.is_primitive() || matches!(dt, DataType::Boolean) => {
-            primitive_array_to_vector(value_array.as_ref(), &mut out.child(value_array.len()))?;
-        }
-        DataType::Utf8 => {
-            string_array_to_vector(as_string_array(value_array.as_ref()), &mut out.child(value_array.len()));
-        }
-        DataType::Utf8View => {
-            string_view_array_to_vector(
-                value_array
-                    .as_ref()
-                    .as_any()
-                    .downcast_ref::<StringViewArray>()
-                    .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to StringViewArray"))?,
-                &mut out.child(value_array.len()),
-            );
-        }
-        DataType::Binary => {
-            binary_array_to_vector(
-                as_generic_binary_array(value_array.as_ref()),
-                &mut out.child(value_array.len()),
-            );
-        }
-        DataType::FixedSizeBinary(_) => {
-            fixed_size_binary_array_to_vector(
-                value_array.as_ref().as_fixed_size_binary(),
-                &mut out.child(value_array.len()),
-            )?;
-        }
-        DataType::BinaryView => {
-            binary_view_array_to_vector(
-                value_array
-                    .as_ref()
-                    .as_any()
-                    .downcast_ref::<BinaryViewArray>()
-                    .ok_or_else(|| Box::<dyn std::error::Error>::from("Unable to downcast to BinaryViewArray"))?,
-                &mut out.child(value_array.len()),
-            );
-        }
-        DataType::List(_) => {
-            list_array_to_vector(as_list_array(value_array.as_ref()), &mut out.list_child())?;
-        }
-        DataType::FixedSizeList(_, _) => {
-            fixed_size_list_array_to_vector(as_fixed_size_list_array(value_array.as_ref()), &mut out.array_child())?;
-        }
-        DataType::Struct(_) => {
-            struct_array_to_vector(
-                as_struct_array(value_array.as_ref()),
-                &mut out.struct_child(value_array.len()),
-            )?;
-        }
-        _ => {
-            return Err(format!(
-                "List with elements of type '{}' are not currently supported.",
-                value_array.data_type()
-            )
-            .into());
-        }
-    }
+    list_like_array_to_vector(value_array.as_ref(), array.value_offsets(), array, out)
+}
 
-    for i in 0..array.len() {
-        let offset = array.value_offsets()[i];
-        let length = array.value_length(i);
-        out.set_entry(i, offset.as_(), length.as_());
+fn list_like_array_to_vector<O: Copy + AsPrimitive<usize>>(
+    values: &dyn Array,
+    offsets: &[O],
+    parent: &dyn Array,
+    out: &mut ListVector<'_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    debug_assert_eq!(offsets.len(), parent.len() + 1);
+
+    let mut child = ChildVector::of_list(out, values.len())?;
+    write_arrow_array_to_vector_ref(values, &mut child)?;
+
+    for (i, window) in offsets.windows(2).enumerate() {
+        let offset = window[0].as_();
+        out.set_entry(i, offset, window[1].as_() - offset);
     }
-    set_nulls_in_list_vector(array, out);
+    set_nulls_in_list_vector(parent, out);
 
     Ok(())
 }
@@ -566,24 +619,11 @@ fn fixed_size_list_array_to_vector(
     out: &mut ArrayVector<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let value_array = array.values();
-    let mut child = out.child(value_array.len());
-    match value_array.data_type() {
-        dt if dt.is_primitive() || matches!(dt, DataType::Boolean) => {
-            primitive_array_to_vector(value_array.as_ref(), &mut child)?;
-        }
-        DataType::Utf8 => {
-            string_array_to_vector(as_string_array(value_array.as_ref()), &mut child);
-        }
-        DataType::Binary => {
-            binary_array_to_vector(as_generic_binary_array(value_array.as_ref()), &mut child);
-        }
-        DataType::FixedSizeBinary(_) => {
-            fixed_size_binary_array_to_vector(value_array.as_ref().as_fixed_size_binary(), &mut child)?;
-        }
-        _ => {
-            return Err("Nested array is not supported yet.".into());
-        }
-    }
+    // arrow-rs normalizes FixedSizeListArray slices by slicing the child
+    // values array, so this is already the exact row count * fixed width span.
+    debug_assert_eq!(value_array.len(), array.len() * array.value_length() as usize);
+    let mut child = ChildVector::of_array(out, value_array.len());
+    write_arrow_array_to_vector_ref(value_array.as_ref(), &mut child)?;
 
     set_nulls_in_array_vector(array, out);
 
@@ -599,46 +639,8 @@ fn as_fixed_size_list_array(arr: &dyn Array) -> &FixedSizeListArray {
 fn struct_array_to_vector(array: &StructArray, out: &mut StructVector<'_>) -> Result<(), Box<dyn std::error::Error>> {
     for i in 0..array.num_columns() {
         let column = array.column(i);
-        match column.data_type() {
-            dt if dt.is_primitive() || matches!(dt, DataType::Boolean) => {
-                primitive_array_to_vector(column, &mut out.child(i, array.len()))?;
-            }
-            DataType::Utf8 => {
-                string_array_to_vector(as_string_array(column.as_ref()), &mut out.child(i, array.len()));
-            }
-            DataType::Binary => {
-                binary_array_to_vector(as_generic_binary_array(column.as_ref()), &mut out.child(i, array.len()));
-            }
-            DataType::FixedSizeBinary(_) => {
-                fixed_size_binary_array_to_vector(
-                    column.as_ref().as_fixed_size_binary(),
-                    &mut out.child(i, array.len()),
-                )?;
-            }
-            DataType::List(_) => {
-                list_array_to_vector(as_list_array(column.as_ref()), &mut out.list_vector_child(i))?;
-            }
-            DataType::LargeList(_) => {
-                list_array_to_vector(as_large_list_array(column.as_ref()), &mut out.list_vector_child(i))?;
-            }
-            DataType::FixedSizeList(_, _) => {
-                fixed_size_list_array_to_vector(
-                    as_fixed_size_list_array(column.as_ref()),
-                    &mut out.array_vector_child(i),
-                )?;
-            }
-            DataType::Struct(_) => {
-                let struct_array = as_struct_array(column.as_ref());
-                let mut struct_vector = out.struct_vector_child(i);
-                struct_array_to_vector(struct_array, &mut struct_vector)?;
-            }
-            _ => {
-                unimplemented!(
-                    "Unsupported data type: {}, please file an issue https://github.com/duckdb/duckdb-rs",
-                    column.data_type()
-                );
-            }
-        }
+        let mut child = ChildVector::of_struct(out, i, array.len());
+        write_arrow_array_to_vector_ref(column.as_ref(), &mut child)?;
     }
     set_nulls_in_struct_vector(array, out);
     Ok(())

--- a/crates/duckdb/src/arrow_interop/to_duckdb.rs
+++ b/crates/duckdb/src/arrow_interop/to_duckdb.rs
@@ -7,6 +7,7 @@ use arrow::{
         OffsetSizeTrait, PrimitiveArray, StringViewArray, StructArray, as_boolean_array, as_generic_binary_array,
         as_large_list_array, as_list_array, as_map_array, as_primitive_array, as_string_array, as_struct_array,
     },
+    buffer::NullBuffer,
     compute::cast,
     datatypes::*,
     record_batch::RecordBatch,
@@ -69,8 +70,9 @@ pub trait WritableVector {
 /// Borrowed child vector handle used while writing one nested Arrow child array.
 struct ChildVector<'a> {
     ptr: duckdb_vector,
-    /// Arrow row count for this child; flat children use it as physical slots,
-    /// and list children use it as list-entry rows.
+    /// Writable span for this child. Flat children use it as physical slots,
+    /// list children use it as list-entry rows, and array/struct routes ignore
+    /// it because their descendants re-derive their own spans.
     capacity: usize,
     _phantom: PhantomData<&'a mut ()>,
 }
@@ -105,30 +107,22 @@ impl<'a> ChildVector<'a> {
     }
 }
 
-#[cfg(debug_assertions)]
-fn debug_assert_child_type<F>(ptr: duckdb_vector, expected: &str, matches_expected: F)
+fn assert_child_type<F>(ptr: duckdb_vector, expected: &str, matches_expected: F)
 where
     F: FnOnce(LogicalTypeId) -> bool,
 {
     let logical_type =
         unsafe { crate::core::LogicalTypeHandle::new(libduckdb_sys::duckdb_vector_get_column_type(ptr)) };
     let actual = logical_type.id();
-    debug_assert!(
+    assert!(
         matches_expected(actual),
         "expected {expected} child vector, got {actual:?}"
     );
 }
 
-#[cfg(not(debug_assertions))]
-fn debug_assert_child_type<F>(_ptr: duckdb_vector, _expected: &str, _matches_expected: F)
-where
-    F: FnOnce(LogicalTypeId) -> bool,
-{
-}
-
 impl WritableVector for ChildVector<'_> {
     fn flat_vector(&mut self) -> FlatVector<'_> {
-        debug_assert_child_type(self.ptr, "scalar", |id| {
+        assert_child_type(self.ptr, "scalar", |id| {
             !matches!(
                 id,
                 LogicalTypeId::List | LogicalTypeId::Array | LogicalTypeId::Struct | LogicalTypeId::Map
@@ -142,7 +136,7 @@ impl WritableVector for ChildVector<'_> {
     }
 
     fn list_vector(&mut self) -> ListVector<'_> {
-        debug_assert_child_type(self.ptr, "list or map", |id| {
+        assert_child_type(self.ptr, "list or map", |id| {
             matches!(id, LogicalTypeId::List | LogicalTypeId::Map)
         });
         // SAFETY: ChildVector mutably borrows the parent while this wrapper
@@ -153,7 +147,7 @@ impl WritableVector for ChildVector<'_> {
     }
 
     fn array_vector(&mut self) -> ArrayVector<'_> {
-        debug_assert_child_type(self.ptr, "array", |id| matches!(id, LogicalTypeId::Array));
+        assert_child_type(self.ptr, "array", |id| matches!(id, LogicalTypeId::Array));
         // SAFETY: ChildVector mutably borrows the parent while this wrapper
         // exists, keeping `ptr` live and uniquely reached through this view.
         // The recursive dispatcher calls this only for logical fixed-size-list
@@ -162,7 +156,7 @@ impl WritableVector for ChildVector<'_> {
     }
 
     fn struct_vector(&mut self) -> StructVector<'_> {
-        debug_assert_child_type(self.ptr, "struct", |id| matches!(id, LogicalTypeId::Struct));
+        assert_child_type(self.ptr, "struct", |id| matches!(id, LogicalTypeId::Struct));
         // SAFETY: ChildVector mutably borrows the parent while this wrapper
         // exists, keeping `ptr` live and uniquely reached through this view.
         // The recursive dispatcher calls this only for logical struct children.
@@ -245,7 +239,12 @@ fn write_arrow_array_to_vector_ref(
             // [`MapArray`] is physically a [`ListArray`] of key values pairs stored as an `entries` [`StructArray`] with 2 child fields.
             let map_array = as_map_array(col);
             let mut out = chunk.list_vector();
-            list_like_array_to_vector(map_array.entries(), map_array.value_offsets(), map_array, &mut out)?;
+            list_like_array_to_vector(
+                map_array.entries(),
+                map_array.value_offsets(),
+                map_array.nulls(),
+                &mut out,
+            )?;
         }
         dt => {
             return Err(format!(
@@ -591,16 +590,19 @@ fn list_array_to_vector<O: OffsetSizeTrait + AsPrimitive<usize>>(
     out: &mut ListVector<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let value_array = array.values();
-    list_like_array_to_vector(value_array.as_ref(), array.value_offsets(), array, out)
+    list_like_array_to_vector(value_array.as_ref(), array.value_offsets(), array.nulls(), out)
 }
 
 fn list_like_array_to_vector<O: Copy + AsPrimitive<usize>>(
     values: &dyn Array,
     offsets: &[O],
-    parent: &dyn Array,
+    nulls: Option<&NullBuffer>,
     out: &mut ListVector<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    debug_assert_eq!(offsets.len(), parent.len() + 1);
+    debug_assert!(!offsets.is_empty());
+    if let Some(nulls) = nulls {
+        debug_assert_eq!(offsets.len(), nulls.len() + 1);
+    }
 
     let mut child = ChildVector::of_list(out, values.len())?;
     write_arrow_array_to_vector_ref(values, &mut child)?;
@@ -609,7 +611,7 @@ fn list_like_array_to_vector<O: Copy + AsPrimitive<usize>>(
         let offset = window[0].as_();
         out.set_entry(i, offset, window[1].as_() - offset);
     }
-    set_nulls_in_list_vector(parent, out);
+    set_nulls_in_list_vector(nulls, out);
 
     Ok(())
 }
@@ -676,8 +678,8 @@ fn set_nulls_in_array_vector(array: &dyn Array, out_vector: &mut ArrayVector<'_>
     }
 }
 
-fn set_nulls_in_list_vector(array: &dyn Array, out_vector: &mut ListVector<'_>) {
-    if let Some(nulls) = array.nulls() {
+fn set_nulls_in_list_vector(nulls: Option<&NullBuffer>, out_vector: &mut ListVector<'_>) {
+    if let Some(nulls) = nulls {
         for (i, null) in nulls.into_iter().enumerate() {
             if !null {
                 out_vector.set_null(i);

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -15,14 +15,28 @@ use libduckdb_sys::{
 };
 
 use super::LogicalTypeHandle;
-use crate::ffi::{
-    duckdb_list_entry, duckdb_list_vector_get_child, duckdb_list_vector_get_size, duckdb_list_vector_reserve,
-    duckdb_list_vector_set_size, duckdb_struct_type_child_count, duckdb_struct_type_child_name,
-    duckdb_struct_vector_get_child, duckdb_validity_set_row_invalid, duckdb_vector,
-    duckdb_vector_assign_string_element, duckdb_vector_assign_string_element_len,
-    duckdb_vector_ensure_validity_writable, duckdb_vector_get_column_type, duckdb_vector_get_data,
-    duckdb_vector_get_validity, duckdb_vector_size,
+use crate::{
+    Result,
+    error::duckdb_failure_from_message,
+    ffi::{
+        DuckDBSuccess, duckdb_list_entry, duckdb_list_vector_get_child, duckdb_list_vector_get_size,
+        duckdb_list_vector_reserve, duckdb_list_vector_set_size, duckdb_state, duckdb_struct_type_child_count,
+        duckdb_struct_type_child_name, duckdb_struct_vector_get_child, duckdb_validity_set_row_invalid, duckdb_vector,
+        duckdb_vector_assign_string_element, duckdb_vector_assign_string_element_len,
+        duckdb_vector_ensure_validity_writable, duckdb_vector_get_column_type, duckdb_vector_get_data,
+        duckdb_vector_get_validity, duckdb_vector_size,
+    },
 };
+
+fn list_vector_state_result(state: duckdb_state, action: &str, size: usize) -> Result<()> {
+    if state == DuckDBSuccess {
+        Ok(())
+    } else {
+        Err(duckdb_failure_from_message(format!(
+            "failed to {action} {size} elements in DuckDB list vector"
+        )))
+    }
+}
 
 /// A flat (contiguous, scalar-row) vector borrowed from a
 /// [`DataChunkHandle`][crate::core::DataChunkHandle].
@@ -45,7 +59,14 @@ impl<'a> FlatVector<'a> {
         }
     }
 
-    fn with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
+    /// Wrap a raw vector pointer with a caller-supplied element capacity.
+    ///
+    /// # Safety
+    /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
+    /// The caller must ensure `capacity` matches the backing allocation for the
+    /// logical view being exposed. Later typed slice and copy methods trust this
+    /// value for bounds checks.
+    pub(crate) unsafe fn with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
         Self {
             ptr,
             capacity,
@@ -241,6 +262,19 @@ impl<'a> ListVector<'a> {
         }
     }
 
+    /// Wrap a raw list vector pointer with a caller-supplied capacity.
+    ///
+    /// # Safety
+    /// `ptr` must be a valid list `duckdb_vector` that remains valid for all of
+    /// `'a`, and `capacity` must not exceed the backing allocation available for
+    /// this vector's list entries.
+    #[cfg(feature = "vtab-arrow")]
+    pub(crate) unsafe fn from_raw_with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
+        Self {
+            entries: unsafe { FlatVector::with_capacity(ptr, capacity) },
+        }
+    }
+
     /// Returns the number of entries in the list vector.
     pub fn len(&self) -> usize {
         unsafe { duckdb_list_vector_get_size(self.entries.ptr) as usize }
@@ -251,17 +285,30 @@ impl<'a> ListVector<'a> {
         self.len() == 0
     }
 
-    /// Returns the child vector.
+    /// Returns the child vector, reserving space for `capacity` child values.
+    ///
+    /// # Panics
+    /// Panics if DuckDB rejects the reserve.
     // TODO: not ideal interface. Where should we keep capacity.
     pub fn child(&self, capacity: usize) -> FlatVector<'a> {
-        self.reserve(capacity);
-        FlatVector::with_capacity(unsafe { duckdb_list_vector_get_child(self.entries.ptr) }, capacity)
+        let ptr = self
+            .try_child_ptr_with_capacity(capacity)
+            .unwrap_or_else(|err| panic!("{err}"));
+        // SAFETY: DuckDB accepted the reserve for `capacity` child values.
+        unsafe { FlatVector::with_capacity(ptr, capacity) }
     }
 
-    /// Take the child as [StructVector].
+    /// Take the child as [StructVector], reserving space for `capacity` child
+    /// values.
+    ///
+    /// # Panics
+    /// Panics if DuckDB rejects the reserve.
     pub fn struct_child(&self, capacity: usize) -> StructVector<'a> {
-        self.reserve(capacity);
-        unsafe { StructVector::from_raw(duckdb_list_vector_get_child(self.entries.ptr)) }
+        let ptr = self
+            .try_child_ptr_with_capacity(capacity)
+            .unwrap_or_else(|err| panic!("{err}"));
+        // SAFETY: DuckDB accepted the reserve for `capacity` child values.
+        unsafe { StructVector::from_raw(ptr) }
     }
 
     /// Take the child as [ArrayVector].
@@ -274,14 +321,29 @@ impl<'a> ListVector<'a> {
         unsafe { ListVector::from_raw(duckdb_list_vector_get_child(self.entries.ptr)) }
     }
 
+    pub(crate) fn try_child_ptr_with_capacity(&self, capacity: usize) -> Result<duckdb_vector> {
+        self.try_reserve(capacity)?;
+        Ok(unsafe { duckdb_list_vector_get_child(self.entries.ptr) })
+    }
+
     /// Set primitive data to the child node.
+    ///
+    /// Reserves child storage and commits the list length to `data.len()`.
+    ///
+    /// # Panics
+    /// Panics if DuckDB rejects the reserve or size update.
     ///
     /// # Safety
     /// The caller must ensure `T` matches the child vector's physical storage
     /// and no other references to the same storage exist during the copy.
     pub unsafe fn set_child<T: Copy>(&self, data: &[T]) {
-        unsafe { self.child(data.len()).copy(data) };
-        self.set_len(data.len());
+        // Reserve and write child storage before committing the list size.
+        let ptr = self
+            .try_child_ptr_with_capacity(data.len())
+            .unwrap_or_else(|err| panic!("{err}"));
+        // SAFETY: DuckDB accepted the reserve for `data.len()` child values.
+        unsafe { FlatVector::with_capacity(ptr, data.len()).copy(data) };
+        self.try_set_len(data.len()).unwrap_or_else(|err| panic!("{err}"));
     }
 
     /// Set offset and length to the entry.
@@ -306,18 +368,27 @@ impl<'a> ListVector<'a> {
         }
     }
 
-    /// Reserve the capacity for its child node.
-    fn reserve(&self, capacity: usize) {
-        unsafe {
-            duckdb_list_vector_reserve(self.entries.ptr, capacity as u64);
-        }
+    /// Reserve space for `capacity` child values.
+    ///
+    /// This is public so callers can surface DuckDB allocation errors without
+    /// using the panic-based convenience methods.
+    pub fn try_reserve(&self, capacity: usize) -> Result<()> {
+        let state = unsafe { duckdb_list_vector_reserve(self.entries.ptr, capacity as u64) };
+        list_vector_state_result(state, "reserve child storage for", capacity)
     }
 
     /// Set the length of the list vector.
+    ///
+    /// Panics if DuckDB rejects the size update. Use [`Self::try_set_len`] to
+    /// handle that error explicitly.
     pub fn set_len(&self, new_len: usize) {
-        unsafe {
-            duckdb_list_vector_set_size(self.entries.ptr, new_len as u64);
-        }
+        self.try_set_len(new_len).unwrap_or_else(|err| panic!("{err}"));
+    }
+
+    /// Set the length of the list vector.
+    pub fn try_set_len(&self, new_len: usize) -> Result<()> {
+        let state = unsafe { duckdb_list_vector_set_size(self.entries.ptr, new_len as u64) };
+        list_vector_state_result(state, "set size to", new_len)
     }
 }
 
@@ -355,17 +426,45 @@ impl<'a> ArrayVector<'a> {
 
     /// Returns the child vector.
     /// capacity should be a multiple of the array size.
+    ///
+    /// # Panics
+    /// Panics if `capacity` is not a multiple of the fixed array size.
     // TODO: not ideal interface. Where should we keep count.
     pub fn child(&self, capacity: usize) -> FlatVector<'a> {
-        FlatVector::with_capacity(unsafe { duckdb_array_vector_get_child(self.ptr) }, capacity)
+        let array_size = self.get_array_size() as usize;
+        assert_eq!(
+            capacity % array_size,
+            0,
+            "array child capacity must be a multiple of the fixed array size"
+        );
+        // SAFETY: callers must pass a capacity covered by the array child
+        // backing allocation. The multiple-of-array-size assertion checks only
+        // fixed-size-list shape, not allocation size.
+        unsafe { FlatVector::with_capacity(self.child_ptr(), capacity) }
+    }
+
+    pub(crate) fn child_ptr(&self) -> duckdb_vector {
+        unsafe { duckdb_array_vector_get_child(self.ptr) }
     }
 
     /// Set primitive data to the child node.
     ///
+    /// # Panics
+    /// Panics if `data.len()` is not a multiple of the fixed array size.
+    ///
     /// # Safety
     /// The caller must ensure `T` matches the child vector's physical storage
-    /// and no other references to the same storage exist during the copy.
+    /// and no other references to the same storage exist during the copy. The
+    /// caller must also ensure the child backing allocation has space for all
+    /// `data` elements; nested callers can arrange this by reserving capacity
+    /// on the parent list vector before taking the array child.
     pub unsafe fn set_child<T: Copy>(&self, data: &[T]) {
+        let array_size = self.get_array_size() as usize;
+        assert_eq!(
+            data.len() % array_size,
+            0,
+            "array child data length must be a multiple of the fixed array size"
+        );
         unsafe { self.child(data.len()).copy(data) };
     }
 
@@ -399,27 +498,33 @@ impl<'a> StructVector<'a> {
         }
     }
 
-    /// Returns the child by idx in the list vector.
+    /// Returns the child by idx in the struct vector.
     pub fn child(&self, idx: usize, capacity: usize) -> FlatVector<'a> {
-        FlatVector::with_capacity(
-            unsafe { duckdb_struct_vector_get_child(self.ptr, idx as u64) },
-            capacity,
-        )
+        // SAFETY: struct children share the parent allocation, and callers pass
+        // the row capacity for the child view they are exposing.
+        unsafe { FlatVector::with_capacity(self.child_ptr(idx), capacity) }
     }
+
+    // Legacy typed child accessors remain public for callers that need nested
+    // vector views.
 
     /// Take the child as [StructVector].
     pub fn struct_vector_child(&self, idx: usize) -> StructVector<'a> {
-        unsafe { StructVector::from_raw(duckdb_struct_vector_get_child(self.ptr, idx as u64)) }
+        unsafe { StructVector::from_raw(self.child_ptr(idx)) }
     }
 
     /// Take the child as [ListVector].
     pub fn list_vector_child(&self, idx: usize) -> ListVector<'a> {
-        unsafe { ListVector::from_raw(duckdb_struct_vector_get_child(self.ptr, idx as u64)) }
+        unsafe { ListVector::from_raw(self.child_ptr(idx)) }
     }
 
     /// Take the child as [ArrayVector].
     pub fn array_vector_child(&self, idx: usize) -> ArrayVector<'a> {
-        unsafe { ArrayVector::from_raw(duckdb_struct_vector_get_child(self.ptr, idx as u64)) }
+        unsafe { ArrayVector::from_raw(self.child_ptr(idx)) }
+    }
+
+    pub(crate) fn child_ptr(&self, idx: usize) -> duckdb_vector {
+        unsafe { duckdb_struct_vector_get_child(self.ptr, idx as u64) }
     }
 
     /// Get the logical type of this struct vector.
@@ -503,5 +608,60 @@ mod tests {
         assert_eq!(list_vector.get_entry(0), (0, 2));
         assert_eq!(list_vector.get_entry(1), (2, 1));
         assert_eq!(list_vector.get_entry(2), (3, 2));
+    }
+
+    #[test]
+    fn test_struct_vector_typed_child_accessors_smoke() {
+        let int_type = LogicalTypeHandle::from(LogicalTypeId::Integer);
+        let list_type = LogicalTypeHandle::list(&int_type);
+        let array_type = LogicalTypeHandle::array(&int_type, 2);
+        let nested_struct_type =
+            LogicalTypeHandle::struct_type(&[("value", LogicalTypeHandle::from(LogicalTypeId::Integer))]);
+        let struct_type = LogicalTypeHandle::struct_type(&[
+            ("items", list_type),
+            ("pair", array_type),
+            ("nested", nested_struct_type),
+        ]);
+        let chunk = DataChunkHandle::new(&[struct_type]);
+        let vector = chunk.struct_vector(0);
+
+        let list_child = vector.list_vector_child(0);
+        assert!(list_child.is_empty());
+        let array_child = vector.array_vector_child(1);
+        assert_eq!(array_child.get_array_size(), 2);
+        let struct_child = vector.struct_vector_child(2);
+        assert_eq!(struct_child.num_children(), 1);
+        assert_eq!(struct_child.child_name(0).to_str().unwrap(), "value");
+
+        let flat_child = vector.child(1, 2);
+        assert_eq!(flat_child.capacity(), 2);
+
+        let child_count = unsafe { duckdb_vector_size() as usize } + 1;
+        let struct_type = LogicalTypeHandle::struct_type(&[("value", LogicalTypeHandle::from(LogicalTypeId::Integer))]);
+        let list_type = LogicalTypeHandle::list(&struct_type);
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+        let child = list.struct_child(child_count);
+        assert_eq!(child.num_children(), 1);
+    }
+
+    #[test]
+    fn test_array_vector_set_child_uses_reserved_nested_capacity() -> Result<()> {
+        let item_type = LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2);
+        let list_type = LogicalTypeHandle::list(&item_type);
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+        let child_count = unsafe { duckdb_vector_size() as usize } + 1;
+        list.try_reserve(child_count)?;
+
+        let array = list.array_child();
+        let data = (0..(child_count * 2) as i32).collect::<Vec<_>>();
+        unsafe { array.set_child(&data) };
+        let child = array.child(data.len());
+        let output = unsafe { child.as_slice_with_len::<i32>(data.len()) };
+
+        assert_eq!(output[data.len() - 1], data[data.len() - 1]);
+
+        Ok(())
     }
 }

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -337,13 +337,8 @@ impl<'a> ListVector<'a> {
     /// The caller must ensure `T` matches the child vector's physical storage
     /// and no other references to the same storage exist during the copy.
     pub unsafe fn set_child<T: Copy>(&self, data: &[T]) {
-        // Reserve and write child storage before committing the list size.
-        let ptr = self
-            .try_child_ptr_with_capacity(data.len())
-            .unwrap_or_else(|err| panic!("{err}"));
-        // SAFETY: DuckDB accepted the reserve for `data.len()` child values.
-        unsafe { FlatVector::with_capacity(ptr, data.len()).copy(data) };
-        self.try_set_len(data.len()).unwrap_or_else(|err| panic!("{err}"));
+        unsafe { self.child(data.len()).copy(data) };
+        self.set_len(data.len());
     }
 
     /// Set offset and length to the entry.
@@ -459,12 +454,6 @@ impl<'a> ArrayVector<'a> {
     /// `data` elements; nested callers can arrange this by reserving capacity
     /// on the parent list vector before taking the array child.
     pub unsafe fn set_child<T: Copy>(&self, data: &[T]) {
-        let array_size = self.get_array_size() as usize;
-        assert_eq!(
-            data.len() % array_size,
-            0,
-            "array child data length must be a multiple of the fixed array size"
-        );
         unsafe { self.child(data.len()).copy(data) };
     }
 


### PR DESCRIPTION
Unify Arrow record-batch writes through one recursive DuckDB vector dispatcher.

- Reuse the top-level Arrow writer for nested list, fixed-size list, struct, and map children
- Track nested child capacities, list child counts, and sliced fixed-size-list child spans correctly
- Propagate DuckDB list-vector reserve/set-size failures
- Harden nested child vector type checks and keep the new `ListVector` fallible API surface limited
- Add coverage for nested maps/lists/structs, sliced arrays, nulls, large child counts, and FixedSizeBinary children
- Carry over the original list/array-of-structs regression cases from #403

This supersedes #403 by @ajwerner. It does not replace #757, which covers `Value`/`ToSql` list binding.

Future work remains for nested DuckDB-vector-to-Arrow export, nested `Value`/`ToSql` APIs, callback panic containment, and richer logical-type metadata preservation for nested values.

Closes #403