### PR TITLE
Read nested DataChunks as Arrow

### DIFF
--- a/crates/duckdb/src/arrow_interop/from_duckdb.rs
+++ b/crates/duckdb/src/arrow_interop/from_duckdb.rs
@@ -1,268 +1,517 @@
-use std::sync::Arc;
+use std::{error::Error, sync::Arc};
 
 use arrow::{
     array::{
-        Array, BooleanArray, Date32Array, GenericBinaryBuilder, PrimitiveArray, StringArray, TimestampMicrosecondArray,
-        TimestampNanosecondArray,
+        Array, ArrayRef, BooleanArray, FixedSizeListArray, GenericBinaryBuilder, ListArray, MapArray, PrimitiveArray,
+        StringArray, StructArray,
     },
-    buffer::{BooleanBuffer, NullBuffer},
+    buffer::{NullBuffer, OffsetBuffer, ScalarBuffer},
     datatypes::*,
     record_batch::RecordBatch,
 };
-use libduckdb_sys::{duckdb_date, duckdb_string_t, duckdb_time, duckdb_timestamp};
+use libduckdb_sys::{
+    duckdb_date, duckdb_string_t, duckdb_time, duckdb_timestamp, duckdb_vector, duckdb_vector_get_column_type,
+};
 
 use crate::{
-    core::{DataChunkHandle, FlatVector, LogicalTypeId},
+    core::{ArrayVector, DataChunkHandle, FlatVector, ListVector, LogicalTypeHandle, LogicalTypeId, StructVector},
     types::DuckString,
 };
 
-/// Converts a DuckDB flat vector to an Arrow array.
-pub fn flat_vector_to_arrow_array(
-    vector: &mut FlatVector<'_>,
-    len: usize,
-) -> Result<Arc<dyn Array>, Box<dyn std::error::Error>> {
+/// Maps each destination row to its DuckDB source row; `None` emits a null.
+type SourceRow = Option<usize>;
+type SourceRows = Vec<SourceRow>;
+
+fn source_len(rows: &[SourceRow]) -> Result<usize, Box<dyn Error>> {
+    rows.iter().flatten().copied().max().map_or(Ok(0), |row| {
+        row.checked_add(1)
+            .ok_or_else(|| "DuckDB row index exceeds usize range".into())
+    })
+}
+
+fn masked_rows<F>(rows: &SourceRows, is_null: F) -> Result<SourceRows, Box<dyn Error>>
+where
+    F: Fn(usize) -> crate::Result<bool>,
+{
+    Ok(rows
+        .iter()
+        .copied()
+        .map(|source_row| match source_row {
+            Some(row) => is_null(row).map(|is_null| (!is_null).then_some(row)),
+            None => Ok(None),
+        })
+        .collect::<crate::Result<_>>()?)
+}
+
+fn null_buffer(rows: &SourceRows) -> Option<NullBuffer> {
+    let validity = NullBuffer::from_iter(rows.iter().map(|source_row| source_row.is_some()));
+    (validity.null_count() > 0).then_some(validity)
+}
+
+/// Reads the physical value stored at `row` through a raw pointer.
+///
+/// DuckDB does not zero-initialize vector payloads, so null or unselected
+/// slots may be uninitialized. Reading one slot at a time avoids materializing
+/// a reference that spans such slots, which `slice::from_raw_parts` would
+/// require to be fully initialized.
+///
+/// # Safety
+/// `T` must match the vector's physical storage and the slot at `row` must be
+/// initialized; DuckDB initializes every valid (non-null) row.
+unsafe fn read_row<T: Copy>(vector: &FlatVector<'_>, row: usize) -> T {
+    assert!(
+        row < vector.capacity(),
+        "row {row} exceeds vector capacity {}",
+        vector.capacity()
+    );
+    // SAFETY: the bounds check above keeps the read inside the backing
+    // allocation the wrapper was constructed with.
+    unsafe { vector.as_mut_ptr::<T>().add(row).read() }
+}
+
+fn fixed_size_rows(rows: &SourceRows, width: usize) -> Result<SourceRows, Box<dyn Error>> {
+    let len = rows
+        .len()
+        .checked_mul(width)
+        .ok_or("DuckDB array child length overflows usize for Arrow conversion")?;
+    let mut child_rows = Vec::with_capacity(len);
+
+    for source_row in rows.iter().copied() {
+        match source_row {
+            Some(source_row) => {
+                let start = source_row
+                    .checked_mul(width)
+                    .ok_or("DuckDB array child span overflows usize for Arrow conversion")?;
+                let end = start
+                    .checked_add(width)
+                    .ok_or("DuckDB array child span overflows usize for Arrow conversion")?;
+                child_rows.extend((start..end).map(Some));
+            }
+            None => child_rows.extend(std::iter::repeat_n(None, width)),
+        }
+    }
+
+    Ok(child_rows)
+}
+
+fn primitive_array_from_rows<T, P, F>(
+    vector: &FlatVector<'_>,
+    rows: &SourceRows,
+    convert: F,
+) -> Result<PrimitiveArray<P>, Box<dyn Error>>
+where
+    T: Copy,
+    P: ArrowPrimitiveType,
+    F: Fn(T) -> P::Native,
+{
+    try_primitive_array_from_rows(vector, rows, |value| Ok(convert(value)))
+}
+
+fn try_primitive_array_from_rows<T, P, F>(
+    vector: &FlatVector<'_>,
+    rows: &SourceRows,
+    convert: F,
+) -> Result<PrimitiveArray<P>, Box<dyn Error>>
+where
+    T: Copy,
+    P: ArrowPrimitiveType,
+    F: Fn(T) -> Result<P::Native, Box<dyn Error>>,
+{
+    rows.iter()
+        .copied()
+        .map(|source_row| {
+            source_row
+                // SAFETY: scalar dispatch instantiates `T` for the logical
+                // type's physical storage, and validity masking already
+                // dropped null rows, so each selected slot is initialized.
+                .map(|row| convert(unsafe { read_row::<T>(vector, row) }))
+                .transpose()
+        })
+        .collect::<Result<PrimitiveArray<P>, _>>()
+}
+
+/// Converts rows whose Arrow native type matches the DuckDB physical storage.
+fn native_array_from_rows<P: ArrowPrimitiveType>(
+    vector: &FlatVector<'_>,
+    rows: &SourceRows,
+) -> Result<Arc<dyn Array>, Box<dyn Error>> {
+    Ok(Arc::new(primitive_array_from_rows::<P::Native, P, _>(
+        vector,
+        rows,
+        |value| value,
+    )?))
+}
+
+/// Converts the first `len` rows of a DuckDB vector to an Arrow array.
+///
+/// Although the entry wrapper is a [`FlatVector`], the logical type may be a
+/// nested list, map, struct, or fixed-size array and is dispatched recursively.
+/// Returns an error if `len` exceeds the wrapper's backing capacity.
+pub fn flat_vector_to_arrow_array(vector: &FlatVector<'_>, len: usize) -> Result<Arc<dyn Array>, Box<dyn Error>> {
+    if len > vector.capacity() {
+        return Err(format!(
+            "DuckDB vector length {len} exceeds backing capacity {}",
+            vector.capacity()
+        )
+        .into());
+    }
+    let rows = (0..len).map(Some).collect();
+    // SAFETY: `vector` keeps its pointer live, and the length check above
+    // bounds every selected row by its backing capacity.
+    unsafe { raw_vector_to_arrow_array(vector.ptr(), &rows) }
+}
+
+fn scalar_vector_rows_to_arrow_array(
+    vector: &FlatVector<'_>,
+    rows: &SourceRows,
+) -> Result<Arc<dyn Array>, Box<dyn Error>> {
     let raw_type_id = vector.logical_type().raw_id();
     let type_id = LogicalTypeId::from(raw_type_id);
     match type_id {
         LogicalTypeId::Invalid => Err("Cannot convert invalid logical type returned by DuckDB".into()),
         LogicalTypeId::Unsupported => Err(format!("Unsupported DuckDB logical type ID {raw_type_id}").into()),
-        LogicalTypeId::Integer => {
-            let data = unsafe { vector.as_slice_with_len::<i32>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<Int32Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
+        LogicalTypeId::Integer => native_array_from_rows::<Int32Type>(vector, rows),
+        // Preserve the legacy Arrow compatibility behavior for timestamp
+        // physical carriers. This adapter does not distinguish unit-specific
+        // timestamp vector payload layouts.
         LogicalTypeId::Timestamp
         | LogicalTypeId::TimestampMs
         | LogicalTypeId::TimestampS
-        | LogicalTypeId::TimestampTZ => {
-            let data = unsafe { vector.as_slice_with_len::<duckdb_timestamp>(len) };
-            let micros = data.iter().map(|duckdb_timestamp { micros }| *micros);
-            let structs = TimestampMicrosecondArray::from_iter_values_with_nulls(
-                micros,
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            );
-
-            Ok(Arc::new(structs))
-        }
+        | LogicalTypeId::TimestampTZ => Ok(Arc::new(primitive_array_from_rows::<
+            duckdb_timestamp,
+            TimestampMicrosecondType,
+            _,
+        >(vector, rows, |value| value.micros)?)),
         LogicalTypeId::Varchar => {
-            let data = unsafe { vector.as_slice_with_len::<duckdb_string_t>(len) };
-
-            let duck_strings = data.iter().enumerate().map(|(i, s)| {
-                if vector.row_is_null(i as u64) {
-                    None
-                } else {
-                    let mut ptr = *s;
-                    Some(DuckString::new(&mut ptr).as_str().to_string())
-                }
-            });
-
-            let values = duck_strings.collect::<Vec<_>>();
+            let values = rows
+                .iter()
+                .map(|source_row| {
+                    source_row.map(|row| {
+                        // SAFETY: the logical type establishes `duckdb_string_t`
+                        // physical storage, and validity masking already dropped
+                        // null rows, so each selected slot is initialized.
+                        let mut ptr = unsafe { read_row::<duckdb_string_t>(vector, row) };
+                        DuckString::new(&mut ptr).as_str().to_string()
+                    })
+                })
+                .collect::<Vec<_>>();
 
             Ok(Arc::new(StringArray::from(values)))
         }
         LogicalTypeId::Boolean => {
-            let data = unsafe { vector.as_slice_with_len::<bool>(len) };
+            // DuckDB stores booleans in one-byte slots; reading them as bytes
+            // avoids constructing Rust `bool`s over arbitrary payloads.
+            let values = rows
+                .iter()
+                .copied()
+                // SAFETY: validity masking already dropped null rows, so each
+                // selected one-byte slot is initialized.
+                .map(|source_row| source_row.map(|row| unsafe { read_row::<u8>(vector, row) } != 0));
 
-            Ok(Arc::new(BooleanArray::new(
-                BooleanBuffer::from_iter(data.iter().copied()),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
+            Ok(Arc::new(BooleanArray::from_iter(values)))
         }
-        LogicalTypeId::Float => {
-            let data = unsafe { vector.as_slice_with_len::<f32>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<Float32Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::Double => {
-            let data = unsafe { vector.as_slice_with_len::<f64>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<Float64Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::Date => {
-            let data = unsafe { vector.as_slice_with_len::<duckdb_date>(len) };
-
-            Ok(Arc::new(Date32Array::from_iter_values_with_nulls(
-                data.iter().map(|duckdb_date { days }| *days),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::Time => {
-            let data = unsafe { vector.as_slice_with_len::<duckdb_time>(len) };
-
-            Ok(Arc::new(
-                PrimitiveArray::<Time64MicrosecondType>::from_iter_values_with_nulls(
-                    data.iter().map(|duckdb_time { micros }| *micros),
-                    Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                        !vector.row_is_null(row as u64)
-                    }))),
-                ),
-            ))
-        }
-        LogicalTypeId::Smallint => {
-            let data = unsafe { vector.as_slice_with_len::<i16>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<Int16Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::USmallint => {
-            let data = unsafe { vector.as_slice_with_len::<u16>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<UInt16Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
+        LogicalTypeId::Float => native_array_from_rows::<Float32Type>(vector, rows),
+        LogicalTypeId::Double => native_array_from_rows::<Float64Type>(vector, rows),
+        LogicalTypeId::Date => Ok(Arc::new(primitive_array_from_rows::<duckdb_date, Date32Type, _>(
+            vector,
+            rows,
+            |value| value.days,
+        )?)),
+        LogicalTypeId::Time => Ok(Arc::new(primitive_array_from_rows::<
+            duckdb_time,
+            Time64MicrosecondType,
+            _,
+        >(vector, rows, |value| value.micros)?)),
+        LogicalTypeId::Smallint => native_array_from_rows::<Int16Type>(vector, rows),
+        LogicalTypeId::USmallint => native_array_from_rows::<UInt16Type>(vector, rows),
         LogicalTypeId::Blob | LogicalTypeId::Geometry => {
             // DuckDB currently stores GEOMETRY vectors as WKB-backed string_t
             // bytes. Treating GEOMETRY like BLOB here relies on that internal
             // representation staying WKB-compatible.
-            let mut data = unsafe { vector.as_slice_with_len::<duckdb_string_t>(len) }.to_vec();
-
-            let duck_strings = data.iter_mut().enumerate().map(|(i, ptr)| {
-                if vector.row_is_null(i as u64) {
-                    None
-                } else {
-                    Some(DuckString::new(ptr))
-                }
-            });
-
             let mut builder = GenericBinaryBuilder::<i32>::new();
-            for s in duck_strings {
-                if let Some(mut s) = s {
-                    builder.append_value(s.as_bytes());
-                } else {
-                    builder.append_null();
+
+            for source_row in rows.iter().copied() {
+                match source_row {
+                    Some(row) => {
+                        // SAFETY: Blob and Geometry use DuckDB string storage
+                        // for their bytes, and validity masking already dropped
+                        // null rows, so each selected slot is initialized.
+                        let mut ptr = unsafe { read_row::<duckdb_string_t>(vector, row) };
+                        let mut value = DuckString::new(&mut ptr);
+                        builder.append_value(value.as_bytes());
+                    }
+                    _ => builder.append_null(),
                 }
             }
 
             Ok(Arc::new(builder.finish()))
         }
-        LogicalTypeId::Tinyint => {
-            let data = unsafe { vector.as_slice_with_len::<i8>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<Int8Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
+        LogicalTypeId::Tinyint => native_array_from_rows::<Int8Type>(vector, rows),
+        LogicalTypeId::Bigint => native_array_from_rows::<Int64Type>(vector, rows),
+        LogicalTypeId::UBigint => native_array_from_rows::<UInt64Type>(vector, rows),
+        LogicalTypeId::UTinyint => native_array_from_rows::<UInt8Type>(vector, rows),
+        LogicalTypeId::UInteger => native_array_from_rows::<UInt32Type>(vector, rows),
+        LogicalTypeId::TimestampNs => Ok(Arc::new(try_primitive_array_from_rows::<
+            duckdb_timestamp,
+            TimestampNanosecondType,
+            _,
+        >(
+            vector,
+            rows,
+            // Preserve the existing C API read behavior, which interprets the
+            // payload as microseconds before producing Arrow nanoseconds. The
+            // unit-specific timestamp vector layouts need a separate audit.
+            |value| {
+                value
+                    .micros
+                    .checked_mul(1000)
+                    .ok_or_else(|| "DuckDB nanosecond timestamp exceeds Arrow i64 range".into())
+            },
+        )?)),
+        type_id @ (LogicalTypeId::Interval
+        | LogicalTypeId::Hugeint
+        | LogicalTypeId::Decimal
+        | LogicalTypeId::Enum
+        | LogicalTypeId::Uuid
+        | LogicalTypeId::Union
+        | LogicalTypeId::Bit
+        | LogicalTypeId::TimeTZ
+        | LogicalTypeId::UHugeint
+        | LogicalTypeId::Any
+        | LogicalTypeId::Bignum
+        | LogicalTypeId::SqlNull
+        | LogicalTypeId::StringLiteral
+        | LogicalTypeId::IntegerLiteral
+        | LogicalTypeId::TimeNs
+        | LogicalTypeId::Variant) => Err(format!("Cannot convert DuckDB logical type {type_id:?} to Arrow").into()),
+        type_id @ (LogicalTypeId::List | LogicalTypeId::Struct | LogicalTypeId::Map | LogicalTypeId::Array) => {
+            Err(format!("Nested DuckDB logical type {type_id:?} reached the scalar Arrow converter").into())
         }
-        LogicalTypeId::Bigint => {
-            let data = unsafe { vector.as_slice_with_len::<i64>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<Int64Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::UBigint => {
-            let data = unsafe { vector.as_slice_with_len::<u64>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<UInt64Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::UTinyint => {
-            let data = unsafe { vector.as_slice_with_len::<u8>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<UInt8Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::UInteger => {
-            let data = unsafe { vector.as_slice_with_len::<u32>(len) };
-
-            Ok(Arc::new(PrimitiveArray::<UInt32Type>::from_iter_values_with_nulls(
-                data.iter().copied(),
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            )))
-        }
-        LogicalTypeId::TimestampNs => {
-            // even nano second precision is stored in micros when using the c api
-            let data = unsafe { vector.as_slice_with_len::<duckdb_timestamp>(len) };
-            let nanos = data.iter().map(|duckdb_timestamp { micros }| *micros * 1000);
-            let structs = TimestampNanosecondArray::from_iter_values_with_nulls(
-                nanos,
-                Some(NullBuffer::new(BooleanBuffer::collect_bool(data.len(), |row| {
-                    !vector.row_is_null(row as u64)
-                }))),
-            );
-
-            Ok(Arc::new(structs))
-        }
-        LogicalTypeId::Interval => todo!(),
-        LogicalTypeId::Hugeint => todo!(),
-        LogicalTypeId::Decimal => todo!(),
-        LogicalTypeId::Enum => todo!(),
-        LogicalTypeId::List => todo!(),
-        LogicalTypeId::Struct => todo!(),
-        LogicalTypeId::Map => todo!(),
-        LogicalTypeId::Array => todo!(),
-        LogicalTypeId::Uuid => todo!(),
-        LogicalTypeId::Union => todo!(),
-        LogicalTypeId::Bit => todo!(),
-        LogicalTypeId::TimeTZ => todo!(),
-        LogicalTypeId::UHugeint => todo!(),
-        LogicalTypeId::Any => todo!(),
-        LogicalTypeId::Bignum => todo!(),
-        LogicalTypeId::SqlNull => todo!(),
-        LogicalTypeId::StringLiteral => todo!(),
-        LogicalTypeId::IntegerLiteral => todo!(),
-        LogicalTypeId::TimeNs => todo!(),
-        LogicalTypeId::Variant => Err("Cannot convert Variant logical type to Arrow".into()),
     }
 }
 
-/// converts a `DataChunk` to arrow `RecordBatch`
-pub fn data_chunk_to_arrow(chunk: &DataChunkHandle) -> Result<RecordBatch, Box<dyn std::error::Error>> {
+/// Converts selected rows from a borrowed DuckDB vector.
+///
+/// Masks `rows` by the vector's validity before dispatching, so the per-type
+/// converters receive pre-masked rows and only handle offsets and children.
+///
+/// # Safety
+///
+/// `ptr` must remain valid for this call, have the logical type reported by
+/// DuckDB, and have backing capacity through the highest source row. Nested
+/// list children can legitimately have capacities larger than
+/// `duckdb_vector_size()`; `rows` carries that effective child span.
+unsafe fn raw_vector_to_arrow_array(ptr: duckdb_vector, rows: &SourceRows) -> Result<ArrayRef, Box<dyn Error>> {
+    let capacity = source_len(rows)?;
+    // SAFETY: `capacity` is one past the highest selected row, and validity is
+    // a vector-level property shared by every logical type.
+    let vector = unsafe { FlatVector::with_capacity(ptr, capacity) };
+    let rows = masked_rows(rows, |row| vector.try_row_is_null(row as u64))?;
+    // SAFETY: callers pass a live vector pointer owned by the parent chunk or
+    // nested vector, and DuckDB returns a newly owned logical type handle.
+    let logical_type = unsafe { LogicalTypeHandle::new(duckdb_vector_get_column_type(ptr)) };
+    match logical_type.id() {
+        LogicalTypeId::List => {
+            // SAFETY: `capacity` is one past the highest selected list row.
+            let vector = unsafe { ListVector::from_raw_with_capacity(ptr, capacity) };
+            list_vector_to_arrow_array(&vector, &rows)
+        }
+        LogicalTypeId::Struct => {
+            // SAFETY: `capacity` is one past the highest selected struct row.
+            let vector = unsafe { StructVector::from_raw_with_capacity(ptr, capacity) };
+            struct_vector_to_arrow_array(&vector, &rows)
+        }
+        LogicalTypeId::Map => {
+            // SAFETY: maps use list storage and `capacity` bounds their rows.
+            let vector = unsafe { ListVector::from_raw_with_capacity(ptr, capacity) };
+            map_vector_to_arrow_array(&vector, &rows)
+        }
+        LogicalTypeId::Array => {
+            // SAFETY: `capacity` is one past the highest selected array row.
+            let vector = unsafe { ArrayVector::from_raw_with_capacity(ptr, capacity) };
+            array_vector_to_arrow_array(&vector, &rows)
+        }
+        _ => scalar_vector_rows_to_arrow_array(&vector, &rows),
+    }
+}
+
+/// Checks the next list offset fits Arrow's i32 range before gathering rows.
+fn checked_list_output_len(current_len: usize, additional_len: usize) -> Result<i32, Box<dyn Error>> {
+    let output_len = current_len
+        .checked_add(additional_len)
+        .ok_or("DuckDB list values exceed Arrow i32 offset range")?;
+    i32::try_from(output_len).map_err(|_| "DuckDB list values exceed Arrow i32 offset range".into())
+}
+
+fn list_layout(
+    vector: &ListVector<'_>,
+    rows: &SourceRows,
+) -> Result<(OffsetBuffer<i32>, Vec<SourceRow>), Box<dyn Error>> {
+    let child_len = vector.len();
+    let mut offsets = Vec::with_capacity(rows.len() + 1);
+    let mut child_rows = Vec::new();
+    let mut next_offset = 0;
+    offsets.push(next_offset);
+
+    for source_row in rows.iter().copied() {
+        if let Some(source_row) = source_row {
+            let (offset, length) = vector.try_get_entry(source_row)?;
+            if length > 0 {
+                let end = offset
+                    .checked_add(length)
+                    .ok_or_else(|| format!("DuckDB list entry at row {source_row} overflows usize"))?;
+                if end > child_len {
+                    return Err(format!(
+                        "DuckDB list entry at row {source_row} ends at {end}, beyond child length {child_len}"
+                    )
+                    .into());
+                }
+                next_offset = checked_list_output_len(child_rows.len(), length)?;
+                child_rows.extend((offset..end).map(Some));
+            }
+        }
+
+        offsets.push(next_offset);
+    }
+
+    Ok((OffsetBuffer::new(ScalarBuffer::from(offsets)), child_rows))
+}
+
+fn list_vector_to_arrow_array(vector: &ListVector<'_>, rows: &SourceRows) -> Result<ArrayRef, Box<dyn Error>> {
+    let (offsets, child_rows) = list_layout(vector, rows)?;
+    // SAFETY: the child pointer remains owned by `vector`, and `list_layout`
+    // bounded every selected child row by the committed, reserved child span.
+    let values = unsafe { raw_vector_to_arrow_array(vector.child_ptr(), &child_rows) }?;
+    let field = Arc::new(Field::new("item", values.data_type().clone(), true));
+    let nulls = null_buffer(rows);
+
+    Ok(Arc::new(ListArray::try_new(field, offsets, values, nulls)?))
+}
+
+fn map_vector_to_arrow_array(vector: &ListVector<'_>, rows: &SourceRows) -> Result<ArrayRef, Box<dyn Error>> {
+    let (offsets, child_rows) = list_layout(vector, rows)?;
+    let entries_len = child_rows.len();
+    // SAFETY: the map child is a struct with one row per list child entry, and
+    // safe list size commits reserve that full span.
+    let entries_vector = unsafe { StructVector::from_raw_with_capacity(vector.child_ptr(), vector.len()) };
+
+    for source_row in child_rows.iter().flatten().copied() {
+        if entries_vector.try_row_is_null(source_row as u64)? {
+            return Err(format!("DuckDB map entry at child row {source_row} is null").into());
+        }
+    }
+
+    // SAFETY: map entry children share the entry struct's reserved row span,
+    // and `child_rows` was bounded by the map's committed child length.
+    let keys = unsafe { raw_vector_to_arrow_array(entries_vector.child_ptr(0), &child_rows) }?;
+    if keys.null_count() > 0 {
+        let source_row = child_rows
+            .iter()
+            .enumerate()
+            .find(|(output_row, _)| keys.is_null(*output_row))
+            .and_then(|(_, source_row)| *source_row);
+        let message = source_row.map_or_else(
+            || "DuckDB map key is null".to_string(),
+            |source_row| format!("DuckDB map key at child row {source_row} is null"),
+        );
+        return Err(message.into());
+    }
+    // SAFETY: the same entry span and selected rows apply to the value child.
+    let values = unsafe { raw_vector_to_arrow_array(entries_vector.child_ptr(1), &child_rows) }?;
+    let fields = Fields::from(vec![
+        Field::new("keys", keys.data_type().clone(), false),
+        Field::new("values", values.data_type().clone(), true),
+    ]);
+    let entries = StructArray::try_new_with_length(fields, vec![keys, values], None, entries_len)?;
+    let field = Arc::new(Field::new("entries", entries.data_type().clone(), false));
+    let nulls = null_buffer(rows);
+
+    Ok(Arc::new(MapArray::try_new(field, offsets, entries, nulls, false)?))
+}
+
+fn array_vector_to_arrow_array(vector: &ArrayVector<'_>, rows: &SourceRows) -> Result<ArrayRef, Box<dyn Error>> {
+    let array_size = usize::try_from(vector.get_array_size())
+        .map_err(|_| "DuckDB array size exceeds usize range for Arrow conversion")?;
+    if array_size == 0 {
+        return Err("DuckDB array size must be greater than zero for Arrow conversion".into());
+    }
+    let value_length =
+        i32::try_from(array_size).map_err(|_| "DuckDB array size exceeds Arrow i32 value length range")?;
+    let child_rows = fixed_size_rows(rows, array_size)?;
+
+    // SAFETY: fixed-array child positions are derived with checked arithmetic
+    // from source rows already bounded by the parent vector capacity.
+    let values = unsafe { raw_vector_to_arrow_array(vector.child_ptr(), &child_rows) }?;
+    let field = Arc::new(Field::new("item", values.data_type().clone(), true));
+    let nulls = null_buffer(rows);
+
+    Ok(Arc::new(FixedSizeListArray::try_new(
+        field,
+        value_length,
+        values,
+        nulls,
+    )?))
+}
+
+fn struct_vector_to_arrow_array(vector: &StructVector<'_>, rows: &SourceRows) -> Result<ArrayRef, Box<dyn Error>> {
+    let logical_type = vector.logical_type();
+    let mut fields = Vec::with_capacity(logical_type.num_children());
+    let mut arrays = Vec::with_capacity(logical_type.num_children());
+
+    for idx in 0..logical_type.num_children() {
+        // SAFETY: struct children share the parent row allocation, and `rows`
+        // contains only rows bounded by the parent capacity.
+        let array = unsafe { raw_vector_to_arrow_array(vector.child_ptr(idx), rows) }?;
+        fields.push(Field::new(
+            logical_type.try_child_name(idx)?,
+            array.data_type().clone(),
+            true,
+        ));
+        arrays.push(array);
+    }
+
+    let nulls = null_buffer(rows);
+    Ok(Arc::new(StructArray::try_new_with_length(
+        Fields::from(fields),
+        arrays,
+        nulls,
+        rows.len(),
+    )?))
+}
+
+/// Converts a DuckDB data chunk to an Arrow record batch.
+///
+/// The Arrow schema is synthesized from DuckDB logical types. Top-level column
+/// names are synthesized as `"0"`, `"1"`, and so on. List
+/// and map child names use Arrow's conventional names, struct children are
+/// nullable, field metadata is not preserved, and lists use 32-bit Arrow
+/// offsets. Timestamp mappings retain this adapter's legacy physical-carrier
+/// behavior and do not provide native unit or timezone fidelity.
+pub fn data_chunk_to_arrow(chunk: &DataChunkHandle) -> Result<RecordBatch, Box<dyn Error>> {
     let len = chunk.len();
 
     let columns = (0..chunk.num_columns())
         .map(|i| {
-            let mut vector = chunk.flat_vector(i);
-            flat_vector_to_arrow_array(&mut vector, len).map(|array| {
-                assert_eq!(array.len(), chunk.len());
-                (i.to_string(), array)
-            })
+            let vector = chunk.flat_vector(i);
+            flat_vector_to_arrow_array(&vector, len)
+                .map(|array| (i.to_string(), array))
+                .map_err(|err| -> Box<dyn Error> { format!("DuckDB column {i}: {err}").into() })
         })
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(RecordBatch::try_from_iter(columns)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::checked_list_output_len;
+
+    #[test]
+    fn list_output_length_is_checked_before_gathering_rows() {
+        let max_offset = i32::MAX as usize;
+        assert_eq!(checked_list_output_len(max_offset - 1, 1).unwrap(), i32::MAX);
+
+        let err = checked_list_output_len(max_offset, 1).unwrap_err();
+        assert_eq!(err.to_string(), "DuckDB list values exceed Arrow i32 offset range");
+    }
 }

--- a/crates/duckdb/src/arrow_interop/tests/from_duckdb_nested.rs
+++ b/crates/duckdb/src/arrow_interop/tests/from_duckdb_nested.rs
@@ -1,0 +1,482 @@
+use super::*;
+use arrow::datatypes::Int32Type;
+
+fn data_chunk_roundtrip_single_array(array: ArrayRef) -> Result<ArrayRef, Box<dyn Error>> {
+    let input_data_type = array.data_type().clone();
+    let chunk = single_array_data_chunk(array)?;
+    let output = data_chunk_to_arrow(&chunk)?.column(0).clone();
+    assert_eq!(output.data_type(), &input_data_type);
+
+    Ok(output)
+}
+
+/// Asserts the chunk-level Arrow read reproduces `array` exactly.
+#[track_caller]
+fn assert_roundtrip_identity(array: ArrayRef) -> Result<(), Box<dyn Error>> {
+    let output = data_chunk_roundtrip_single_array(array.clone())?;
+    assert_eq!(output.as_ref(), array.as_ref());
+
+    Ok(())
+}
+
+/// Builds a single-column chunk of `LIST(child)` committed to `rows` rows.
+fn list_chunk(child: &LogicalTypeHandle, rows: usize) -> DataChunkHandle {
+    let chunk = DataChunkHandle::new(&[LogicalTypeHandle::list(child)]);
+    chunk.set_len(rows);
+    chunk
+}
+
+/// Builds a `MAP(VARCHAR, INTEGER)` chunk with one row holding one entry.
+fn single_entry_map_chunk() -> DataChunkHandle {
+    let map_type = LogicalTypeHandle::map(
+        &LogicalTypeHandle::from(LogicalTypeId::Varchar),
+        &LogicalTypeHandle::from(LogicalTypeId::Integer),
+    );
+    let chunk = DataChunkHandle::new(&[map_type]);
+    chunk.set_len(1);
+    let mut map = chunk.list_vector(0);
+    map.set_entry(0, 0, 1);
+    map.set_len(1);
+    chunk
+}
+
+#[track_caller]
+fn assert_conversion_err(chunk: &DataChunkHandle, expected: &str) {
+    assert_eq!(data_chunk_to_arrow(chunk).unwrap_err().to_string(), expected);
+}
+
+#[test]
+fn test_flat_vector_to_arrow_rejects_len_beyond_capacity() {
+    let chunk = DataChunkHandle::new(&[LogicalTypeId::Integer.into()]);
+    let vector = chunk.flat_vector(0);
+    let len = vector.capacity() + 1;
+
+    let err = flat_vector_to_arrow_array(&vector, len).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "DuckDB vector length {len} exceeds backing capacity {}",
+            vector.capacity()
+        )
+    );
+}
+
+#[test]
+fn test_data_chunk_to_arrow_returns_error_for_unsupported_nested_type() {
+    let chunk = list_chunk(&LogicalTypeHandle::decimal(10, 2), 1);
+    chunk.list_vector(0).set_entry(0, 0, 0);
+
+    assert_conversion_err(
+        &chunk,
+        "DuckDB column 0: Cannot convert DuckDB logical type Decimal to Arrow",
+    );
+}
+
+#[test]
+fn test_data_chunk_to_arrow_rejects_list_entry_beyond_child_len() {
+    let list_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
+    let chunk = DataChunkHandle::new(&[LogicalTypeId::Integer.into(), list_type]);
+    chunk.set_len(1);
+
+    let mut list = chunk.list_vector(1);
+    list.set_entry(0, 0, 2);
+    unsafe { list.set_child(&[10_i32]) };
+
+    assert_conversion_err(
+        &chunk,
+        "DuckDB column 1: DuckDB list entry at row 0 ends at 2, beyond child length 1",
+    );
+}
+
+#[test]
+fn test_data_chunk_to_arrow_rejects_overflowing_list_entry() {
+    let chunk = list_chunk(&LogicalTypeId::Integer.into(), 1);
+    chunk.list_vector(0).set_entry(0, usize::MAX, 1);
+
+    assert_conversion_err(&chunk, "DuckDB column 0: DuckDB list entry at row 0 overflows usize");
+}
+
+#[test]
+fn test_data_chunk_to_arrow_accepts_empty_list_with_stale_offset() -> Result<(), Box<dyn Error>> {
+    let chunk = list_chunk(&LogicalTypeId::Integer.into(), 1);
+    chunk.list_vector(0).set_entry(0, usize::MAX, 0);
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_list::<i32>();
+    assert_eq!(output.value_offsets(), &[0, 0]);
+    assert!(output.values().is_empty());
+    assert!(output.is_valid(0));
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_rejects_array_in_list_beyond_child_len() {
+    // The child length is measured in array-child rows, not flattened values,
+    // so one committed row of ARRAY(2) rejects an entry ending at 2.
+    let array_type = LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2);
+    let chunk = list_chunk(&array_type, 1);
+    let mut list = chunk.list_vector(0);
+    list.set_entry(0, 0, 2);
+    list.set_len(1);
+
+    assert_conversion_err(
+        &chunk,
+        "DuckDB column 0: DuckDB list entry at row 0 ends at 2, beyond child length 1",
+    );
+}
+
+#[test]
+fn test_data_chunk_to_arrow_reads_list_larger_than_standard_vector() -> Result<(), Box<dyn Error>> {
+    const CHILD_COUNT: usize = 3000;
+
+    let chunk = list_chunk(&LogicalTypeId::Integer.into(), 1);
+    let mut list = chunk.list_vector(0);
+    list.set_entry(0, 0, CHILD_COUNT);
+    let values = (0..CHILD_COUNT as i32).collect::<Vec<_>>();
+    unsafe { list.set_child(&values) };
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_list::<i32>();
+    let values = output.values().as_primitive::<Int32Type>();
+
+    assert_eq!(output.value_length(0), CHILD_COUNT as i32);
+    assert_eq!(values.value(CHILD_COUNT - 1), (CHILD_COUNT - 1) as i32);
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_reads_map_larger_than_standard_vector() -> Result<(), Box<dyn Error>> {
+    const ENTRY_COUNT: usize = 3000;
+
+    let map_type = LogicalTypeHandle::map(
+        &LogicalTypeHandle::from(LogicalTypeId::Integer),
+        &LogicalTypeHandle::from(LogicalTypeId::Integer),
+    );
+    let chunk = DataChunkHandle::new(&[map_type]);
+    chunk.set_len(1);
+    let mut map = chunk.list_vector(0);
+    map.set_entry(0, 0, ENTRY_COUNT);
+    map.set_len(ENTRY_COUNT);
+    let entries = map.struct_child(ENTRY_COUNT);
+    let values = (0..ENTRY_COUNT as i32).collect::<Vec<_>>();
+    unsafe {
+        entries.child(0, ENTRY_COUNT).copy(&values);
+        entries.child(1, ENTRY_COUNT).copy(&values);
+    }
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_map();
+    let keys = output.keys().as_primitive::<Int32Type>();
+    let values = output.values().as_primitive::<Int32Type>();
+
+    assert_eq!(output.value_length(0), ENTRY_COUNT as i32);
+    assert_eq!(keys.value(ENTRY_COUNT - 1), (ENTRY_COUNT - 1) as i32);
+    assert_eq!(values.value(ENTRY_COUNT - 1), (ENTRY_COUNT - 1) as i32);
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_handles_empty_list_chunk() -> Result<(), Box<dyn Error>> {
+    let lists = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0])),
+        Arc::new(Int32Array::from(Vec::<i32>::new())),
+        None,
+    );
+
+    assert_roundtrip_identity(Arc::new(lists))
+}
+
+#[test]
+fn test_data_chunk_to_arrow_preserves_top_level_struct_nulls() -> Result<(), Box<dyn Error>> {
+    let fields = Fields::from(vec![
+        Field::new("i", DataType::Int32, true),
+        Field::new("s", DataType::Utf8, true),
+    ]);
+    let struct_array = StructArray::new(
+        fields,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef,
+            Arc::new(StringArray::from(vec!["one", "hidden", "three"])) as ArrayRef,
+        ],
+        Some(NullBuffer::from([true, false, true].as_slice())),
+    );
+
+    let output = data_chunk_roundtrip_single_array(Arc::new(struct_array))?;
+    let output = output.as_struct();
+    assert!(output.is_valid(0));
+    assert!(output.is_null(1));
+    assert!(output.is_valid(2));
+    assert!(output.column(0).is_null(1));
+    assert!(output.column(1).is_null(1));
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_ignores_null_list_entries() -> Result<(), Box<dyn Error>> {
+    let chunk = list_chunk(&LogicalTypeId::Integer.into(), 3);
+    let mut list = chunk.list_vector(0);
+    list.set_entry(0, 0, 2);
+    list.set_entry(1, usize::MAX, usize::MAX);
+    list.set_entry(2, 2, 1);
+    list.set_null(1);
+    unsafe { list.set_child(&[10_i32, 11, 30]) };
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_list::<i32>();
+    assert_eq!(output.value_offsets(), &[0, 2, 2, 3]);
+    assert!(output.is_null(1));
+    assert_eq!(output.values().as_primitive::<Int32Type>().values(), &[10, 11, 30]);
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_gathers_non_contiguous_list_entries() -> Result<(), Box<dyn Error>> {
+    let chunk = list_chunk(&LogicalTypeId::Integer.into(), 2);
+    let mut list = chunk.list_vector(0);
+    list.set_entry(0, 1, 2);
+    list.set_entry(1, 4, 1);
+    unsafe { list.set_child(&[99_i32, 10, 11, 98, 30]) };
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_list::<i32>();
+    assert_eq!(output.value_offsets(), &[0, 2, 3]);
+    assert_eq!(output.values().as_primitive::<Int32Type>().values(), &[10, 11, 30]);
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_gathers_non_contiguous_nested_lists() -> Result<(), Box<dyn Error>> {
+    let inner_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
+    let chunk = list_chunk(&inner_type, 2);
+    let mut outer = chunk.list_vector(0);
+    outer.set_entry(0, 1, 2);
+    outer.set_entry(1, 4, 1);
+    outer.set_len(5);
+
+    let mut inner = outer.list_child();
+    inner.set_entry(1, 0, 2);
+    inner.set_entry(2, 2, 1);
+    inner.set_entry(4, 3, 2);
+    unsafe { inner.set_child(&[10_i32, 11, 20, 40, 41]) };
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_list::<i32>();
+    let inner = output.values().as_list::<i32>();
+    let values = inner.values().as_primitive::<Int32Type>();
+
+    assert_eq!(output.value_offsets(), &[0, 2, 3]);
+    assert_eq!(inner.value_offsets(), &[0, 2, 3, 5]);
+    assert_eq!(values.values(), &[10, 11, 20, 40, 41]);
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_masks_array_children_under_null_parents() -> Result<(), Box<dyn Error>> {
+    let array_type = LogicalTypeHandle::array(&LogicalTypeId::Varchar.into(), 2);
+    let chunk = DataChunkHandle::new(&[array_type]);
+    chunk.set_len(2);
+
+    let mut array = chunk.array_vector(0);
+    let child = array.child(4);
+    child.insert(0, "one");
+    child.insert(1, "two");
+    array.set_null(1);
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_fixed_size_list();
+    let values = output.values().as_string::<i32>();
+    assert_eq!(values.value(0), "one");
+    assert_eq!(values.value(1), "two");
+    assert!(values.is_null(2));
+    assert!(values.is_null(3));
+    assert!(output.is_null(1));
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_gathers_sparse_array_rows_in_lists() -> Result<(), Box<dyn Error>> {
+    let array_type = LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2);
+    let chunk = list_chunk(&array_type, 2);
+    let mut list = chunk.list_vector(0);
+    list.set_entry(0, 1, 1);
+    list.set_entry(1, 3, 1);
+    list.set_len(4);
+    let arrays = list.array_child();
+    unsafe { arrays.set_child(&[90_i32, 91, 10, 11, 80, 81, 30, 31]) };
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_list::<i32>();
+    let arrays = output.values().as_fixed_size_list();
+    let values = arrays.values().as_primitive::<Int32Type>();
+
+    assert_eq!(output.value_offsets(), &[0, 1, 2]);
+    assert_eq!(values.values(), &[10, 11, 30, 31]);
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_masks_unwritten_struct_children() -> Result<(), Box<dyn Error>> {
+    let struct_type = LogicalTypeHandle::struct_type(&[("value", LogicalTypeHandle::from(LogicalTypeId::Varchar))]);
+    let chunk = DataChunkHandle::new(&[struct_type]);
+    chunk.set_len(1);
+
+    let mut struct_vector = chunk.struct_vector(0);
+    struct_vector.set_null(0);
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_struct();
+    let values = output.column(0).as_string::<i32>();
+
+    assert!(output.is_null(0));
+    assert!(values.is_null(0));
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_rejects_invalid_utf8_struct_field_name() {
+    use std::ffi::CString;
+
+    let child = LogicalTypeHandle::from(LogicalTypeId::Integer);
+    let name = CString::from_vec_with_nul(vec![b'f', 0x80, 0]).unwrap();
+    let mut child_types = [child.ptr];
+    let mut child_names = [name.as_ptr()];
+    let ptr = unsafe { crate::ffi::duckdb_create_struct_type(child_types.as_mut_ptr(), child_names.as_mut_ptr(), 1) };
+    let struct_type = unsafe { LogicalTypeHandle::new(ptr) };
+    let chunk = DataChunkHandle::new(&[struct_type]);
+
+    assert_conversion_err(
+        &chunk,
+        "DuckDB column 0: invalid utf-8 sequence of 1 bytes from index 1",
+    );
+}
+
+#[test]
+fn test_data_chunk_to_arrow_rejects_null_map_entries() {
+    let chunk = single_entry_map_chunk();
+    chunk.list_vector(0).struct_child(1).set_null(0);
+
+    assert_conversion_err(&chunk, "DuckDB column 0: DuckDB map entry at child row 0 is null");
+}
+
+#[test]
+fn test_data_chunk_to_arrow_rejects_null_map_keys() {
+    let chunk = single_entry_map_chunk();
+    chunk.list_vector(0).struct_child(1).child(0, 1).set_null(0);
+
+    assert_conversion_err(&chunk, "DuckDB column 0: DuckDB map key at child row 0 is null");
+}
+
+#[test]
+fn test_data_chunk_to_arrow_masks_invalid_boolean_payload_under_null() -> Result<(), Box<dyn Error>> {
+    let chunk = DataChunkHandle::new(&[LogicalTypeId::Boolean.into()]);
+    chunk.set_len(1);
+    let mut vector = chunk.flat_vector(0);
+    // A null slot need not contain a valid Rust `bool` representation.
+    unsafe { vector.copy(&[2_u8]) };
+    vector.set_null(0);
+
+    let output = data_chunk_to_arrow(&chunk)?;
+
+    assert!(output.column(0).as_boolean().is_null(0));
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_rejects_nanosecond_timestamp_overflow() {
+    let chunk = DataChunkHandle::new(&[LogicalTypeId::TimestampNs.into()]);
+    chunk.set_len(1);
+    let mut vector = chunk.flat_vector(0);
+    unsafe {
+        vector.copy(&[libduckdb_sys::duckdb_timestamp { micros: i64::MAX }]);
+    }
+
+    assert_conversion_err(
+        &chunk,
+        "DuckDB column 0: DuckDB nanosecond timestamp exceeds Arrow i64 range",
+    );
+}
+
+#[test]
+fn test_data_chunk_to_arrow_recurses_for_list_of_structs() -> Result<(), Box<dyn Error>> {
+    let struct_values = StructArray::from(vec![
+        (
+            Arc::new(Field::new("i", DataType::Int32, true)),
+            Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("s", DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![Some("one"), Some("two"), None])) as ArrayRef,
+        ),
+    ]);
+    let lists = ListArray::new(
+        Arc::new(Field::new("item", struct_values.data_type().clone(), true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 3])),
+        Arc::new(struct_values),
+        Some(NullBuffer::from([true, false, true].as_slice())),
+    );
+
+    assert_roundtrip_identity(Arc::new(lists))
+}
+
+#[test]
+fn test_data_chunk_to_arrow_recurses_for_map_with_list_values() -> Result<(), Box<dyn Error>> {
+    let list_values = ListArray::new(
+        Arc::new(Field::new("item", DataType::Int32, true)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 4])),
+        Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3), None])),
+        Some(NullBuffer::from([true, false, true].as_slice())),
+    );
+    let entries = StructArray::from(vec![
+        (
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("values", list_values.data_type().clone(), true)),
+            Arc::new(list_values) as ArrayRef,
+        ),
+    ]);
+    let map = MapArray::new(
+        Arc::new(Field::new("entries", entries.data_type().clone(), false)),
+        OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2, 3])),
+        entries,
+        Some(NullBuffer::from([true, false, true].as_slice())),
+        false,
+    );
+
+    assert_roundtrip_identity(Arc::new(map))
+}
+
+#[test]
+fn test_data_chunk_to_arrow_recurses_for_fixed_size_list() -> Result<(), Box<dyn Error>> {
+    let struct_values = StructArray::from(vec![
+        (
+            Arc::new(Field::new("i", DataType::Int32, true)),
+            Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3), Some(4)])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("s", DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![Some("one"), None, Some("three"), Some("four")])) as ArrayRef,
+        ),
+    ]);
+    let lists = FixedSizeListArray::new(
+        Arc::new(Field::new("item", struct_values.data_type().clone(), true)),
+        2,
+        Arc::new(struct_values),
+        Some(NullBuffer::from([true, false].as_slice())),
+    );
+
+    assert_roundtrip_identity(Arc::new(lists))
+}

--- a/crates/duckdb/src/arrow_interop/tests/mod.rs
+++ b/crates/duckdb/src/arrow_interop/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    UUID_BYTE_WIDTH, UUID_EXTENSION_NAME, data_chunk_to_arrow, record_batch_to_duckdb_data_chunk,
-    to_duckdb_logical_type, to_duckdb_logical_type_for_field,
+    UUID_BYTE_WIDTH, UUID_EXTENSION_NAME, data_chunk_to_arrow, flat_vector_to_arrow_array,
+    record_batch_to_duckdb_data_chunk, to_duckdb_logical_type, to_duckdb_logical_type_for_field,
 };
 use crate::{
     Connection, Result,
@@ -29,6 +29,7 @@ use arrow::{
 use std::{collections::HashMap, error::Error, sync::Arc};
 
 mod fixed_size_binary;
+mod from_duckdb_nested;
 mod nested;
 
 #[test]
@@ -346,6 +347,17 @@ fn roundtrip_single_array(array: ArrayRef) -> Result<ArrayRef, Box<dyn Error>> {
     let rb = stmt.query_arrow(param)?.next().expect("no record batch");
 
     Ok(rb.column(0).clone())
+}
+
+/// Writes a single-column record batch into a fresh DuckDB data chunk.
+fn single_array_data_chunk(array: ArrayRef) -> Result<DataChunkHandle, Box<dyn Error>> {
+    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array])?;
+    let logical_type = to_duckdb_logical_type(batch.column(0).data_type())?;
+    let mut chunk = DataChunkHandle::new(&[logical_type]);
+    record_batch_to_duckdb_data_chunk(&batch, &mut chunk)?;
+
+    Ok(chunk)
 }
 
 #[test]

--- a/crates/duckdb/src/arrow_interop/tests/nested.rs
+++ b/crates/duckdb/src/arrow_interop/tests/nested.rs
@@ -618,11 +618,7 @@ fn test_nested_list_sizes_are_set_to_child_counts() -> Result<(), Box<dyn Error>
         None,
     );
 
-    let schema = Schema::new(vec![Field::new("a", list_of_lists.data_type().clone(), true)]);
-    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_of_lists) as ArrayRef])?;
-    let logical_type = to_duckdb_logical_type(batch.column(0).data_type())?;
-    let mut chunk = DataChunkHandle::new(&[logical_type]);
-    record_batch_to_duckdb_data_chunk(&batch, &mut chunk)?;
+    let chunk = single_array_data_chunk(Arc::new(list_of_lists))?;
 
     let outer = chunk.list_vector(0);
     assert_eq!(outer.len(), 3);

--- a/crates/duckdb/src/arrow_interop/to_duckdb.rs
+++ b/crates/duckdb/src/arrow_interop/to_duckdb.rs
@@ -70,9 +70,7 @@ pub trait WritableVector {
 /// Borrowed child vector handle used while writing one nested Arrow child array.
 struct ChildVector<'a> {
     ptr: duckdb_vector,
-    /// Writable span for this child. Flat children use it as physical slots,
-    /// list children use it as list-entry rows, and array/struct routes ignore
-    /// it because their descendants re-derive their own spans.
+    /// This child vector's own writable row count.
     capacity: usize,
     _phantom: PhantomData<&'a mut ()>,
 }
@@ -131,7 +129,8 @@ impl WritableVector for ChildVector<'_> {
         // SAFETY: ChildVector mutably borrows the parent while this wrapper
         // exists, keeping `ptr` live and uniquely reached through this view.
         // The recursive dispatcher calls this only for scalar logical
-        // children, and `capacity` is that child vector's physical slot count.
+        // children, and `capacity` is the reserved row span for this child
+        // view.
         unsafe { FlatVector::with_capacity(self.ptr, self.capacity) }
     }
 
@@ -151,16 +150,17 @@ impl WritableVector for ChildVector<'_> {
         // SAFETY: ChildVector mutably borrows the parent while this wrapper
         // exists, keeping `ptr` live and uniquely reached through this view.
         // The recursive dispatcher calls this only for logical fixed-size-list
-        // children.
-        unsafe { ArrayVector::from_raw(self.ptr) }
+        // children, and `capacity` is this child vector's own row count.
+        unsafe { ArrayVector::from_raw_with_capacity(self.ptr, self.capacity) }
     }
 
     fn struct_vector(&mut self) -> StructVector<'_> {
         assert_child_type(self.ptr, "struct", |id| matches!(id, LogicalTypeId::Struct));
         // SAFETY: ChildVector mutably borrows the parent while this wrapper
         // exists, keeping `ptr` live and uniquely reached through this view.
-        // The recursive dispatcher calls this only for logical struct children.
-        unsafe { StructVector::from_raw(self.ptr) }
+        // The recursive dispatcher calls this only for logical struct children,
+        // and `capacity` is this child vector's own row count.
+        unsafe { StructVector::from_raw_with_capacity(self.ptr, self.capacity) }
     }
 }
 

--- a/crates/duckdb/src/core/logical_type.rs
+++ b/crates/duckdb/src/core/logical_type.rs
@@ -356,8 +356,22 @@ impl LogicalTypeHandle {
 
     /// Logical type child name by idx
     ///
+    /// Invalid UTF-8 bytes are replaced with the Unicode replacement character.
+    ///
     /// Panics if the logical type is not a struct or union, or if `idx` is out of range.
     pub fn child_name(&self, idx: usize) -> String {
+        self.child_name_string(idx).to_string_lossy().into_owned()
+    }
+
+    /// Logical type child name by idx, rejecting invalid UTF-8.
+    ///
+    /// Panics if the logical type is not a struct or union, or if `idx` is out
+    /// of range.
+    pub fn try_child_name(&self, idx: usize) -> crate::Result<String> {
+        Ok(self.child_name_string(idx).to_str()?.to_owned())
+    }
+
+    fn child_name_string(&self, idx: usize) -> DuckDbString {
         unsafe {
             let child_name_ptr = match self.id() {
                 LogicalTypeId::Struct => duckdb_struct_type_child_name(self.ptr, idx as u64),
@@ -368,9 +382,7 @@ impl LogicalTypeHandle {
             if child_name_ptr.is_null() {
                 panic!("child index {idx} out of range");
             }
-            let c_str = DuckDbString::from_ptr(child_name_ptr);
-            let name = c_str.to_str().unwrap();
-            name.to_string()
+            DuckDbString::from_ptr(child_name_ptr)
         }
     }
 
@@ -436,7 +448,10 @@ impl LogicalTypeHandle {
 
 #[cfg(test)]
 mod test {
+    use std::ffi::CString;
+
     use crate::core::{LogicalTypeHandle, LogicalTypeId};
+    use crate::ffi::duckdb_create_struct_type;
 
     #[test]
     fn test_struct() {
@@ -446,6 +461,19 @@ mod test {
         assert_eq!(typ.num_children(), 1);
         assert_eq!(typ.child_name(0), "hello");
         assert_eq!(typ.child(0).id(), LogicalTypeId::Boolean);
+    }
+
+    #[test]
+    fn test_struct_child_name_handles_invalid_utf8() {
+        let child = LogicalTypeHandle::from(LogicalTypeId::Integer);
+        let name = CString::from_vec_with_nul(vec![b'f', 0x80, 0]).unwrap();
+        let mut child_types = [child.ptr];
+        let mut child_names = [name.as_ptr()];
+        let ptr = unsafe { duckdb_create_struct_type(child_types.as_mut_ptr(), child_names.as_mut_ptr(), 1) };
+        let typ = unsafe { LogicalTypeHandle::new(ptr) };
+
+        assert_eq!(typ.child_name(0), "f\u{fffd}");
+        assert!(typ.try_child_name(0).is_err());
     }
 
     #[test]

--- a/crates/duckdb/src/core/vector.rs
+++ b/crates/duckdb/src/core/vector.rs
@@ -8,7 +8,7 @@
 //! caller-chosen and must not exceed the DuckDB vector's actual validity —
 //! that path does not track liveness in the type system.
 
-use std::{ffi::CString, marker::PhantomData, slice};
+use std::{cell::Cell, ffi::CString, marker::PhantomData, slice};
 
 use libduckdb_sys::{
     DuckDbString, duckdb_array_type_array_size, duckdb_array_vector_get_child, duckdb_validity_row_is_valid,
@@ -28,6 +28,14 @@ use crate::{
     },
 };
 
+/// Mirrors DuckDB's `DConstants::MAX_VECTOR_SIZE`, the largest allocation a
+/// single vector can hold (not the per-chunk row count reported by
+/// `duckdb_vector_size()`). `ListVector::Reserve` throws a C++ exception for
+/// larger requests, and `duckdb_list_vector_reserve` does not catch it, so the
+/// exception would cross the non-unwinding C boundary and abort the process.
+/// Rejecting such requests up front keeps them recoverable errors.
+const MAX_VECTOR_SIZE: u64 = 1 << 37;
+
 fn list_vector_state_result(state: duckdb_state, action: &str, size: usize) -> Result<()> {
     if state == DuckDBSuccess {
         Ok(())
@@ -36,6 +44,32 @@ fn list_vector_state_result(state: duckdb_state, action: &str, size: usize) -> R
             "failed to {action} {size} elements in DuckDB list vector"
         )))
     }
+}
+
+fn try_vector_row_is_null(ptr: duckdb_vector, row: u64, capacity: usize) -> Result<bool> {
+    let row_index = usize::try_from(row)
+        .map_err(|_| duckdb_failure_from_message(format!("row index {row} exceeds usize range")))?;
+    if row_index >= capacity {
+        return Err(duckdb_failure_from_message(format!(
+            "row index {row} exceeds vector capacity {capacity}"
+        )));
+    }
+    let valid = unsafe {
+        let validity = duckdb_vector_get_validity(ptr);
+
+        // validity can return a NULL pointer if the entire vector is valid
+        if validity.is_null() {
+            return Ok(false);
+        }
+
+        duckdb_validity_row_is_valid(validity, row)
+    };
+
+    Ok(!valid)
+}
+
+fn vector_row_is_null(ptr: duckdb_vector, row: u64, capacity: usize) -> bool {
+    try_vector_row_is_null(ptr, row, capacity).unwrap_or_else(|err| panic!("{err}"))
 }
 
 /// A flat (contiguous, scalar-row) vector borrowed from a
@@ -63,9 +97,9 @@ impl<'a> FlatVector<'a> {
     ///
     /// # Safety
     /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
-    /// The caller must ensure `capacity` matches the backing allocation for the
-    /// logical view being exposed. Later typed slice and copy methods trust this
-    /// value for bounds checks.
+    /// The caller must ensure `capacity` does not exceed the backing allocation
+    /// for the logical view being exposed. Later typed slice and copy methods
+    /// trust this value for bounds checks.
     pub(crate) unsafe fn with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
         Self {
             ptr,
@@ -79,22 +113,22 @@ impl<'a> FlatVector<'a> {
         self.capacity
     }
 
+    #[cfg(feature = "vtab-arrow")]
+    pub(crate) fn ptr(&self) -> duckdb_vector {
+        self.ptr
+    }
+
     /// Returns true if the row at the given index is null
+    ///
+    /// # Panics
+    /// Panics if `row` is outside the vector capacity.
     pub fn row_is_null(&self, row: u64) -> bool {
-        // use idx_t entry_idx = row_idx / 64; idx_t idx_in_entry = row_idx % 64; bool is_valid = validity_mask[entry_idx] & (1 « idx_in_entry);
-        // as the row is valid function is slower
-        let valid = unsafe {
-            let validity = duckdb_vector_get_validity(self.ptr);
+        vector_row_is_null(self.ptr, row, self.capacity)
+    }
 
-            // validity can return a NULL pointer if the entire vector is valid
-            if validity.is_null() {
-                return false;
-            }
-
-            duckdb_validity_row_is_valid(validity, row)
-        };
-
-        !valid
+    /// Returns whether the row is null, or an error if it is out of range.
+    pub fn try_row_is_null(&self, row: u64) -> Result<bool> {
+        try_vector_row_is_null(self.ptr, row, self.capacity)
     }
 
     /// Returns a mutable pointer to the vector's backing data cast to `T`.
@@ -249,6 +283,7 @@ impl Inserter<&Vec<u8>> for FlatVector<'_> {
 pub struct ListVector<'a> {
     /// ListVector does not own the vector pointer.
     entries: FlatVector<'a>,
+    reserved_child_capacity: Cell<usize>,
 }
 
 impl<'a> ListVector<'a> {
@@ -259,6 +294,7 @@ impl<'a> ListVector<'a> {
     pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
         Self {
             entries: unsafe { FlatVector::from_raw(ptr) },
+            reserved_child_capacity: Cell::new(0),
         }
     }
 
@@ -267,15 +303,20 @@ impl<'a> ListVector<'a> {
     /// # Safety
     /// `ptr` must be a valid list `duckdb_vector` that remains valid for all of
     /// `'a`, and `capacity` must not exceed the backing allocation available for
-    /// this vector's list entries.
-    #[cfg(feature = "vtab-arrow")]
+    /// this vector's list entries. Any committed child size reported by DuckDB
+    /// must also be covered by the child allocation, as it is when the size was
+    /// committed through this wrapper or produced by DuckDB.
     pub(crate) unsafe fn from_raw_with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
         Self {
             entries: unsafe { FlatVector::with_capacity(ptr, capacity) },
+            reserved_child_capacity: Cell::new(0),
         }
     }
 
-    /// Returns the number of entries in the list vector.
+    /// Returns the number of child elements stored by the list vector.
+    ///
+    /// This is the upper bound for the end of non-empty list entries, not the
+    /// number of parent list rows.
     pub fn len(&self) -> usize {
         unsafe { duckdb_list_vector_get_size(self.entries.ptr) as usize }
     }
@@ -308,22 +349,58 @@ impl<'a> ListVector<'a> {
             .try_child_ptr_with_capacity(capacity)
             .unwrap_or_else(|err| panic!("{err}"));
         // SAFETY: DuckDB accepted the reserve for `capacity` child values.
-        unsafe { StructVector::from_raw(ptr) }
+        unsafe { StructVector::from_raw_with_capacity(ptr, capacity) }
+    }
+
+    /// Capacity of the child vector's backing storage.
+    ///
+    /// DuckDB initializes list children with standard vector capacity. This
+    /// wrapper tracks larger explicit reservations, and larger committed sizes
+    /// must already have been reserved; the safe size setters and
+    /// DuckDB-produced chunks preserve that invariant.
+    fn child_capacity(&self) -> usize {
+        self.len()
+            .max(self.reserved_child_capacity.get())
+            .max(unsafe { duckdb_vector_size() as usize })
     }
 
     /// Take the child as [ArrayVector].
     pub fn array_child(&self) -> ArrayVector<'a> {
-        unsafe { ArrayVector::from_raw(duckdb_list_vector_get_child(self.entries.ptr)) }
+        // SAFETY: `child_capacity` is covered by the child's backing storage.
+        unsafe {
+            ArrayVector::from_raw_with_capacity(duckdb_list_vector_get_child(self.entries.ptr), self.child_capacity())
+        }
     }
 
     /// Take the child as [ListVector].
     pub fn list_child(&self) -> ListVector<'a> {
-        unsafe { ListVector::from_raw(duckdb_list_vector_get_child(self.entries.ptr)) }
+        // SAFETY: `child_capacity` is covered by the child's backing storage.
+        unsafe {
+            ListVector::from_raw_with_capacity(duckdb_list_vector_get_child(self.entries.ptr), self.child_capacity())
+        }
     }
 
     pub(crate) fn try_child_ptr_with_capacity(&self, capacity: usize) -> Result<duckdb_vector> {
         self.try_reserve(capacity)?;
         Ok(unsafe { duckdb_list_vector_get_child(self.entries.ptr) })
+    }
+
+    #[cfg(feature = "vtab-arrow")]
+    pub(crate) fn child_ptr(&self) -> duckdb_vector {
+        unsafe { duckdb_list_vector_get_child(self.entries.ptr) }
+    }
+
+    /// Returns true if the row at the given index is null.
+    ///
+    /// # Panics
+    /// Panics if `row` is outside the vector capacity.
+    pub fn row_is_null(&self, row: u64) -> bool {
+        self.entries.row_is_null(row)
+    }
+
+    /// Returns whether the row is null, or an error if it is out of range.
+    pub fn try_row_is_null(&self, row: u64) -> Result<bool> {
+        self.entries.try_row_is_null(row)
     }
 
     /// Set primitive data to the child node.
@@ -342,16 +419,64 @@ impl<'a> ListVector<'a> {
     }
 
     /// Set offset and length to the entry.
+    ///
+    /// # Panics
+    /// Panics if `idx` is outside the vector capacity.
     pub fn set_entry(&mut self, idx: usize, offset: usize, length: usize) {
-        let entries = unsafe { self.entries.as_mut_slice::<duckdb_list_entry>() };
-        entries[idx].offset = offset as u64;
-        entries[idx].length = length as u64;
+        assert!(
+            idx < self.entries.capacity(),
+            "list entry row {idx} exceeds vector capacity {}",
+            self.entries.capacity()
+        );
+        // SAFETY: the bounds check above keeps the write inside the entry
+        // allocation, and a single-slot write avoids materializing a slice
+        // over neighboring entries DuckDB may have left uninitialized.
+        unsafe {
+            self.entries
+                .as_mut_ptr::<duckdb_list_entry>()
+                .add(idx)
+                .write(duckdb_list_entry {
+                    offset: offset as u64,
+                    length: length as u64,
+                });
+        }
     }
 
     /// Get offset and length for the entry at index.
+    ///
+    /// # Panics
+    /// Panics if the entry is out of range or its offset or length cannot fit
+    /// in `usize` on the current target.
     pub fn get_entry(&self, idx: usize) -> (usize, usize) {
-        let entry = (unsafe { self.entries.as_slice::<duckdb_list_entry>() })[idx];
-        (entry.offset as usize, entry.length as usize)
+        self.try_get_entry(idx).unwrap_or_else(|err| panic!("{err}"))
+    }
+
+    /// Returns the entry offset and length, or an error if the entry is out of
+    /// range or cannot be represented on the current target.
+    pub fn try_get_entry(&self, idx: usize) -> Result<(usize, usize)> {
+        if idx >= self.entries.capacity() {
+            return Err(duckdb_failure_from_message(format!(
+                "list entry row {idx} exceeds vector capacity {}",
+                self.entries.capacity()
+            )));
+        }
+        // SAFETY: the bounds check above keeps the read inside the entry
+        // allocation, and a single-slot read avoids materializing a slice
+        // over neighboring entries DuckDB may have left uninitialized.
+        let entry = unsafe { self.entries.as_mut_ptr::<duckdb_list_entry>().add(idx).read() };
+        let offset = usize::try_from(entry.offset).map_err(|_| {
+            duckdb_failure_from_message(format!(
+                "DuckDB list entry offset {} at row {idx} exceeds usize range",
+                entry.offset
+            ))
+        })?;
+        let length = usize::try_from(entry.length).map_err(|_| {
+            duckdb_failure_from_message(format!(
+                "DuckDB list entry length {} at row {idx} exceeds usize range",
+                entry.length
+            ))
+        })?;
+        Ok((offset, length))
     }
 
     /// Set row as null
@@ -365,23 +490,36 @@ impl<'a> ListVector<'a> {
 
     /// Reserve space for `capacity` child values.
     ///
-    /// This is public so callers can surface DuckDB allocation errors without
-    /// using the panic-based convenience methods.
+    /// This is public so callers can handle reservation errors without the
+    /// panic-based convenience methods. Requests beyond DuckDB's maximum
+    /// vector size (`2^37` elements) are rejected here as `Err`, because
+    /// DuckDB reports them with a C++ exception the C API does not catch.
+    /// Allocation failure inside DuckDB escapes the same way and aborts the
+    /// process; it cannot be returned as an error through the current C API.
     pub fn try_reserve(&self, capacity: usize) -> Result<()> {
+        if capacity as u64 > MAX_VECTOR_SIZE {
+            return Err(duckdb_failure_from_message(format!(
+                "cannot reserve {capacity} elements in DuckDB list vector: exceeds maximum vector size {MAX_VECTOR_SIZE}"
+            )));
+        }
         let state = unsafe { duckdb_list_vector_reserve(self.entries.ptr, capacity as u64) };
-        list_vector_state_result(state, "reserve child storage for", capacity)
+        list_vector_state_result(state, "reserve child storage for", capacity)?;
+        self.reserved_child_capacity
+            .set(self.reserved_child_capacity.get().max(capacity));
+        Ok(())
     }
 
-    /// Set the length of the list vector.
+    /// Reserve child storage and set the length of the list vector.
     ///
-    /// Panics if DuckDB rejects the size update. Use [`Self::try_set_len`] to
-    /// handle that error explicitly.
+    /// Panics if DuckDB rejects the reserve or size update. Use
+    /// [`Self::try_set_len`] to handle that error explicitly.
     pub fn set_len(&self, new_len: usize) {
         self.try_set_len(new_len).unwrap_or_else(|err| panic!("{err}"));
     }
 
-    /// Set the length of the list vector.
+    /// Reserve child storage and set the length of the list vector.
     pub fn try_set_len(&self, new_len: usize) -> Result<()> {
+        self.try_reserve(new_len)?;
         let state = unsafe { duckdb_list_vector_set_size(self.entries.ptr, new_len as u64) };
         list_vector_state_result(state, "set size to", new_len)
     }
@@ -393,6 +531,7 @@ impl<'a> ListVector<'a> {
 /// Exposes a fixed-width list whose child storage is contiguous across all rows.
 pub struct ArrayVector<'a> {
     ptr: duckdb_vector,
+    capacity: usize,
     _phantom: PhantomData<&'a ()>,
 }
 
@@ -402,8 +541,18 @@ impl<'a> ArrayVector<'a> {
     /// # Safety
     /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
     pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+        unsafe { Self::from_raw_with_capacity(ptr, duckdb_vector_size() as usize) }
+    }
+
+    /// Wrap a raw array vector pointer with a caller-supplied row capacity.
+    ///
+    /// # Safety
+    /// `ptr` must be a valid array `duckdb_vector` that remains valid for all
+    /// of `'a`, and `capacity` must not exceed the backing row allocation.
+    pub(crate) unsafe fn from_raw_with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
         Self {
             ptr,
+            capacity,
             _phantom: PhantomData,
         }
     }
@@ -419,11 +568,25 @@ impl<'a> ArrayVector<'a> {
         unsafe { duckdb_array_type_array_size(ty.ptr) as u64 }
     }
 
+    /// Returns true if the row at the given index is null.
+    ///
+    /// # Panics
+    /// Panics if `row` is outside the vector capacity.
+    pub fn row_is_null(&self, row: u64) -> bool {
+        vector_row_is_null(self.ptr, row, self.capacity)
+    }
+
+    /// Returns whether the row is null, or an error if it is out of range.
+    pub fn try_row_is_null(&self, row: u64) -> Result<bool> {
+        try_vector_row_is_null(self.ptr, row, self.capacity)
+    }
+
     /// Returns the child vector.
     /// capacity should be a multiple of the array size.
     ///
     /// # Panics
-    /// Panics if `capacity` is not a multiple of the fixed array size.
+    /// Panics if `capacity` is not a multiple of the fixed array size or exceeds
+    /// the child allocation derived from the parent capacity.
     // TODO: not ideal interface. Where should we keep count.
     pub fn child(&self, capacity: usize) -> FlatVector<'a> {
         let array_size = self.get_array_size() as usize;
@@ -432,9 +595,16 @@ impl<'a> ArrayVector<'a> {
             0,
             "array child capacity must be a multiple of the fixed array size"
         );
-        // SAFETY: callers must pass a capacity covered by the array child
-        // backing allocation. The multiple-of-array-size assertion checks only
-        // fixed-size-list shape, not allocation size.
+        let child_capacity = self
+            .capacity
+            .checked_mul(array_size)
+            .expect("array child capacity overflows usize");
+        assert!(
+            capacity <= child_capacity,
+            "array child capacity {capacity} exceeds backing capacity {child_capacity}"
+        );
+        // SAFETY: fixed-array children contain `array_size` values per parent
+        // row, and the checks above bound `capacity` by that allocation.
         unsafe { FlatVector::with_capacity(self.child_ptr(), capacity) }
     }
 
@@ -472,6 +642,7 @@ impl<'a> ArrayVector<'a> {
 /// Groups one child vector per struct field, all sharing the same row count.
 pub struct StructVector<'a> {
     ptr: duckdb_vector,
+    capacity: usize,
     _phantom: PhantomData<&'a ()>,
 }
 
@@ -481,16 +652,34 @@ impl<'a> StructVector<'a> {
     /// # Safety
     /// `ptr` must be a valid `duckdb_vector` that remains valid for all of `'a`.
     pub(crate) unsafe fn from_raw(ptr: duckdb_vector) -> Self {
+        unsafe { Self::from_raw_with_capacity(ptr, duckdb_vector_size() as usize) }
+    }
+
+    /// Wrap a raw struct vector pointer with a caller-supplied row capacity.
+    ///
+    /// # Safety
+    /// `ptr` must be a valid struct `duckdb_vector` that remains valid for all
+    /// of `'a`, and `capacity` must not exceed the backing row allocation.
+    pub(crate) unsafe fn from_raw_with_capacity(ptr: duckdb_vector, capacity: usize) -> Self {
         Self {
             ptr,
+            capacity,
             _phantom: PhantomData,
         }
     }
 
     /// Returns the child by idx in the struct vector.
+    ///
+    /// # Panics
+    /// Panics if `capacity` exceeds the parent vector capacity.
     pub fn child(&self, idx: usize, capacity: usize) -> FlatVector<'a> {
-        // SAFETY: struct children share the parent allocation, and callers pass
-        // the row capacity for the child view they are exposing.
+        assert!(
+            capacity <= self.capacity,
+            "struct child capacity {capacity} exceeds parent capacity {}",
+            self.capacity
+        );
+        // SAFETY: struct children share the parent allocation, and the check
+        // above bounds the exposed child view by the parent capacity.
         unsafe { FlatVector::with_capacity(self.child_ptr(idx), capacity) }
     }
 
@@ -499,17 +688,17 @@ impl<'a> StructVector<'a> {
 
     /// Take the child as [StructVector].
     pub fn struct_vector_child(&self, idx: usize) -> StructVector<'a> {
-        unsafe { StructVector::from_raw(self.child_ptr(idx)) }
+        unsafe { StructVector::from_raw_with_capacity(self.child_ptr(idx), self.capacity) }
     }
 
     /// Take the child as [ListVector].
     pub fn list_vector_child(&self, idx: usize) -> ListVector<'a> {
-        unsafe { ListVector::from_raw(self.child_ptr(idx)) }
+        unsafe { ListVector::from_raw_with_capacity(self.child_ptr(idx), self.capacity) }
     }
 
     /// Take the child as [ArrayVector].
     pub fn array_vector_child(&self, idx: usize) -> ArrayVector<'a> {
-        unsafe { ArrayVector::from_raw(self.child_ptr(idx)) }
+        unsafe { ArrayVector::from_raw_with_capacity(self.child_ptr(idx), self.capacity) }
     }
 
     pub(crate) fn child_ptr(&self, idx: usize) -> duckdb_vector {
@@ -519,6 +708,19 @@ impl<'a> StructVector<'a> {
     /// Get the logical type of this struct vector.
     pub fn logical_type(&self) -> LogicalTypeHandle {
         unsafe { LogicalTypeHandle::new(duckdb_vector_get_column_type(self.ptr)) }
+    }
+
+    /// Returns true if the row at the given index is null.
+    ///
+    /// # Panics
+    /// Panics if `row` is outside the vector capacity.
+    pub fn row_is_null(&self, row: u64) -> bool {
+        vector_row_is_null(self.ptr, row, self.capacity)
+    }
+
+    /// Returns whether the row is null, or an error if it is out of range.
+    pub fn try_row_is_null(&self, row: u64) -> Result<bool> {
+        try_vector_row_is_null(self.ptr, row, self.capacity)
     }
 
     /// Get the name of the child by idx.
@@ -600,6 +802,31 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "exceeds vector capacity")]
+    fn test_flat_vector_row_is_null_checks_capacity() {
+        let chunk = DataChunkHandle::new(&[LogicalTypeId::Integer.into()]);
+        let vector = chunk.flat_vector(0);
+
+        vector.row_is_null(unsafe { duckdb_vector_size() });
+    }
+
+    #[test]
+    fn test_vector_try_row_is_null_rejects_row_beyond_capacity() {
+        let row = unsafe { duckdb_vector_size() };
+        let chunk = DataChunkHandle::new(&[
+            LogicalTypeId::Integer.into(),
+            LogicalTypeHandle::list(&LogicalTypeId::Integer.into()),
+            LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2),
+            LogicalTypeHandle::struct_type(&[("value", LogicalTypeId::Integer.into())]),
+        ]);
+
+        assert!(chunk.flat_vector(0).try_row_is_null(row).is_err());
+        assert!(chunk.list_vector(1).try_row_is_null(row).is_err());
+        assert!(chunk.array_vector(2).try_row_is_null(row).is_err());
+        assert!(chunk.struct_vector(3).try_row_is_null(row).is_err());
+    }
+
+    #[test]
     fn test_struct_vector_typed_child_accessors_smoke() {
         let int_type = LogicalTypeHandle::from(LogicalTypeId::Integer);
         let list_type = LogicalTypeHandle::list(&int_type);
@@ -635,6 +862,28 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "exceeds parent capacity")]
+    fn test_struct_vector_child_rejects_capacity_beyond_parent() {
+        let struct_type = LogicalTypeHandle::struct_type(&[("value", LogicalTypeHandle::from(LogicalTypeId::Integer))]);
+        let chunk = DataChunkHandle::new(&[struct_type]);
+        let vector = chunk.struct_vector(0);
+        let capacity = unsafe { duckdb_vector_size() as usize } + 1;
+
+        vector.child(0, capacity);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds backing capacity")]
+    fn test_array_vector_child_rejects_capacity_beyond_parent() {
+        let array_type = LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2);
+        let chunk = DataChunkHandle::new(&[array_type]);
+        let vector = chunk.array_vector(0);
+        let capacity = (unsafe { duckdb_vector_size() as usize } + 1) * 2;
+
+        vector.child(capacity);
+    }
+
+    #[test]
     fn test_array_vector_set_child_uses_reserved_nested_capacity() -> Result<()> {
         let item_type = LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2);
         let list_type = LogicalTypeHandle::list(&item_type);
@@ -652,5 +901,93 @@ mod tests {
         assert_eq!(output[data.len() - 1], data[data.len() - 1]);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_list_vector_set_len_reserves_list_child_storage() {
+        let child_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
+        let list_type = LogicalTypeHandle::list(&child_type);
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+        let child_count = unsafe { duckdb_vector_size() as usize } + 1;
+        list.set_len(child_count);
+
+        let mut child = list.list_child();
+        child.set_entry(child_count - 1, 0, 0);
+
+        assert_eq!(child.get_entry(child_count - 1), (0, 0));
+        assert!(!child.row_is_null((child_count - 1) as u64));
+    }
+
+    #[test]
+    fn test_list_vector_set_len_reserves_array_child_storage() {
+        let child_type = LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2);
+        let list_type = LogicalTypeHandle::list(&child_type);
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+        let child_count = unsafe { duckdb_vector_size() as usize } + 1;
+        list.set_len(child_count);
+
+        let child = list.array_child();
+
+        assert!(!child.row_is_null((child_count - 1) as u64));
+    }
+
+    #[test]
+    fn test_list_vector_try_get_entry_rejects_row_beyond_capacity() {
+        let list_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+        let row = unsafe { duckdb_vector_size() as usize };
+
+        let err = list.try_get_entry(row).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!("list entry row {row} exceeds vector capacity {row}")
+        );
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_list_vector_try_set_len_rejects_oversized_capacity() {
+        let list_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+        let oversized = MAX_VECTOR_SIZE as usize + 1;
+
+        let err = list.try_set_len(oversized).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "cannot reserve {oversized} elements in DuckDB list vector: exceeds maximum vector size {MAX_VECTOR_SIZE}"
+            )
+        );
+    }
+
+    #[test]
+    fn test_list_vector_list_child_retains_default_capacity_before_len() {
+        let child_type = LogicalTypeHandle::list(&LogicalTypeId::Integer.into());
+        let list_type = LogicalTypeHandle::list(&child_type);
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+
+        let mut child = list.list_child();
+        child.set_entry(0, 0, 0);
+
+        assert_eq!(child.get_entry(0), (0, 0));
+    }
+
+    #[test]
+    fn test_list_vector_array_child_retains_default_capacity_before_len() {
+        let child_type = LogicalTypeHandle::array(&LogicalTypeId::Integer.into(), 2);
+        let list_type = LogicalTypeHandle::list(&child_type);
+        let chunk = DataChunkHandle::new(&[list_type]);
+        let list = chunk.list_vector(0);
+
+        let child = list.array_child();
+
+        assert!(!child.row_is_null(0));
     }
 }

--- a/crates/duckdb/src/vscalar/arrow.rs
+++ b/crates/duckdb/src/vscalar/arrow.rs
@@ -133,7 +133,7 @@ mod test {
     use std::{error::Error, sync::Arc};
 
     use arrow::{
-        array::{Array, RecordBatch, StringArray},
+        array::{Array, Int32Array, ListArray, RecordBatch, StringArray},
         datatypes::DataType,
     };
 
@@ -397,6 +397,60 @@ mod test {
         assert_eq!(string_values.value(0), "hello");
         assert_eq!(string_values.value(1), "world");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_scalar_reads_filtered_list_vectors() -> Result<(), Box<dyn Error>> {
+        struct ListFirstValueFunction;
+
+        impl VArrowScalar for ListFirstValueFunction {
+            type State = ();
+
+            fn invoke(_: &Self::State, input: RecordBatch) -> Result<Arc<dyn Array>, Box<dyn std::error::Error>> {
+                let lists = input.column(0).as_any().downcast_ref::<ListArray>().unwrap();
+                let first_values = lists
+                    .iter()
+                    .map(|value| value.map(|value| value.as_any().downcast_ref::<Int32Array>().unwrap().value(0)))
+                    .collect::<Int32Array>();
+                Ok(Arc::new(first_values))
+            }
+
+            fn signatures() -> Vec<ArrowFunctionSignature> {
+                vec![ArrowFunctionSignature::exact(
+                    vec![DataType::List(Arc::new(arrow::datatypes::Field::new(
+                        "item",
+                        DataType::Int32,
+                        true,
+                    )))],
+                    DataType::Int32,
+                )]
+            }
+        }
+
+        let conn = Connection::open_in_memory()?;
+        conn.register_scalar_function::<ListFirstValueFunction>("arrow_list_first_value")?;
+        conn.execute_batch(
+            "create table list_input as \
+             select i::integer as id, \
+                    case when i % 7 = 0 then null \
+                         else [i::integer, (i + 1)::integer] end as values \
+             from range(5000) t(i)",
+        )?;
+
+        let first_values = conn
+            .prepare(
+                "select arrow_list_first_value(values) \
+                 from list_input where id % 97 = 0 order by id",
+            )?
+            .query_map([], |row| row.get::<_, Option<i32>>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let expected = (0..5000)
+            .step_by(97)
+            .map(|id| if id % 7 == 0 { None } else { Some(id) })
+            .collect::<Vec<_>>();
+        assert_eq!(first_values, expected);
         Ok(())
     }
 }


### PR DESCRIPTION
This PR follows #811 and completes the conversion needed by `VArrowScalar`. Arrow scalar functions can now read DuckDB callback inputs containing `LIST`, `STRUCT`, `MAP`, and fixed-size `ARRAY` values.

The converter preserves nested nulls, handles filtered and non-contiguous values, supports large list and map children, and reports malformed input as errors. Tests cover direct data chunks and a registered scalar function.

This PR stays within the existing Arrow integration. Follow-up work will add native nested `Value`, `ValueRef`, and `ToSql` support and correct timestamp handling.

Closes #817