### PR TITLE
Fix extension header for downloaded DuckDB libs

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -341,35 +341,44 @@ mod build_linked {
             return Ok(());
         }
 
-        copy_header_from_bundled_archive(header_filename(), &header_path)
+        copy_header_from_bundled_archive(&header_path)
     }
 
     // duckdb.tar.gz is version-matched to the downloaded release by construction.
-    fn copy_header_from_bundled_archive(header: &str, destination: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    fn copy_header_from_bundled_archive(destination: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        let header = header_filename();
         let source_path = format!("duckdb/src/include/{header}");
-        let archive_file = fs::File::open("duckdb.tar.gz")
-            .map_err(|err| format!("could not open duckdb.tar.gz to extract {header}: {err}"))?;
+        let archive_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("duckdb.tar.gz");
+        let archive_file = fs::File::open(&archive_path)
+            .map_err(|err| format!("could not open {} to extract {header}: {err}", archive_path.display()))?;
         let tar = flate2::read::GzDecoder::new(archive_file);
         let mut archive = tar::Archive::new(tar);
+        let extraction_error =
+            |err: io::Error| format!("could not extract {header} from {}: {err}", archive_path.display());
 
-        for entry in archive.entries()? {
-            let mut entry = entry?;
-            if entry.path()?.as_ref() != Path::new(&source_path) {
+        for entry in archive.entries().map_err(&extraction_error)? {
+            let mut entry = entry.map_err(&extraction_error)?;
+            if entry.path().map_err(&extraction_error)?.as_ref() != Path::new(&source_path) {
                 continue;
             }
 
             let tmp_path = destination.with_extension("download");
             let mut tmp_file = fs::File::create(&tmp_path)?;
-            io::copy(&mut entry, &mut tmp_file)?;
+            io::copy(&mut entry, &mut tmp_file).map_err(&extraction_error)?;
             fs::rename(&tmp_path, destination)?;
             println!(
-                "cargo:warning=Copied {header} from duckdb.tar.gz to {}",
+                "cargo:warning=Copied {header} from {} to {}",
+                archive_path.display(),
                 destination.display()
             );
             return Ok(());
         }
 
-        Err(format!("duckdb.tar.gz did not contain required header {source_path}").into())
+        Err(format!(
+            "{} did not contain required header {source_path}",
+            archive_path.display()
+        )
+        .into())
     }
 
     fn configure_link_search(lib_dir: &Path) {

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -145,7 +145,7 @@ mod build_linked {
     #[cfg(feature = "buildtime_bindgen")]
     use super::bindings;
 
-    use super::{HeaderLocation, is_compiler, is_loadable_extension, win_target};
+    use super::{HeaderLocation, header_filename, is_compiler, is_loadable_extension, win_target};
     use std::{
         env, fs, io,
         path::{Path, PathBuf},
@@ -328,9 +328,48 @@ mod build_linked {
 
         configure_link_search(&download_dir);
 
+        ensure_header(&download_dir)?;
+
         copy_libduckdb(&download_dir, archive.dynamic_lib, out_dir)?;
 
         Ok(HeaderLocation::IncludeDir(download_dir))
+    }
+
+    fn ensure_header(download_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        let header_path = download_dir.join(header_filename());
+        if header_path.exists() {
+            return Ok(());
+        }
+
+        copy_header_from_bundled_archive(header_filename(), &header_path)
+    }
+
+    // duckdb.tar.gz is version-matched to the downloaded release by construction.
+    fn copy_header_from_bundled_archive(header: &str, destination: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        let source_path = format!("duckdb/src/include/{header}");
+        let archive_file = fs::File::open("duckdb.tar.gz")
+            .map_err(|err| format!("could not open duckdb.tar.gz to extract {header}: {err}"))?;
+        let tar = flate2::read::GzDecoder::new(archive_file);
+        let mut archive = tar::Archive::new(tar);
+
+        for entry in archive.entries()? {
+            let mut entry = entry?;
+            if entry.path()?.as_ref() != Path::new(&source_path) {
+                continue;
+            }
+
+            let tmp_path = destination.with_extension("download");
+            let mut tmp_file = fs::File::create(&tmp_path)?;
+            io::copy(&mut entry, &mut tmp_file)?;
+            fs::rename(&tmp_path, destination)?;
+            println!(
+                "cargo:warning=Copied {header} from duckdb.tar.gz to {}",
+                destination.display()
+            );
+            return Ok(());
+        }
+
+        Err(format!("duckdb.tar.gz did not contain required header {source_path}").into())
     }
 
     fn configure_link_search(lib_dir: &Path) {


### PR DESCRIPTION
Found this with `cargo hack`:

When `DUCKDB_DOWNLOAD_LIB=1` is used with `buildtime_bindgen`, bindgen expects the selected header next to the downloaded DuckDB library. Binary release archives do not currently include `duckdb_extension.h`, so the `loadable-extension` combination failed.

Ensure the selected header exists in the versioned download directory. When it is absent, copy the matching header from the crate's version-matched `duckdb.tar.gz` archive.

## Before

```
❯ DUCKDB_DOWNLOAD_LIB=1 cargo check -p libduckdb-sys --no-default-features --features buildtime_bindgen,loadable-extension
...
warning: `libduckdb-sys` (build script) generated 1 warning
warning: libduckdb-sys@1.10504.0: Downloaded libduckdb from https://github.com/duckdb/duckdb/releases/download/v1.5.4/libduckdb-osx-universal.zip
warning: libduckdb-sys@1.10504.0: Extracted libduckdb to /Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4
warning: libduckdb-sys@1.10504.0: Copied libduckdb to /Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libduckdb.dylib
error: failed to run custom build command for `libduckdb-sys v1.10504.0 (/Users/mathias/devel/duckdb/duckdb-rs/crates/libduckdb-sys)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/Users/mathias/devel/duckdb/duckdb-rs/target/debug/build/libduckdb-sys-eb3bcc1b974ba819/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=DUCKDB_DOWNLOAD_LIB
  cargo:warning=Downloaded libduckdb from https://github.com/duckdb/duckdb/releases/download/v1.5.4/libduckdb-osx-universal.zip
  cargo:warning=Extracted libduckdb to /Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4
  cargo:rustc-link-search=native=/Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4
  cargo:rustc-link-arg=-Wl,-rpath,/Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4
  cargo:warning=Copied libduckdb to /Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libduckdb.dylib
  cargo:include=/Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64-apple-darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_darwin
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS
  cargo:rerun-if-changed=/Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4/duckdb_extension.h

  --- stderr

  thread 'main' (26520400) panicked at crates/libduckdb-sys/build.rs:627:33:
  could not run bindgen on header /Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4/duckdb_extension.h
  stack backtrace:
     0: __rustc::rust_begin_unwind
               at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/std/src/panicking.rs:689:5
     1: core::panicking::panic_fmt
               at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/panicking.rs:80:14
     2: build_script_build::bindings::write_to_out_dir::{closure#0}
     3: <core::result::Result<bindgen::Bindings, bindgen::BindgenError>>::unwrap_or_else::<build_script_build::bindings::write_to_out_dir::{closure#0}>
     4: build_script_build::bindings::write_to_out_dir
     5: build_script_build::build_linked::main
     6: build_script_build::main
     7: <fn() as core::ops::function::FnOnce<()>>::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

## After

```
❯ DUCKDB_DOWNLOAD_LIB=1 cargo check -p libduckdb-sys --no-default-features --features buildtime_bindgen,loadable-extension
   Compiling libduckdb-sys v1.10504.0 (/Users/mathias/devel/duckdb/duckdb-rs/crates/libduckdb-sys)
...
warning: `libduckdb-sys` (build script) generated 1 warning
warning: libduckdb-sys@1.10504.0: Reusing libduckdb from /Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4
warning: libduckdb-sys@1.10504.0: Copied duckdb_extension.h from duckdb.tar.gz to /Users/mathias/devel/duckdb/duckdb-rs/target/duckdb-download/aarch64-apple-darwin/1.5.4/duckdb_extension.h
warning: libduckdb-sys@1.10504.0: Copied libduckdb to /Users/mathias/devel/duckdb/duckdb-rs/target/debug/deps/libduckdb.dylib
    Finished [`dev` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 2.66s
```