### PR TITLE
Fix Arrow timestamp carrier conversion

### DIFF
--- a/crates/duckdb/src/arrow_interop/from_duckdb.rs
+++ b/crates/duckdb/src/arrow_interop/from_duckdb.rs
@@ -9,9 +9,7 @@ use arrow::{
     datatypes::*,
     record_batch::RecordBatch,
 };
-use libduckdb_sys::{
-    duckdb_date, duckdb_string_t, duckdb_time, duckdb_timestamp, duckdb_vector, duckdb_vector_get_column_type,
-};
+use libduckdb_sys::{duckdb_date, duckdb_string_t, duckdb_time, duckdb_vector, duckdb_vector_get_column_type};
 
 use crate::{
     core::{ArrayVector, DataChunkHandle, FlatVector, ListVector, LogicalTypeHandle, LogicalTypeId, StructVector},
@@ -94,28 +92,11 @@ fn fixed_size_rows(rows: &SourceRows, width: usize) -> Result<SourceRows, Box<dy
     Ok(child_rows)
 }
 
-fn primitive_array_from_rows<T, P, F>(
-    vector: &FlatVector<'_>,
-    rows: &SourceRows,
-    convert: F,
-) -> Result<PrimitiveArray<P>, Box<dyn Error>>
+fn primitive_array_from_rows<T, P, F>(vector: &FlatVector<'_>, rows: &SourceRows, convert: F) -> PrimitiveArray<P>
 where
     T: Copy,
     P: ArrowPrimitiveType,
     F: Fn(T) -> P::Native,
-{
-    try_primitive_array_from_rows(vector, rows, |value| Ok(convert(value)))
-}
-
-fn try_primitive_array_from_rows<T, P, F>(
-    vector: &FlatVector<'_>,
-    rows: &SourceRows,
-    convert: F,
-) -> Result<PrimitiveArray<P>, Box<dyn Error>>
-where
-    T: Copy,
-    P: ArrowPrimitiveType,
-    F: Fn(T) -> Result<P::Native, Box<dyn Error>>,
 {
     rows.iter()
         .copied()
@@ -125,21 +106,20 @@ where
                 // type's physical storage, and validity masking already
                 // dropped null rows, so each selected slot is initialized.
                 .map(|row| convert(unsafe { read_row::<T>(vector, row) }))
-                .transpose()
         })
-        .collect::<Result<PrimitiveArray<P>, _>>()
+        .collect()
 }
 
-/// Converts rows whose Arrow native type matches the DuckDB physical storage.
+/// Reads rows whose Arrow native type matches the DuckDB physical storage.
+fn native_rows<P: ArrowPrimitiveType>(vector: &FlatVector<'_>, rows: &SourceRows) -> PrimitiveArray<P> {
+    primitive_array_from_rows::<P::Native, P, _>(vector, rows, |value| value)
+}
+
 fn native_array_from_rows<P: ArrowPrimitiveType>(
     vector: &FlatVector<'_>,
     rows: &SourceRows,
 ) -> Result<Arc<dyn Array>, Box<dyn Error>> {
-    Ok(Arc::new(primitive_array_from_rows::<P::Native, P, _>(
-        vector,
-        rows,
-        |value| value,
-    )?))
+    Ok(Arc::new(native_rows::<P>(vector, rows)))
 }
 
 /// Converts the first `len` rows of a DuckDB vector to an Arrow array.
@@ -171,17 +151,18 @@ fn scalar_vector_rows_to_arrow_array(
         LogicalTypeId::Invalid => Err("Cannot convert invalid logical type returned by DuckDB".into()),
         LogicalTypeId::Unsupported => Err(format!("Unsupported DuckDB logical type ID {raw_type_id}").into()),
         LogicalTypeId::Integer => native_array_from_rows::<Int32Type>(vector, rows),
-        // Preserve the legacy Arrow compatibility behavior for timestamp
-        // physical carriers. This adapter does not distinguish unit-specific
-        // timestamp vector payload layouts.
-        LogicalTypeId::Timestamp
-        | LogicalTypeId::TimestampMs
-        | LogicalTypeId::TimestampS
-        | LogicalTypeId::TimestampTZ => Ok(Arc::new(primitive_array_from_rows::<
-            duckdb_timestamp,
-            TimestampMicrosecondType,
-            _,
-        >(vector, rows, |value| value.micros)?)),
+        // DuckDB's timestamp carriers (duckdb_timestamp_s/_ms/_ns and
+        // duckdb_timestamp) are single-i64 structs, so each unit reads
+        // natively into its Arrow timestamp type.
+        LogicalTypeId::TimestampS => native_array_from_rows::<TimestampSecondType>(vector, rows),
+        LogicalTypeId::TimestampMs => native_array_from_rows::<TimestampMillisecondType>(vector, rows),
+        LogicalTypeId::Timestamp => native_array_from_rows::<TimestampMicrosecondType>(vector, rows),
+        LogicalTypeId::TimestampNs => native_array_from_rows::<TimestampNanosecondType>(vector, rows),
+        // TIMESTAMP_TZ stores UTC microseconds; a data chunk carries no
+        // session display timezone.
+        LogicalTypeId::TimestampTZ => Ok(Arc::new(
+            native_rows::<TimestampMicrosecondType>(vector, rows).with_timezone("UTC"),
+        )),
         LogicalTypeId::Varchar => {
             let values = rows
                 .iter()
@@ -216,12 +197,12 @@ fn scalar_vector_rows_to_arrow_array(
             vector,
             rows,
             |value| value.days,
-        )?)),
+        ))),
         LogicalTypeId::Time => Ok(Arc::new(primitive_array_from_rows::<
             duckdb_time,
             Time64MicrosecondType,
             _,
-        >(vector, rows, |value| value.micros)?)),
+        >(vector, rows, |value| value.micros))),
         LogicalTypeId::Smallint => native_array_from_rows::<Int16Type>(vector, rows),
         LogicalTypeId::USmallint => native_array_from_rows::<UInt16Type>(vector, rows),
         LogicalTypeId::Blob | LogicalTypeId::Geometry => {
@@ -251,23 +232,6 @@ fn scalar_vector_rows_to_arrow_array(
         LogicalTypeId::UBigint => native_array_from_rows::<UInt64Type>(vector, rows),
         LogicalTypeId::UTinyint => native_array_from_rows::<UInt8Type>(vector, rows),
         LogicalTypeId::UInteger => native_array_from_rows::<UInt32Type>(vector, rows),
-        LogicalTypeId::TimestampNs => Ok(Arc::new(try_primitive_array_from_rows::<
-            duckdb_timestamp,
-            TimestampNanosecondType,
-            _,
-        >(
-            vector,
-            rows,
-            // Preserve the existing C API read behavior, which interprets the
-            // payload as microseconds before producing Arrow nanoseconds. The
-            // unit-specific timestamp vector layouts need a separate audit.
-            |value| {
-                value
-                    .micros
-                    .checked_mul(1000)
-                    .ok_or_else(|| "DuckDB nanosecond timestamp exceeds Arrow i64 range".into())
-            },
-        )?)),
         type_id @ (LogicalTypeId::Interval
         | LogicalTypeId::Hugeint
         | LogicalTypeId::Decimal
@@ -485,8 +449,10 @@ fn struct_vector_to_arrow_array(vector: &StructVector<'_>, rows: &SourceRows) ->
 /// names are synthesized as `"0"`, `"1"`, and so on. List
 /// and map child names use Arrow's conventional names, struct children are
 /// nullable, field metadata is not preserved, and lists use 32-bit Arrow
-/// offsets. Timestamp mappings retain this adapter's legacy physical-carrier
-/// behavior and do not provide native unit or timezone fidelity.
+/// offsets. Timestamp mappings preserve DuckDB's seconds, milliseconds,
+/// microseconds, and nanoseconds carriers. Timestamp-with-time-zone values are
+/// emitted as UTC microseconds because a data chunk does not carry a session
+/// display timezone.
 pub fn data_chunk_to_arrow(chunk: &DataChunkHandle) -> Result<RecordBatch, Box<dyn Error>> {
     let len = chunk.len();
 

--- a/crates/duckdb/src/arrow_interop/tests/from_duckdb_nested.rs
+++ b/crates/duckdb/src/arrow_interop/tests/from_duckdb_nested.rs
@@ -1,5 +1,9 @@
 use super::*;
-use arrow::datatypes::Int32Type;
+use arrow::datatypes::{
+    Int32Type, TimeUnit, TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+    TimestampSecondType,
+};
+use libduckdb_sys::{duckdb_timestamp, duckdb_timestamp_ms, duckdb_timestamp_ns, duckdb_timestamp_s};
 
 fn data_chunk_roundtrip_single_array(array: ArrayRef) -> Result<ArrayRef, Box<dyn Error>> {
     let input_data_type = array.data_type().clone();
@@ -394,18 +398,109 @@ fn test_data_chunk_to_arrow_masks_invalid_boolean_payload_under_null() -> Result
 }
 
 #[test]
-fn test_data_chunk_to_arrow_rejects_nanosecond_timestamp_overflow() {
-    let chunk = DataChunkHandle::new(&[LogicalTypeId::TimestampNs.into()]);
-    chunk.set_len(1);
-    let mut vector = chunk.flat_vector(0);
+fn test_data_chunk_to_arrow_preserves_timestamp_carriers() -> Result<(), Box<dyn Error>> {
+    let chunk = DataChunkHandle::new(&[
+        LogicalTypeId::TimestampS.into(),
+        LogicalTypeId::TimestampMs.into(),
+        LogicalTypeId::Timestamp.into(),
+        LogicalTypeId::TimestampNs.into(),
+        LogicalTypeId::TimestampTZ.into(),
+    ]);
+    chunk.set_len(2);
+
+    // 2024-01-01T00:00:00Z plus a unit-specific fractional component.
     unsafe {
-        vector.copy(&[libduckdb_sys::duckdb_timestamp { micros: i64::MAX }]);
+        chunk.flat_vector(0).copy(&[
+            duckdb_timestamp_s { seconds: -1 },
+            duckdb_timestamp_s { seconds: 1_704_067_200 },
+        ]);
+        chunk.flat_vector(1).copy(&[
+            duckdb_timestamp_ms { millis: -1_001 },
+            duckdb_timestamp_ms {
+                millis: 1_704_067_200_123,
+            },
+        ]);
+        chunk.flat_vector(2).copy(&[
+            duckdb_timestamp { micros: -1_000_001 },
+            duckdb_timestamp {
+                micros: 1_704_067_200_123_456,
+            },
+        ]);
+        chunk.flat_vector(3).copy(&[
+            duckdb_timestamp_ns { nanos: -1_000_000_123 },
+            duckdb_timestamp_ns {
+                nanos: 1_704_067_200_000_000_123,
+            },
+        ]);
+        chunk.flat_vector(4).copy(&[
+            duckdb_timestamp { micros: -1_000_001 },
+            duckdb_timestamp {
+                micros: 1_704_067_200_123_456,
+            },
+        ]);
     }
 
-    assert_conversion_err(
-        &chunk,
-        "DuckDB column 0: DuckDB nanosecond timestamp exceeds Arrow i64 range",
+    let output = data_chunk_to_arrow(&chunk)?;
+    let expected_types = [
+        DataType::Timestamp(TimeUnit::Second, None),
+        DataType::Timestamp(TimeUnit::Millisecond, None),
+        DataType::Timestamp(TimeUnit::Microsecond, None),
+        DataType::Timestamp(TimeUnit::Nanosecond, None),
+        DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+    ];
+    for (column, expected) in expected_types.iter().enumerate() {
+        assert_eq!(output.column(column).data_type(), expected, "column {column}");
+    }
+    assert_eq!(
+        output.column(0).as_primitive::<TimestampSecondType>().values(),
+        &[-1, 1_704_067_200]
     );
+    assert_eq!(
+        output.column(1).as_primitive::<TimestampMillisecondType>().values(),
+        &[-1_001, 1_704_067_200_123]
+    );
+    assert_eq!(
+        output.column(2).as_primitive::<TimestampMicrosecondType>().values(),
+        &[-1_000_001, 1_704_067_200_123_456]
+    );
+    assert_eq!(
+        output.column(3).as_primitive::<TimestampNanosecondType>().values(),
+        &[-1_000_000_123, 1_704_067_200_000_000_123]
+    );
+    assert_eq!(
+        output.column(4).as_primitive::<TimestampMicrosecondType>().values(),
+        &[-1_000_001, 1_704_067_200_123_456]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_data_chunk_to_arrow_preserves_nested_nanosecond_timestamp() -> Result<(), Box<dyn Error>> {
+    let chunk = list_chunk(&LogicalTypeId::TimestampNs.into(), 1);
+    let mut list = chunk.list_vector(0);
+    list.set_entry(0, 0, 2);
+    unsafe {
+        list.set_child(&[
+            duckdb_timestamp_ns { nanos: -123 },
+            duckdb_timestamp_ns {
+                nanos: 1_704_067_200_000_000_123,
+            },
+        ]);
+    }
+
+    let output = data_chunk_to_arrow(&chunk)?;
+    let output = output.column(0).as_list::<i32>();
+    assert_eq!(
+        output.values().data_type(),
+        &DataType::Timestamp(TimeUnit::Nanosecond, None)
+    );
+    assert_eq!(
+        output.values().as_primitive::<TimestampNanosecondType>().values(),
+        &[-123, 1_704_067_200_000_000_123]
+    );
+
+    Ok(())
 }
 
 #[test]

--- a/crates/duckdb/src/arrow_interop/to_duckdb.rs
+++ b/crates/duckdb/src/arrow_interop/to_duckdb.rs
@@ -374,7 +374,7 @@ fn primitive_array_to_vector(array: &dyn Array, out: &mut FlatVector<'_>) -> Res
             );
             primitive_array_to_flat_vector::<IntervalMonthDayNanoType>(as_primitive_array(&array), out);
         }
-        // DuckDB Only supports timetamp_tz in microsecond precision
+        // DuckDB only supports TIMESTAMP_TZ at microsecond precision.
         DataType::Timestamp(_, Some(tz)) => primitive_array_to_flat_vector_cast::<TimestampMicrosecondType>(
             DataType::Timestamp(TimeUnit::Microsecond, Some(tz.clone())),
             array,

--- a/crates/duckdb/src/vscalar/arrow.rs
+++ b/crates/duckdb/src/vscalar/arrow.rs
@@ -133,8 +133,11 @@ mod test {
     use std::{error::Error, sync::Arc};
 
     use arrow::{
-        array::{Array, Int32Array, ListArray, RecordBatch, StringArray},
-        datatypes::DataType,
+        array::{Array, AsArray, Int32Array, Int64Array, ListArray, RecordBatch, StringArray},
+        datatypes::{
+            ArrowPrimitiveType, DataType, TimeUnit, TimestampMicrosecondType, TimestampMillisecondType,
+            TimestampNanosecondType, TimestampSecondType,
+        },
     };
 
     use crate::{Connection, vscalar::arrow::ArrowFunctionSignature};
@@ -451,6 +454,100 @@ mod test {
             .map(|id| if id % 7 == 0 { None } else { Some(id) })
             .collect::<Vec<_>>();
         assert_eq!(first_values, expected);
+        Ok(())
+    }
+
+    fn timestamp_value<T>(input: &RecordBatch, column: usize, expected_type: &DataType) -> Result<i64, Box<dyn Error>>
+    where
+        T: ArrowPrimitiveType<Native = i64>,
+    {
+        let array = input.column(column);
+        if array.data_type() != expected_type {
+            return Err(format!(
+                "expected timestamp column {column} to have type {expected_type}, got {}",
+                array.data_type()
+            )
+            .into());
+        }
+
+        array
+            .as_primitive_opt::<T>()
+            .map(|timestamps| timestamps.value(0))
+            .ok_or_else(|| format!("timestamp column {column} has an unexpected Arrow array implementation").into())
+    }
+
+    #[test]
+    fn test_arrow_scalar_reads_timestamp_carriers() -> Result<(), Box<dyn Error>> {
+        struct TimestampCarrierProbe;
+
+        impl VArrowScalar for TimestampCarrierProbe {
+            type State = ();
+
+            fn invoke(_: &Self::State, input: RecordBatch) -> Result<Arc<dyn Array>, Box<dyn std::error::Error>> {
+                let timestamp_tz = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+                let actual = [
+                    timestamp_value::<TimestampSecondType>(&input, 0, &DataType::Timestamp(TimeUnit::Second, None))?,
+                    timestamp_value::<TimestampMillisecondType>(
+                        &input,
+                        1,
+                        &DataType::Timestamp(TimeUnit::Millisecond, None),
+                    )?,
+                    timestamp_value::<TimestampMicrosecondType>(
+                        &input,
+                        2,
+                        &DataType::Timestamp(TimeUnit::Microsecond, None),
+                    )?,
+                    timestamp_value::<TimestampNanosecondType>(
+                        &input,
+                        3,
+                        &DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    )?,
+                    timestamp_value::<TimestampMicrosecondType>(&input, 4, &timestamp_tz)?,
+                ];
+                let expected = [
+                    1_704_067_200,
+                    1_704_067_200_123,
+                    1_704_067_200_123_456,
+                    1_704_067_200_000_000_123,
+                    1_704_067_200_123_456,
+                ];
+                if actual != expected {
+                    return Err(format!("expected timestamp carriers {expected:?}, got {actual:?}").into());
+                }
+
+                Ok(Arc::new(Int64Array::from_iter_values([actual[3]])))
+            }
+
+            fn signatures() -> Vec<ArrowFunctionSignature> {
+                vec![ArrowFunctionSignature::exact(
+                    vec![
+                        DataType::Timestamp(TimeUnit::Second, None),
+                        DataType::Timestamp(TimeUnit::Millisecond, None),
+                        DataType::Timestamp(TimeUnit::Microsecond, None),
+                        DataType::Timestamp(TimeUnit::Nanosecond, None),
+                        DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                    ],
+                    DataType::Int64,
+                )]
+            }
+        }
+
+        let conn = Connection::open_in_memory()?;
+        conn.register_scalar_function::<TimestampCarrierProbe>("arrow_timestamp_carriers_raw")?;
+
+        // 2024-01-01T00:00:00Z in each carrier's resolution.
+        let value = conn.query_row(
+            "select arrow_timestamp_carriers_raw(\
+             TIMESTAMP_S '2024-01-01 00:00:00', \
+             TIMESTAMP_MS '2024-01-01 00:00:00.123', \
+             TIMESTAMP '2024-01-01 00:00:00.123456', \
+             TIMESTAMP_NS '2024-01-01 00:00:00.000000123', \
+             TIMESTAMPTZ '2024-01-01 00:00:00.123456+00')",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        assert_eq!(value, 1_704_067_200_000_000_123);
+
         Ok(())
     }
 }


### PR DESCRIPTION
DuckDB stores timestamp units in distinct physical vector payloads. This PR makes `data_chunk_to_arrow` and `flat_vector_to_arrow_array` preserve those units and represent `TIMESTAMPTZ` using `UTC` metadata.

This changes observable public conversion behavior:

- `TIMESTAMP_S` and `TIMESTAMP_MS` now produce Arrow second and millisecond arrays instead of microsecond arrays.
- `TIMESTAMP_NS` preserves its raw nanosecond payload instead of multiplying it by 1000.
- `TIMESTAMP_TZ` now includes `UTC` timezone metadata.

No Rust signatures change, but existing schema comparisons, downcasts, or workarounds for the previous behavior may require updating.

Follow-up to #813