### PR TITLE
Vector binding, nested containers, and serde STRUCT support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "rand 0.9.4",
  "rust_decimal",
  "rustyline",
+ "serde",
  "serde_json",
  "strum",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libduckdb-sys",
+ "ndarray",
  "num",
  "num-integer",
  "polars",
@@ -1766,6 +1767,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1816,21 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -2556,6 +2582,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,6 +2899,12 @@ checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ fallible-iterator = "0.3"
 fallible-streaming-iterator = "0.1"
 flate2 = "1.0"
 hashlink = "0.10"
+ndarray = "0.16"
 num = { version = "0.4", default-features = false }
 num-integer = "0.1.46"
 pkg-config = "0.3.24"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ These extensions are only available through the CMake build backend and imply `b
 
 - `appender-arrow` - Efficient bulk insertion of Arrow data into DuckDB tables.
 - `polars` - Integration with Polars DataFrames.
+- `ndarray` - Conversions between DuckDB vector (`ARRAY`) columns and
+  `ndarray::Array1<f32>` / `Array1<f64>`. Also see the `Vec<f32>` / `[T; N]`
+  `ToSql`/`FromSql` impls, which are available without this feature.
+- `serde` - Round-trip `#[derive(Serialize, Deserialize)]` Rust values to and
+  from DuckDB `STRUCT` columns through the `types::Struct<T>` wrapper. Rust
+  structs and string-keyed maps map to `STRUCT`; `Vec`/`[T; N]` map to `LIST`;
+  unit enum variants map to `VARCHAR`. A bare `impl<T: Serialize> ToSql` is
+  incoherent with the scalar impls, so values are wrapped (`[Struct(&value)]`
+  to bind, `Struct<T>` to read back).
 - `rust_decimal` - Compatibility impls for `rust_decimal::Decimal`. DuckDB
   `DECIMAL` values use `duckdb::types::Decimal` as the core full-domain
   carrier; this feature restores `ToSql`/`FromSql` conversions for
@@ -129,7 +138,7 @@ These extensions are only available through the CMake build backend and imply `b
 
 - `vtab-full` - Enables virtual table features: `vtab-arrow` and `appender-arrow`; retains the deprecated `vtab-excel` compatibility flag.
 - `extensions-full` - Enables all major extensions: `json`, `parquet`, and `vtab-full`.
-- `modern-full` - Enables modern Rust ecosystem integrations: `chrono`, `serde_json`, `url`, `r2d2`, `uuid`, `polars`, and `rust_decimal`.
+- `modern-full` - Enables modern Rust ecosystem integrations: `chrono`, `serde`, `serde_json`, `url`, `r2d2`, `uuid`, `polars`, `rust_decimal`, and `ndarray`.
 
 ### Build configuration
 

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -39,9 +39,10 @@ appender-arrow = ["vtab-arrow"]
 vtab-full = ["vtab-excel", "vtab-arrow", "appender-arrow"]
 extensions-full = ["json", "parquet", "vtab-full"]
 buildtime_bindgen = ["libduckdb-sys/buildtime_bindgen"]
-modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars", "rust_decimal"]
+modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars", "rust_decimal", "ndarray"]
 polars = ["dep:polars", "dep:polars-core"]
 rust_decimal = ["dep:rust_decimal"]
+ndarray = ["dep:ndarray"]
 # Warning: experimental feature
 loadable-extension = ["vtab", "duckdb-loadable-macros", "libduckdb-sys/loadable-extension"]
 
@@ -54,6 +55,7 @@ fallible-iterator = { workspace = true }
 fallible-streaming-iterator = { workspace = true }
 hashlink = { workspace = true }
 libduckdb-sys = { workspace = true }
+ndarray = { workspace = true, optional = true }
 num = { workspace = true, features = ["std"], optional = true }
 num-integer = { workspace = true }
 polars = { workspace = true, features = ["dtype-full"], optional = true }

--- a/crates/duckdb/Cargo.toml
+++ b/crates/duckdb/Cargo.toml
@@ -39,10 +39,11 @@ appender-arrow = ["vtab-arrow"]
 vtab-full = ["vtab-excel", "vtab-arrow", "appender-arrow"]
 extensions-full = ["json", "parquet", "vtab-full"]
 buildtime_bindgen = ["libduckdb-sys/buildtime_bindgen"]
-modern-full = ["chrono", "serde_json", "url", "r2d2", "uuid", "polars", "rust_decimal", "ndarray"]
+modern-full = ["chrono", "serde", "serde_json", "url", "r2d2", "uuid", "polars", "rust_decimal", "ndarray"]
 polars = ["dep:polars", "dep:polars-core"]
 rust_decimal = ["dep:rust_decimal"]
 ndarray = ["dep:ndarray"]
+serde = ["dep:serde"]
 # Warning: experimental feature
 loadable-extension = ["vtab", "duckdb-loadable-macros", "libduckdb-sys/loadable-extension"]
 
@@ -62,6 +63,7 @@ polars = { workspace = true, features = ["dtype-full"], optional = true }
 polars-core = { workspace = true, optional = true }
 r2d2 = { workspace = true, optional = true }
 rust_decimal = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 url = { workspace = true, optional = true }

--- a/crates/duckdb/src/appender/mod.rs
+++ b/crates/duckdb/src/appender/mod.rs
@@ -176,6 +176,12 @@ impl Appender<'_> {
 
     fn validate_parameter_values(&self, values: &[ToSqlOutput<'_>]) -> Result<()> {
         for value in values {
+            // Containers are validated during FfiValue construction in bind_parameter.
+            if let ToSqlOutput::Owned(v) = value {
+                if crate::types::is_bindable_container(v) {
+                    continue;
+                }
+            }
             let value = to_value_ref(value)?;
             validate_appender_value_ref(value)?;
         }
@@ -191,6 +197,20 @@ impl Appender<'_> {
 
     fn bind_parameter(&mut self, value: &ToSqlOutput<'_>) -> Result<()> {
         let ptr = self.app;
+
+        // Container values (List/Array/Struct/Map) bypass the ValueRef path and
+        // are built recursively into a duckdb_value.
+        if let ToSqlOutput::Owned(v) = value {
+            if crate::types::is_bindable_container(v) {
+                let ffi_value = crate::types::FfiValue::from_value(v)?;
+                let rc = unsafe { ffi::duckdb_append_value(ptr, ffi_value.ptr()) };
+                if rc != 0 {
+                    return Err(error_from_appender_code(rc, self.app));
+                }
+                return Ok(());
+            }
+        }
+
         let value = to_value_ref(value)?;
         // TODO: append more
         let rc = match value {
@@ -465,7 +485,7 @@ mod test {
     }
 
     #[test]
-    fn test_append_unsupported_container_type_returns_error() -> Result<()> {
+    fn test_append_owned_list_succeeds_and_borrowed_list_rejected() -> Result<()> {
         use arrow::{array::ListArray, datatypes::Int32Type};
 
         use crate::{
@@ -495,7 +515,7 @@ mod test {
             }
         }
 
-        fn assert_unsupported_list_error(err: Error) {
+        fn assert_borrowed_list_error(err: Error) {
             match err {
                 Error::ToSqlConversionFailure(e) => {
                     assert!(
@@ -508,35 +528,22 @@ mod test {
         }
 
         let db = Connection::open_in_memory()?;
-        db.execute_batch("CREATE TABLE foo(id INTEGER, name TEXT)")?;
+        db.execute_batch("CREATE TABLE foo(id INTEGER, numbers INTEGER[])")?;
 
-        let list = OwnedList;
         let mut app = db.appender("foo")?;
-        app.append_row(params![10, "before"])?;
-        app.append_row(params![11, "also before"])?;
-        let err = app.append_row(params![1, list]).unwrap_err();
-        assert_unsupported_list_error(err);
-
-        let borrowed_list = BorrowedList::new();
-        let err = app.append_row(params![3, borrowed_list]).unwrap_err();
-        assert_unsupported_list_error(err);
-        app.append_row(params![2, "ok"])?;
+        // Owned Value::List now appends successfully.
+        app.append_row(params![10, OwnedList])?;
+        // Borrowed ValueRef::List is still rejected.
+        let err = app.append_row(params![3, BorrowedList::new()]).unwrap_err();
+        assert_borrowed_list_error(err);
+        app.append_row(params![2, Value::Null])?;
         app.flush()?;
 
         let rows = db
-            .prepare("SELECT id, name FROM foo ORDER BY id")?
-            .query_map([], |row| Ok((row.get::<_, i32>(0)?, row.get::<_, String>(1)?)))?
+            .prepare("SELECT id FROM foo ORDER BY id")?
+            .query_map([], |row| row.get::<_, i32>(0))?
             .collect::<Result<Vec<_>>>()?;
-        assert_eq!(
-            rows,
-            vec![
-                (2, "ok".to_string()),
-                (10, "before".to_string()),
-                (11, "also before".to_string())
-            ]
-        );
-        let count: i32 = db.query_row("SELECT COUNT(*) FROM foo", [], |row| row.get(0))?;
-        assert_eq!(count, 3);
+        assert_eq!(rows, vec![2, 10]);
         Ok(())
     }
 

--- a/crates/duckdb/src/statement.rs
+++ b/crates/duckdb/src/statement.rs
@@ -592,10 +592,22 @@ impl Statement<'_> {
 
     // generic because many of these branches can constant fold away.
     fn bind_parameter<P: ?Sized + ToSql>(&self, param: &P, col: usize) -> Result<()> {
-        let value = param.to_sql()?;
+        let output = param.to_sql()?;
 
         let ptr = unsafe { self.stmt.ptr() };
-        let value = match value {
+
+        // Container values (List/Array/Struct/Map) cannot become ValueRef from
+        // an owned Value. Build a duckdb_value recursively and bind it via the
+        // generic duckdb_bind_value entry point.
+        if let ToSqlOutput::Owned(value) = &output {
+            if crate::types::is_bindable_container(value) {
+                let ffi_value = crate::types::FfiValue::from_value(value)?;
+                let rc = unsafe { ffi::duckdb_bind_value(ptr, col as u64, ffi_value.ptr()) };
+                return result_from_duckdb_prepare(rc, ptr);
+            }
+        }
+
+        let value = match output {
             ToSqlOutput::Borrowed(v) => v,
             ToSqlOutput::Owned(ref v) => value_ref_from_value(v, binding_unsupported_value)?,
         };
@@ -2181,9 +2193,11 @@ mod test {
         Ok(())
     }
 
-    // Unsupported Value variants must surface an error instead of panicking.
+    // Owned container `Value`s bind via the duckdb_value API, while borrowed
+    // `ValueRef::List` (built from an Arrow array) is not yet routable through
+    // that path and is rejected at the bind boundary.
     #[test]
-    fn test_bind_unsupported_container_type_returns_error() -> Result<()> {
+    fn test_bind_owned_list_succeeds_and_borrowed_list_rejected() -> Result<()> {
         use crate::types::Value;
 
         struct OwnedList;
@@ -2196,13 +2210,12 @@ mod test {
         let db = Connection::open_in_memory()?;
         db.execute("CREATE TABLE t (id INTEGER, numbers INTEGER[])", [])?;
 
-        let list = OwnedList;
-        let err = db
-            .execute("INSERT INTO t VALUES (?, ?)", crate::params![1, list])
-            .unwrap_err();
+        // Owned Value::List now binds successfully.
+        db.execute("INSERT INTO t VALUES (?, ?)", crate::params![1, OwnedList])?;
+        let numbers: Value = db.query_row("SELECT numbers FROM t WHERE id = 1", [], |row| row.get(0))?;
+        assert!(matches!(numbers, Value::List(items) if items == vec![Value::Int(1), Value::Int(2)]));
 
-        assert_binding_list_error(err);
-
+        // Borrowed ValueRef::List is still rejected.
         let borrowed_list = BorrowedList::new();
         let err = db
             .execute("INSERT INTO t VALUES (?, ?)", crate::params![2, borrowed_list])

--- a/crates/duckdb/src/types/from_sql.rs
+++ b/crates/duckdb/src/types/from_sql.rs
@@ -2,7 +2,8 @@ use std::{error::Error, fmt};
 
 use cast;
 
-use super::{Decimal, TimeUnit, Value, ValueRef};
+use super::{Decimal, ListType, TimeUnit, Value, ValueRef};
+use arrow::array::{Array, Float32Array, Float64Array};
 
 /// Enum listing possible errors from [`FromSql`] trait.
 #[derive(Debug)]
@@ -317,6 +318,76 @@ impl FromSql for Value {
         Ok(value.into())
     }
 }
+
+/// Reads a DuckDB fixed-size `ARRAY` (`FLOAT[N]` / `DOUBLE[N]`) or `LIST` column
+/// into a Rust `Vec<T>` (and, when the length is known, `[T; N]`). Elements must
+/// be non-null; null elements report [`FromSqlError::InvalidType`].
+macro_rules! from_sql_float_array {
+    ($t:ty, $array:ident) => {
+        impl FromSql for Vec<$t> {
+            fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+                let (start, end, child) = match value {
+                    ValueRef::Array(arr, idx) => {
+                        let width = usize::try_from(arr.value_length()).map_err(|_| FromSqlError::InvalidType)?;
+                        let start = idx.checked_mul(width).ok_or(FromSqlError::InvalidType)?;
+                        let end = start.checked_add(width).ok_or(FromSqlError::InvalidType)?;
+                        (start, end, arr.values())
+                    }
+                    ValueRef::List(ListType::Regular(arr), idx) => {
+                        let offsets = arr.offsets();
+                        let start = offsets
+                            .get(idx)
+                            .and_then(|o| (*o).try_into().ok())
+                            .ok_or(FromSqlError::InvalidType)?;
+                        let end = offsets
+                            .get(idx + 1)
+                            .and_then(|o| (*o).try_into().ok())
+                            .ok_or(FromSqlError::InvalidType)?;
+                        (start, end, arr.values())
+                    }
+                    ValueRef::List(ListType::Large(arr), idx) => {
+                        let offsets = arr.offsets();
+                        let start = offsets
+                            .get(idx)
+                            .and_then(|o| (*o).try_into().ok())
+                            .ok_or(FromSqlError::InvalidType)?;
+                        let end = offsets
+                            .get(idx + 1)
+                            .and_then(|o| (*o).try_into().ok())
+                            .ok_or(FromSqlError::InvalidType)?;
+                        (start, end, arr.values())
+                    }
+                    _ => return Err(FromSqlError::InvalidType),
+                };
+                let floats = child
+                    .as_ref()
+                    .as_any()
+                    .downcast_ref::<$array>()
+                    .ok_or(FromSqlError::InvalidType)?;
+                for i in start..end {
+                    if !floats.is_valid(i) {
+                        return Err(FromSqlError::InvalidType);
+                    }
+                }
+                Ok(floats
+                    .values()
+                    .get(start..end)
+                    .ok_or(FromSqlError::InvalidType)?
+                    .to_vec())
+            }
+        }
+
+        impl<const N: usize> FromSql for [$t; N] {
+            fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+                let vec = Vec::<$t>::column_result(value)?;
+                vec.try_into().map_err(|_| FromSqlError::InvalidType)
+            }
+        }
+    };
+}
+
+from_sql_float_array!(f32, Float32Array);
+from_sql_float_array!(f64, Float64Array);
 
 #[cfg(test)]
 mod test {

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -64,6 +64,7 @@ pub use self::{
     value_ref::{EnumType, ListType, TimeUnit, ValueRef},
 };
 pub(crate) use decimal::to_duckdb_decimal;
+pub(crate) use value_ffi::{FfiValue, is_bindable_container};
 pub(crate) use value_ref::{binding_unsupported_value, value_ref_from_value};
 
 use arrow::datatypes::DataType;
@@ -74,6 +75,8 @@ use crate::ffi;
 #[cfg(feature = "chrono")]
 mod chrono;
 mod from_sql;
+#[cfg(feature = "ndarray")]
+mod ndarray;
 #[cfg(feature = "serde_json")]
 mod serde_json;
 mod to_sql;
@@ -85,6 +88,7 @@ mod value_ref;
 mod decimal;
 mod ordered_map;
 mod string;
+mod value_ffi;
 
 pub(crate) fn to_duckdb_hugeint(i: i128) -> ffi::duckdb_hugeint {
     ffi::duckdb_hugeint {
@@ -316,7 +320,7 @@ mod test {
     fn test_empty_blob() -> Result<()> {
         let db = checked_memory_handle()?;
 
-        let empty = vec![];
+        let empty: Vec<u8> = vec![];
         db.execute("INSERT INTO foo(b) VALUES (?)", [&empty])?;
 
         let v: Vec<u8> = db.query_row("SELECT b FROM foo", [], |r| r.get(0))?;

--- a/crates/duckdb/src/types/mod.rs
+++ b/crates/duckdb/src/types/mod.rs
@@ -54,6 +54,8 @@
 //! container API, so they materialize through their Arrow binary carrier as
 //! [`Value::Blob`] values.
 
+#[cfg(feature = "serde")]
+pub use self::serde_struct::Struct;
 pub use self::{
     decimal::{Decimal, DecimalError},
     from_sql::{FromSql, FromSqlError, FromSqlResult},
@@ -79,6 +81,8 @@ mod from_sql;
 mod ndarray;
 #[cfg(feature = "serde_json")]
 mod serde_json;
+#[cfg(feature = "serde")]
+mod serde_struct;
 mod to_sql;
 #[cfg(feature = "url")]
 mod url;

--- a/crates/duckdb/src/types/ndarray.rs
+++ b/crates/duckdb/src/types/ndarray.rs
@@ -1,0 +1,57 @@
+//! Conversions between DuckDB vector (`ARRAY`) columns and [`ndarray`] 1-D
+//! arrays.
+//!
+//! Enable the `ndarray` cargo feature to use these impls. A DuckDB
+//! `FLOAT[N]` / `DOUBLE[N]` column maps to [`Array1<f32>`] / [`Array1<f64>`]
+//! respectively. Empty arrays cannot be bound because the element type cannot
+//! be inferred from the value alone.
+
+use crate::{
+    Error, Result,
+    types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, Value, ValueRef},
+};
+use ndarray::Array1;
+
+macro_rules! impl_ndarray_array1 {
+    ($t:ty, $variant:ident) => {
+        impl ToSql for Array1<$t> {
+            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+                if self.is_empty() {
+                    return Err(Error::ToSqlConversionFailure(
+                        "cannot bind an empty array; the element type cannot be inferred".into(),
+                    ));
+                }
+                let value = Value::Array(self.iter().map(|&x| Value::$variant(x)).collect());
+                Ok(ToSqlOutput::Owned(value))
+            }
+        }
+
+        impl FromSql for Array1<$t> {
+            fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+                Ok(Array1::from_vec(Vec::<$t>::column_result(value)?))
+            }
+        }
+    };
+}
+
+impl_ndarray_array1!(f32, Float);
+impl_ndarray_array1!(f64, Double);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ToSql;
+
+    #[test]
+    fn array1_to_sql_is_owned_vector() {
+        let arr = Array1::from_vec(vec![1.0_f32, 2.0, 3.0]);
+        let out = arr.to_sql().expect("to_sql succeeds");
+        assert!(out.to_sql().is_ok());
+    }
+
+    #[test]
+    fn empty_array1_to_sql_errors() {
+        let arr = Array1::<f32>::zeros(0);
+        assert!(arr.to_sql().is_err());
+    }
+}

--- a/crates/duckdb/src/types/ordered_map.rs
+++ b/crates/duckdb/src/types/ordered_map.rs
@@ -1,6 +1,12 @@
 /// An ordered map of key-value pairs.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct OrderedMap<K, V>(Vec<(K, V)>);
+pub struct OrderedMap<K, V>(pub(crate) Vec<(K, V)>);
+
+impl<K, V> Default for OrderedMap<K, V> {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
 
 impl<K: PartialEq, V> From<Vec<(K, V)>> for OrderedMap<K, V> {
     fn from(value: Vec<(K, V)>) -> Self {
@@ -9,9 +15,23 @@ impl<K: PartialEq, V> From<Vec<(K, V)>> for OrderedMap<K, V> {
 }
 
 impl<K: std::cmp::PartialEq, V> OrderedMap<K, V> {
+    /// Creates an empty `OrderedMap`.
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
     /// Returns the value corresponding to the key.
     pub fn get(&self, key: &K) -> Option<&V> {
         self.0.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+    }
+    /// Inserts a key-value pair, replacing any existing value for the key.
+    ///
+    /// Returns the previous value if the key already existed.
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if let Some((_, existing)) = self.0.iter_mut().find(|(k, _)| *k == key) {
+            return Some(std::mem::replace(existing, value));
+        }
+        self.0.push((key, value));
+        None
     }
     /// Returns the number of entries.
     pub fn len(&self) -> usize {

--- a/crates/duckdb/src/types/ordered_map.rs
+++ b/crates/duckdb/src/types/ordered_map.rs
@@ -13,6 +13,14 @@ impl<K: std::cmp::PartialEq, V> OrderedMap<K, V> {
     pub fn get(&self, key: &K) -> Option<&V> {
         self.0.iter().find(|(k, _)| k == key).map(|(_, v)| v)
     }
+    /// Returns the number of entries.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+    /// Returns `true` if the map contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
     /// Returns an iterator over the keys in the map.
     pub fn keys(&self) -> impl Iterator<Item = &K> {
         self.0.iter().map(|(k, _)| k)

--- a/crates/duckdb/src/types/serde_struct.rs
+++ b/crates/duckdb/src/types/serde_struct.rs
@@ -1,0 +1,1153 @@
+//! Round-trip conversion between `Serialize`/`Deserialize` Rust values and
+//! DuckDB `STRUCT` columns, via the [`Struct<T>`] newtype.
+//!
+//! Enable the `serde` cargo feature to use these impls. A `#[derive(Serialize,
+//! Deserialize)]` struct maps to a DuckDB `STRUCT` whose field names match the
+//! Rust field names. Nested structs, `Vec`/`[T; N]` (-> `LIST`), and string-keyed
+//! maps (`HashMap`/`BTreeMap` -> `STRUCT`) are handled recursively.
+//!
+//! A blanket `impl<T: Serialize> ToSql` is impossible here because the existing
+//! scalar `ToSql` impls (`i32`, `String`, `Option<T>`, ...) are themselves
+//! `Serialize`, which would create overlapping impls. Wrapping the value in
+//! [`Struct`] gives an equivalent blanket impl with no coherence conflict.
+//!
+//! ```rust,no_run
+//! # use duckdb::{Connection, Result, types::Struct};
+//! # use serde::{Serialize, Deserialize};
+//! #[derive(Serialize, Deserialize, PartialEq, Debug)]
+//! struct Point { x: i32, y: f64 }
+//!
+//! # fn example(conn: &Connection) -> Result<()> {
+//! let p = Point { x: 3, y: 4.5 };
+//! conn.execute("CREATE TABLE t (p STRUCT(x INTEGER, y DOUBLE))", [])?;
+//! conn.execute("INSERT INTO t VALUES (?)", [Struct(&p)])?;
+//! let back: Struct<Point> = conn.query_row("SELECT p FROM t", [], |r| r.get(0))?;
+//! assert_eq!(back.0, p);
+//! # Ok(())
+//! # }
+//! ```
+
+use std::fmt;
+
+use serde::Serialize;
+use serde::de::{
+    self, DeserializeOwned, DeserializeSeed, Deserializer, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor,
+};
+use serde::ser::{self, SerializeMap, SerializeSeq, SerializeStruct, SerializeTuple, Serializer};
+
+use crate::{
+    Error, Result,
+    types::{FromSql, FromSqlError, FromSqlResult, OrderedMap, ToSql, ToSqlOutput, Value, ValueRef},
+};
+
+/// Newtype wrapping a `Serialize`/`Deserialize` value for binding to or reading
+/// from a DuckDB `STRUCT` column.
+///
+/// See the [module docs](crate::types::serde_struct) for the mapping rules.
+#[derive(Debug, Clone)]
+pub struct Struct<T>(pub T);
+
+impl<T: Serialize> ToSql for Struct<T> {
+    fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+        let value = self
+            .0
+            .serialize(ValueSerializer)
+            .map_err(|e: SerError| Error::ToSqlConversionFailure(e.into()))?;
+        Ok(ToSqlOutput::Owned(value))
+    }
+}
+
+impl<T: DeserializeOwned> FromSql for Struct<T> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let owned = Value::from(value);
+        let inner =
+            T::deserialize(ValueDeserializer::new(owned)).map_err(|e: SerError| FromSqlError::Other(e.into()))?;
+        Ok(Struct(inner))
+    }
+}
+
+/// Error surfaced by both the serializer and the deserializer.
+#[derive(Debug, Clone)]
+struct SerError(String);
+
+impl fmt::Display for SerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SerError {}
+
+impl ser::Error for SerError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        SerError(msg.to_string())
+    }
+}
+
+impl de::Error for SerError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        SerError(msg.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Serializer: Rust value -> DuckDB Value
+// ---------------------------------------------------------------------------
+
+struct ValueSerializer;
+
+impl Serializer for ValueSerializer {
+    type Ok = Value;
+    type Error = SerError;
+
+    type SerializeSeq = SerSeq;
+    type SerializeTuple = SerSeq;
+    type SerializeTupleStruct = SerSeq;
+    type SerializeTupleVariant = SerSeq;
+    type SerializeMap = SerMap;
+    type SerializeStruct = SerStruct;
+    type SerializeStructVariant = SerStructVariant;
+
+    fn serialize_bool(self, v: bool) -> Result<Value, SerError> {
+        Ok(Value::Boolean(v))
+    }
+    fn serialize_i8(self, v: i8) -> Result<Value, SerError> {
+        Ok(Value::TinyInt(v))
+    }
+    fn serialize_i16(self, v: i16) -> Result<Value, SerError> {
+        Ok(Value::SmallInt(v))
+    }
+    fn serialize_i32(self, v: i32) -> Result<Value, SerError> {
+        Ok(Value::Int(v))
+    }
+    fn serialize_i64(self, v: i64) -> Result<Value, SerError> {
+        Ok(Value::BigInt(v))
+    }
+    fn serialize_i128(self, v: i128) -> Result<Value, SerError> {
+        Ok(Value::HugeInt(v))
+    }
+    fn serialize_u8(self, v: u8) -> Result<Value, SerError> {
+        Ok(Value::UTinyInt(v))
+    }
+    fn serialize_u16(self, v: u16) -> Result<Value, SerError> {
+        Ok(Value::USmallInt(v))
+    }
+    fn serialize_u32(self, v: u32) -> Result<Value, SerError> {
+        Ok(Value::UInt(v))
+    }
+    fn serialize_u64(self, v: u64) -> Result<Value, SerError> {
+        Ok(Value::UBigInt(v))
+    }
+    fn serialize_u128(self, v: u128) -> Result<Value, SerError> {
+        Ok(Value::UHugeInt(v))
+    }
+    fn serialize_f32(self, v: f32) -> Result<Value, SerError> {
+        Ok(Value::Float(v))
+    }
+    fn serialize_f64(self, v: f64) -> Result<Value, SerError> {
+        Ok(Value::Double(v))
+    }
+    fn serialize_char(self, v: char) -> Result<Value, SerError> {
+        Ok(Value::Text(v.to_string()))
+    }
+    fn serialize_str(self, v: &str) -> Result<Value, SerError> {
+        Ok(Value::Text(v.to_string()))
+    }
+    fn serialize_bytes(self, v: &[u8]) -> Result<Value, SerError> {
+        Ok(Value::Blob(v.to_vec()))
+    }
+    fn serialize_none(self) -> Result<Value, SerError> {
+        Ok(Value::Null)
+    }
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Value, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_unit(self) -> Result<Value, SerError> {
+        Ok(Value::Null)
+    }
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Value, SerError> {
+        Ok(Value::Null)
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Value, SerError> {
+        Ok(Value::Text(variant.to_string()))
+    }
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Value, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Value, SerError> {
+        let inner = value.serialize(ValueSerializer)?;
+        let mut fields = OrderedMap::new();
+        fields.insert(variant.to_string(), inner);
+        Ok(Value::Struct(fields))
+    }
+    fn serialize_seq(self, _len: Option<usize>) -> Result<SerSeq, SerError> {
+        Ok(SerSeq {
+            items: Vec::new(),
+            tag: None,
+        })
+    }
+    fn serialize_tuple(self, _len: usize) -> Result<SerSeq, SerError> {
+        Ok(SerSeq {
+            items: Vec::new(),
+            tag: None,
+        })
+    }
+    fn serialize_tuple_struct(self, _name: &'static str, _len: usize) -> Result<SerSeq, SerError> {
+        Ok(SerSeq {
+            items: Vec::new(),
+            tag: None,
+        })
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<SerSeq, SerError> {
+        Ok(SerSeq {
+            items: Vec::new(),
+            tag: Some(variant.to_string()),
+        })
+    }
+    fn serialize_map(self, _len: Option<usize>) -> Result<SerMap, SerError> {
+        Ok(SerMap {
+            fields: OrderedMap::new(),
+            next_key: None,
+        })
+    }
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<SerStruct, SerError> {
+        Ok(SerStruct {
+            fields: OrderedMap::new(),
+        })
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<SerStructVariant, SerError> {
+        Ok(SerStructVariant {
+            tag: variant.to_string(),
+            fields: OrderedMap::new(),
+        })
+    }
+}
+
+/// Collects a sequence (and tuple/tuple-struct/tuple-variant) into a `Value::List`.
+struct SerSeq {
+    items: Vec<Value>,
+    /// Set for tuple variants so `end` wraps the list in a tagged struct.
+    tag: Option<String>,
+}
+
+impl SerializeSeq for SerSeq {
+    type Ok = Value;
+    type Error = SerError;
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(ValueSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Value, SerError> {
+        Ok(wrap_variant(self.tag, Value::List(self.items)))
+    }
+}
+
+impl SerializeTuple for SerSeq {
+    type Ok = Value;
+    type Error = SerError;
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(ValueSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Value, SerError> {
+        Ok(wrap_variant(self.tag, Value::List(self.items)))
+    }
+}
+
+impl ser::SerializeTupleStruct for SerSeq {
+    type Ok = Value;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(ValueSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Value, SerError> {
+        Ok(wrap_variant(self.tag, Value::List(self.items)))
+    }
+}
+
+impl ser::SerializeTupleVariant for SerSeq {
+    type Ok = Value;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        self.items.push(value.serialize(ValueSerializer)?);
+        Ok(())
+    }
+    fn end(self) -> Result<Value, SerError> {
+        Ok(wrap_variant(self.tag, Value::List(self.items)))
+    }
+}
+
+/// Collects a map into a `Value::Struct` (string field names only).
+struct SerMap {
+    fields: OrderedMap<String, Value>,
+    next_key: Option<String>,
+}
+
+impl SerializeMap for SerMap {
+    type Ok = Value;
+    type Error = SerError;
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), SerError> {
+        let key = key.serialize(MapKeySerializer)?;
+        self.next_key = Some(key);
+        Ok(())
+    }
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), SerError> {
+        let key = self
+            .next_key
+            .take()
+            .ok_or_else(|| SerError("map value serialized without a key".into()))?;
+        let value = value.serialize(ValueSerializer)?;
+        self.fields.insert(key, value);
+        Ok(())
+    }
+    fn end(self) -> Result<Value, SerError> {
+        Ok(Value::Struct(self.fields))
+    }
+}
+
+/// Collects a struct into a `Value::Struct`.
+struct SerStruct {
+    fields: OrderedMap<String, Value>,
+}
+
+impl SerializeStruct for SerStruct {
+    type Ok = Value;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> Result<(), SerError> {
+        let value = value.serialize(ValueSerializer)?;
+        self.fields.insert(key.to_string(), value);
+        Ok(())
+    }
+    fn end(self) -> Result<Value, SerError> {
+        Ok(Value::Struct(self.fields))
+    }
+    fn skip_field(&mut self, _key: &'static str) -> Result<(), SerError> {
+        Ok(())
+    }
+}
+
+/// Collects a struct variant into a single-field tagged `Value::Struct`.
+struct SerStructVariant {
+    tag: String,
+    fields: OrderedMap<String, Value>,
+}
+
+impl ser::SerializeStructVariant for SerStructVariant {
+    type Ok = Value;
+    type Error = SerError;
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, key: &'static str, value: &T) -> Result<(), SerError> {
+        let value = value.serialize(ValueSerializer)?;
+        self.fields.insert(key.to_string(), value);
+        Ok(())
+    }
+    fn end(self) -> Result<Value, SerError> {
+        Ok(wrap_variant(Some(self.tag), Value::Struct(self.fields)))
+    }
+}
+
+fn wrap_variant(tag: Option<String>, value: Value) -> Value {
+    match tag {
+        Some(variant) => {
+            let mut fields = OrderedMap::new();
+            fields.insert(variant, value);
+            Value::Struct(fields)
+        }
+        None => value,
+    }
+}
+
+/// Serializer restricted to scalar string-like keys. DuckDB `STRUCT` field
+/// names are strings, so non-string map keys are rejected with a clear error.
+struct MapKeySerializer;
+
+impl Serializer for MapKeySerializer {
+    type Ok = String;
+    type Error = SerError;
+    type SerializeSeq = ser::Impossible<String, SerError>;
+    type SerializeTuple = ser::Impossible<String, SerError>;
+    type SerializeTupleStruct = ser::Impossible<String, SerError>;
+    type SerializeTupleVariant = ser::Impossible<String, SerError>;
+    type SerializeMap = ser::Impossible<String, SerError>;
+    type SerializeStruct = ser::Impossible<String, SerError>;
+    type SerializeStructVariant = ser::Impossible<String, SerError>;
+
+    fn serialize_str(self, v: &str) -> Result<String, SerError> {
+        Ok(v.to_string())
+    }
+    fn serialize_char(self, v: char) -> Result<String, SerError> {
+        Ok(v.to_string())
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<String, SerError> {
+        Ok(variant.to_string())
+    }
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<String, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<String, SerError> {
+        value.serialize(self)
+    }
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<String, SerError> {
+        value.serialize(self)
+    }
+
+    fn serialize_bool(self, v: bool) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_i8(self, v: i8) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_i16(self, v: i16) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_i32(self, v: i32) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_i64(self, v: i64) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_i128(self, v: i128) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_u8(self, v: u8) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_u16(self, v: u16) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_u32(self, v: u32) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_u64(self, v: u64) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_u128(self, v: u128) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_f32(self, v: f32) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_f64(self, v: f64) -> Result<String, SerError> {
+        non_string_key(v)
+    }
+    fn serialize_bytes(self, v: &[u8]) -> Result<String, SerError> {
+        non_string_key(format_args!("{v:?}"))
+    }
+    fn serialize_none(self) -> Result<String, SerError> {
+        non_string_key("None")
+    }
+    fn serialize_unit(self) -> Result<String, SerError> {
+        non_string_key("()")
+    }
+    fn serialize_unit_struct(self, name: &'static str) -> Result<String, SerError> {
+        non_string_key(name)
+    }
+    fn serialize_seq(self, _len: Option<usize>) -> Result<ser::Impossible<String, SerError>, SerError> {
+        Err(SerError("DuckDB STRUCT field names must be strings".into()))
+    }
+    fn serialize_tuple(self, _len: usize) -> Result<ser::Impossible<String, SerError>, SerError> {
+        Err(SerError("DuckDB STRUCT field names must be strings".into()))
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<ser::Impossible<String, SerError>, SerError> {
+        Err(SerError("DuckDB STRUCT field names must be strings".into()))
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<ser::Impossible<String, SerError>, SerError> {
+        Err(SerError("DuckDB STRUCT field names must be strings".into()))
+    }
+    fn serialize_map(self, _len: Option<usize>) -> Result<ser::Impossible<String, SerError>, SerError> {
+        Err(SerError("DuckDB STRUCT field names must be strings".into()))
+    }
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<ser::Impossible<String, SerError>, SerError> {
+        Err(SerError("DuckDB STRUCT field names must be strings".into()))
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<ser::Impossible<String, SerError>, SerError> {
+        Err(SerError("DuckDB STRUCT field names must be strings".into()))
+    }
+}
+
+fn non_string_key<T: fmt::Display>(v: T) -> Result<String, SerError> {
+    Err(SerError(format!("DuckDB STRUCT field names must be strings, got {v}")))
+}
+
+// ---------------------------------------------------------------------------
+// Deserializer: DuckDB Value -> Rust value
+// ---------------------------------------------------------------------------
+
+struct ValueDeserializer {
+    value: Value,
+}
+
+impl ValueDeserializer {
+    fn new(value: Value) -> Self {
+        Self { value }
+    }
+
+    fn as_i64(&self) -> Result<i64, SerError> {
+        match &self.value {
+            Value::TinyInt(i) => Ok(*i as i64),
+            Value::SmallInt(i) => Ok(*i as i64),
+            Value::Int(i) => Ok(*i as i64),
+            Value::BigInt(i) => Ok(*i),
+            Value::UTinyInt(i) => Ok(*i as i64),
+            Value::USmallInt(i) => Ok(*i as i64),
+            Value::UInt(i) => Ok(*i as i64),
+            Value::UBigInt(i) => i64::try_from(*i).map_err(|_| SerError(format!("value {i} out of range for i64"))),
+            other => Err(SerError(format!("expected an integer, got {}", other.type_label()))),
+        }
+    }
+
+    fn as_u64(&self) -> Result<u64, SerError> {
+        match &self.value {
+            Value::UTinyInt(i) => Ok(*i as u64),
+            Value::USmallInt(i) => Ok(*i as u64),
+            Value::UInt(i) => Ok(*i as u64),
+            Value::UBigInt(i) => Ok(*i),
+            Value::TinyInt(i) if *i >= 0 => Ok(*i as u64),
+            Value::SmallInt(i) if *i >= 0 => Ok(*i as u64),
+            Value::Int(i) if *i >= 0 => Ok(*i as u64),
+            Value::BigInt(i) if *i >= 0 => Ok(*i as u64),
+            other => Err(SerError(format!(
+                "expected an unsigned integer, got {}",
+                other.type_label()
+            ))),
+        }
+    }
+
+    fn as_i128(&self) -> Result<i128, SerError> {
+        match &self.value {
+            Value::HugeInt(i) => Ok(*i),
+            Value::UHugeInt(i) => i128::try_from(*i).map_err(|_| SerError(format!("value {i} out of range for i128"))),
+            other => self
+                .as_i64()
+                .map(|v| v as i128)
+                .map_err(|_| SerError(format!("expected an integer, got {}", other.type_label()))),
+        }
+    }
+
+    fn as_f64(&self) -> Result<f64, SerError> {
+        match &self.value {
+            Value::Float(f) => Ok(*f as f64),
+            Value::Double(d) => Ok(*d),
+            other => self
+                .as_i64()
+                .map(|v| v as f64)
+                .map_err(|_| SerError(format!("expected a number, got {}", other.type_label()))),
+        }
+    }
+}
+
+impl Value {
+    fn type_label(&self) -> &'static str {
+        match self {
+            Value::Null => "Null",
+            Value::Boolean(_) => "Boolean",
+            Value::TinyInt(_) => "TinyInt",
+            Value::SmallInt(_) => "SmallInt",
+            Value::Int(_) => "Int",
+            Value::BigInt(_) => "BigInt",
+            Value::HugeInt(_) => "HugeInt",
+            Value::UHugeInt(_) => "UHugeInt",
+            Value::UTinyInt(_) => "UTinyInt",
+            Value::USmallInt(_) => "USmallInt",
+            Value::UInt(_) => "UInt",
+            Value::UBigInt(_) => "UBigInt",
+            Value::Float(_) => "Float",
+            Value::Double(_) => "Double",
+            Value::Decimal(_) => "Decimal",
+            Value::Timestamp(_, _) => "Timestamp",
+            Value::Text(_) => "Text",
+            Value::Blob(_) => "Blob",
+            Value::Geometry(_) => "Geometry",
+            Value::Date32(_) => "Date32",
+            Value::Time64(_, _) => "Time64",
+            Value::Interval { .. } => "Interval",
+            Value::List(_) => "List",
+            Value::Enum(_) => "Enum",
+            Value::Struct(_) => "Struct",
+            Value::Array(_) => "Array",
+            Value::Map(_) => "Map",
+            Value::Union(_) => "Union",
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for ValueDeserializer {
+    type Error = SerError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Null => visitor.visit_unit(),
+            Value::Boolean(b) => visitor.visit_bool(b),
+            Value::TinyInt(i) => visitor.visit_i64(i as i64),
+            Value::SmallInt(i) => visitor.visit_i64(i as i64),
+            Value::Int(i) => visitor.visit_i64(i as i64),
+            Value::BigInt(i) => visitor.visit_i64(i),
+            Value::UTinyInt(i) => visitor.visit_u64(i as u64),
+            Value::USmallInt(i) => visitor.visit_u64(i as u64),
+            Value::UInt(i) => visitor.visit_u64(i as u64),
+            Value::UBigInt(i) => visitor.visit_u64(i),
+            Value::HugeInt(i) => visitor.visit_i128(i),
+            Value::UHugeInt(i) => visitor.visit_u128(i),
+            Value::Float(f) => visitor.visit_f64(f as f64),
+            Value::Double(d) => visitor.visit_f64(d),
+            Value::Text(s) => visitor.visit_string(s),
+            Value::Blob(b) => visitor.visit_byte_buf(b),
+            Value::Geometry(b) => visitor.visit_bytes(&b),
+            Value::Decimal(d) => visitor.visit_string(d.to_string()),
+            Value::Timestamp(_, i) => visitor.visit_i64(i),
+            Value::Date32(d) => visitor.visit_i64(d as i64),
+            Value::Time64(_, i) => visitor.visit_i64(i),
+            Value::Interval { months, days, nanos } => {
+                let mut fields = OrderedMap::new();
+                fields.insert("months".to_string(), Value::Int(months));
+                fields.insert("days".to_string(), Value::Int(days));
+                fields.insert("nanos".to_string(), Value::BigInt(nanos));
+                visitor.visit_map(MapDeserializer {
+                    entries: struct_entries(fields),
+                    next_value: None,
+                })
+            }
+            Value::List(items) | Value::Array(items) => visitor.visit_seq(SeqDeserializer {
+                items: items.into_iter(),
+            }),
+            Value::Struct(fields) => visitor.visit_map(MapDeserializer {
+                entries: struct_entries(fields),
+                next_value: None,
+            }),
+            Value::Map(entries) => visitor.visit_map(MapDeserializer {
+                entries: entries.0.into_iter(),
+                next_value: None,
+            }),
+            Value::Enum(s) => visitor.visit_string(s),
+            Value::Union(_) => Err(SerError(
+                "Union values cannot be deserialized into a typed struct".into(),
+            )),
+        }
+    }
+
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Boolean(b) => visitor.visit_bool(b),
+            _ => visitor.visit_bool(
+                self.as_i64()
+                    .map(|i| i != 0)
+                    .map_err(|_| SerError(format!("expected bool, got {}", self.value.type_label())))?,
+            ),
+        }
+    }
+
+    fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_i64(self.as_i64()?)
+    }
+    fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_i64(self.as_i64()?)
+    }
+    fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_i64(self.as_i64()?)
+    }
+    fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_i64(self.as_i64()?)
+    }
+    fn deserialize_i128<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_i128(self.as_i128()?)
+    }
+    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_u64(self.as_u64()?)
+    }
+    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_u64(self.as_u64()?)
+    }
+    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_u64(self.as_u64()?)
+    }
+    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_u64(self.as_u64()?)
+    }
+    fn deserialize_u128<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_u128(match self.value {
+            Value::UHugeInt(i) => i,
+            _ => self.as_u64()? as u128,
+        })
+    }
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_f64(self.as_f64()?)
+    }
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_f64(self.as_f64()?)
+    }
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        self.deserialize_str(visitor)
+    }
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Text(s) => visitor.visit_string(s),
+            Value::Enum(s) => visitor.visit_string(s),
+            other => Err(SerError(format!("expected a string, got {}", other.type_label()))),
+        }
+    }
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        self.deserialize_str(visitor)
+    }
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Blob(b) => visitor.visit_byte_buf(b),
+            Value::Geometry(b) => visitor.visit_byte_buf(b),
+            other => Err(SerError(format!("expected bytes, got {}", other.type_label()))),
+        }
+    }
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        self.deserialize_bytes(visitor)
+    }
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Null => visitor.visit_unit(),
+            other => Err(SerError(format!("expected unit, got {}", other.type_label()))),
+        }
+    }
+    fn deserialize_unit_struct<V: Visitor<'de>>(self, _name: &'static str, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_unit()
+    }
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, SerError> {
+        visitor.visit_newtype_struct(self)
+    }
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::List(items) | Value::Array(items) => visitor.visit_seq(SeqDeserializer {
+                items: items.into_iter(),
+            }),
+            Value::Null => visitor.visit_seq(SeqDeserializer {
+                items: Vec::new().into_iter(),
+            }),
+            other => Err(SerError(format!("expected a sequence, got {}", other.type_label()))),
+        }
+    }
+    fn deserialize_tuple<V: Visitor<'de>>(self, _len: usize, visitor: V) -> Result<V::Value, SerError> {
+        self.deserialize_seq(visitor)
+    }
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, SerError> {
+        self.deserialize_seq(visitor)
+    }
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Struct(fields) => visitor.visit_map(MapDeserializer {
+                entries: struct_entries(fields),
+                next_value: None,
+            }),
+            Value::Map(fields) => visitor.visit_map(MapDeserializer {
+                entries: fields.0.into_iter(),
+                next_value: None,
+            }),
+            other => Err(SerError(format!("expected a struct/map, got {}", other.type_label()))),
+        }
+    }
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, SerError> {
+        self.deserialize_map(visitor)
+    }
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, SerError> {
+        match self.value {
+            Value::Text(s) => visitor.visit_enum(UnitEnumAccess { name: s }),
+            Value::Enum(s) => visitor.visit_enum(UnitEnumAccess { name: s }),
+            Value::Struct(mut fields) if fields.len() == 1 => {
+                let (variant, inner) = fields.0.swap_remove(0);
+                visitor.visit_enum(TaggedEnumAccess { variant, inner })
+            }
+            other => Err(SerError(format!("expected an enum, got {}", other.type_label()))),
+        }
+    }
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        self.deserialize_str(visitor)
+    }
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_unit()
+    }
+}
+
+struct SeqDeserializer {
+    items: std::vec::IntoIter<Value>,
+}
+
+impl<'de> SeqAccess<'de> for SeqDeserializer {
+    type Error = SerError;
+    fn next_element_seed<T: DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>, SerError> {
+        match self.items.next() {
+            Some(value) => Ok(Some(seed.deserialize(ValueDeserializer::new(value))?)),
+            None => Ok(None),
+        }
+    }
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.items.len())
+    }
+}
+
+struct MapDeserializer {
+    entries: std::vec::IntoIter<(Value, Value)>,
+    next_value: Option<Value>,
+}
+
+/// Wraps `STRUCT` string field names as `Value::Text` so the same `(Value,
+/// Value)` entry stream serves both STRUCT and MAP deserialization.
+fn struct_entries(fields: OrderedMap<String, Value>) -> std::vec::IntoIter<(Value, Value)> {
+    fields
+        .0
+        .into_iter()
+        .map(|(k, v)| (Value::Text(k), v))
+        .collect::<Vec<_>>()
+        .into_iter()
+}
+
+impl<'de> MapAccess<'de> for MapDeserializer {
+    type Error = SerError;
+    fn next_key_seed<K: DeserializeSeed<'de>>(&mut self, seed: K) -> Result<Option<K::Value>, SerError> {
+        match self.entries.next() {
+            Some((key, value)) => {
+                self.next_value = Some(value);
+                Ok(Some(seed.deserialize(ValueDeserializer::new(key))?))
+            }
+            None => Ok(None),
+        }
+    }
+    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, SerError> {
+        let value = self
+            .next_value
+            .take()
+            .ok_or_else(|| SerError("struct field value missing its key".into()))?;
+        seed.deserialize(ValueDeserializer::new(value))
+    }
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.entries.len())
+    }
+}
+
+struct UnitEnumAccess {
+    name: String,
+}
+
+impl<'de> EnumAccess<'de> for UnitEnumAccess {
+    type Error = SerError;
+    type Variant = UnitVariantAccess;
+    fn variant_seed<V: DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, Self::Variant), SerError> {
+        let value = seed.deserialize(StrDeserializer(&self.name))?;
+        Ok((value, UnitVariantAccess))
+    }
+}
+
+struct TaggedEnumAccess {
+    variant: String,
+    inner: Value,
+}
+
+impl<'de> EnumAccess<'de> for TaggedEnumAccess {
+    type Error = SerError;
+    type Variant = ValueVariantAccess;
+    fn variant_seed<V: DeserializeSeed<'de>>(self, seed: V) -> Result<(V::Value, Self::Variant), SerError> {
+        let value = seed.deserialize(StrDeserializer(&self.variant))?;
+        Ok((
+            value,
+            ValueVariantAccess {
+                inner: Some(self.inner),
+            },
+        ))
+    }
+}
+
+struct UnitVariantAccess;
+
+impl<'de> VariantAccess<'de> for UnitVariantAccess {
+    type Error = SerError;
+    fn unit_variant(self) -> Result<(), SerError> {
+        Ok(())
+    }
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(self, _seed: T) -> Result<T::Value, SerError> {
+        Err(SerError(
+            "expected a unit enum variant, got newtype variant data".into(),
+        ))
+    }
+    fn tuple_variant<V: Visitor<'de>>(self, _len: usize, _visitor: V) -> Result<V::Value, SerError> {
+        Err(SerError("expected a unit enum variant, got tuple variant data".into()))
+    }
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, SerError> {
+        Err(SerError("expected a unit enum variant, got struct variant data".into()))
+    }
+}
+
+struct ValueVariantAccess {
+    inner: Option<Value>,
+}
+
+impl<'de> VariantAccess<'de> for ValueVariantAccess {
+    type Error = SerError;
+    fn unit_variant(self) -> Result<(), SerError> {
+        Ok(())
+    }
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(mut self, seed: T) -> Result<T::Value, SerError> {
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| SerError("enum variant already consumed".into()))?;
+        seed.deserialize(ValueDeserializer::new(inner))
+    }
+    fn tuple_variant<V: Visitor<'de>>(self, _len: usize, visitor: V) -> Result<V::Value, SerError> {
+        let inner = self
+            .inner
+            .ok_or_else(|| SerError("enum variant already consumed".into()))?;
+        ValueDeserializer::new(inner).deserialize_seq(visitor)
+    }
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, SerError> {
+        let inner = self
+            .inner
+            .ok_or_else(|| SerError("enum variant already consumed".into()))?;
+        ValueDeserializer::new(inner).deserialize_map(visitor)
+    }
+}
+
+/// Deserializer that always yields a borrowed string. Used for struct/enum
+/// identifiers read back from a DuckDB `STRUCT` field name.
+struct StrDeserializer<'a>(&'a str);
+
+impl<'de> de::Deserializer<'de> for StrDeserializer<'_> {
+    type Error = SerError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, SerError> {
+        visitor.visit_str(self.0)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Connection, Result, types::Value};
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Point {
+        x: i32,
+        y: f64,
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Nested {
+        name: String,
+        point: Point,
+        tags: Vec<String>,
+        scores: Vec<f64>,
+        active: bool,
+        maybe: Option<f32>,
+        meta: HashMap<String, i64>,
+        count: u32,
+        big: i128,
+    }
+
+    #[test]
+    fn serializer_maps_struct_to_value_struct() {
+        let p = Point { x: 3, y: 4.5 };
+        let wrapper = Struct(&p);
+        let value = wrapper.to_sql().unwrap();
+        let owned = match value {
+            ToSqlOutput::Owned(v) => v,
+            other => panic!("expected Owned, got {other:?}"),
+        };
+        match owned {
+            Value::Struct(fields) => {
+                assert_eq!(fields.get(&"x".to_string()), Some(&Value::Int(3)));
+                match fields.get(&"y".to_string()) {
+                    Some(Value::Double(d)) => assert!((d - 4.5).abs() < 1e-9),
+                    other => panic!("unexpected y: {other:?}"),
+                }
+            }
+            other => panic!("expected Value::Struct, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serializer_rejects_non_string_map_key() {
+        let mut bad: HashMap<i32, i32> = HashMap::new();
+        bad.insert(1, 2);
+        let err = Struct(&bad).to_sql().unwrap_err();
+        assert!(err.to_string().contains("STRUCT field names must be strings"), "{err}");
+    }
+
+    #[test]
+    fn round_trip_nested_struct() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE t (row STRUCT(
+                name VARCHAR,
+                point STRUCT(x INTEGER, y DOUBLE),
+                tags VARCHAR[],
+                scores DOUBLE[],
+                active BOOLEAN,
+                maybe FLOAT,
+                meta MAP(VARCHAR, BIGINT),
+                count UINTEGER,
+                big HUGEINT
+            ));",
+        )?;
+
+        let mut meta = HashMap::new();
+        meta.insert("a".to_string(), 1_i64);
+        meta.insert("b".to_string(), 2_i64);
+        let row = Nested {
+            name: "hi".to_string(),
+            point: Point { x: 3, y: 4.5 },
+            tags: vec!["t1".to_string(), "t2".to_string()],
+            scores: vec![1.0, 2.5],
+            active: true,
+            maybe: Some(9.5),
+            meta,
+            count: 42,
+            big: 1_000_000_000_000,
+        };
+
+        conn.execute("INSERT INTO t VALUES (?)", [Struct(&row)])?;
+        let back: Struct<Nested> = conn.query_row("SELECT row FROM t", [], |r| r.get(0))?;
+        assert_eq!(back.0, row);
+        Ok(())
+    }
+
+    #[test]
+    fn round_trip_unit_enum() -> Result<()> {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Item {
+            color: Color,
+        }
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        #[allow(dead_code)]
+        enum Color {
+            Red,
+            Green,
+            Blue,
+        }
+
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE t (row STRUCT(color VARCHAR));")?;
+        let item = Item { color: Color::Green };
+        conn.execute("INSERT INTO t VALUES (?)", [Struct(&item)])?;
+        let back: Struct<Item> = conn.query_row("SELECT row FROM t", [], |r| r.get(0))?;
+        assert_eq!(back.0, item);
+        Ok(())
+    }
+
+    #[test]
+    fn round_trip_none_option() -> Result<()> {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Row {
+            maybe: Option<f32>,
+        }
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE t (row STRUCT(maybe FLOAT));")?;
+        let row = Row { maybe: None };
+        conn.execute("INSERT INTO t VALUES (?)", [Struct(&row)])?;
+        let back: Struct<Row> = conn.query_row("SELECT row FROM t", [], |r| r.get(0))?;
+        assert_eq!(back.0, row);
+        Ok(())
+    }
+
+    #[test]
+    fn from_sql_rejects_type_mismatch() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE t (v INTEGER); INSERT INTO t VALUES (1);")?;
+        let err = conn
+            .query_row::<Struct<Point>, _, _>("SELECT v FROM t", [], |r| r.get(0))
+            .unwrap_err();
+        assert!(err.to_string().contains("expected a struct/map"), "{err}");
+        Ok(())
+    }
+}

--- a/crates/duckdb/src/types/serde_struct.rs
+++ b/crates/duckdb/src/types/serde_struct.rs
@@ -43,7 +43,7 @@ use crate::{
 /// Newtype wrapping a `Serialize`/`Deserialize` value for binding to or reading
 /// from a DuckDB `STRUCT` column.
 ///
-/// See the [module docs](crate::types::serde_struct) for the mapping rules.
+/// See the `serde_struct` module-level docs for the mapping rules.
 #[derive(Debug, Clone)]
 pub struct Struct<T>(pub T);
 

--- a/crates/duckdb/src/types/to_sql.rs
+++ b/crates/duckdb/src/types/to_sql.rs
@@ -1,5 +1,5 @@
 use super::{Null, TimeUnit, Value, ValueRef, binding_unsupported_value, value_ref_from_value};
-use crate::Result;
+use crate::{Error, Result};
 use std::borrow::Cow;
 
 /// `ToSqlOutput` represents the possible output types for implementers of the
@@ -64,9 +64,14 @@ from_value!(uuid::Uuid);
 impl ToSql for ToSqlOutput<'_> {
     #[inline]
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        Ok(match *self {
-            ToSqlOutput::Borrowed(v) => ToSqlOutput::Borrowed(v),
-            ToSqlOutput::Owned(ref v) => ToSqlOutput::Borrowed(value_ref_from_value(v, binding_unsupported_value)?),
+        Ok(match self {
+            ToSqlOutput::Borrowed(v) => ToSqlOutput::Borrowed(*v),
+            // Container values cannot become ValueRef from an owned Value, so
+            // keep them Owned for the bind/append sites to handle recursively.
+            ToSqlOutput::Owned(v) => match value_ref_from_value(v, binding_unsupported_value) {
+                Ok(borrowed) => ToSqlOutput::Borrowed(borrowed),
+                Err(_) => ToSqlOutput::Owned(v.clone()),
+            },
         })
     }
 }
@@ -191,10 +196,18 @@ impl ToSql for [u8] {
 impl ToSql for Value {
     #[inline]
     fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
-        Ok(ToSqlOutput::Borrowed(value_ref_from_value(
-            self,
-            binding_unsupported_value,
-        )?))
+        match self {
+            // Container variants cannot become ValueRef from an owned Value.
+            // Keep them Owned so the bind/append sites can build duckdb_value
+            // recursively via the C value API.
+            Value::List(_) | Value::Array(_) | Value::Struct(_) | Value::Map(_) | Value::Union(_) | Value::Enum(_) => {
+                Ok(ToSqlOutput::Owned(self.clone()))
+            }
+            _ => Ok(ToSqlOutput::Borrowed(value_ref_from_value(
+                self,
+                binding_unsupported_value,
+            )?)),
+        }
     }
 }
 
@@ -216,6 +229,47 @@ impl ToSql for std::time::Duration {
         )))
     }
 }
+
+/// Implements [`ToSql`] for `Vec<T>` and `[T; N]` by binding the elements as a
+/// DuckDB fixed-size `ARRAY` (`T[N]`). Empty containers are rejected because
+/// the element type cannot be inferred from the value alone.
+macro_rules! to_sql_numeric_array {
+    ($t:ty, $variant:ident) => {
+        impl ToSql for Vec<$t> {
+            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+                if self.is_empty() {
+                    return Err(Error::ToSqlConversionFailure(
+                        "cannot bind an empty Vec; the array element type cannot be inferred".into(),
+                    ));
+                }
+                let value = Value::Array(self.iter().map(|x| Value::$variant(*x)).collect());
+                Ok(ToSqlOutput::Owned(value))
+            }
+        }
+
+        impl<const N: usize> ToSql for [$t; N] {
+            fn to_sql(&self) -> Result<ToSqlOutput<'_>> {
+                if N == 0 {
+                    return Err(Error::ToSqlConversionFailure(
+                        "cannot bind a zero-length array; DuckDB arrays require at least one element".into(),
+                    ));
+                }
+                let value = Value::Array(self.iter().map(|x| Value::$variant(*x)).collect());
+                Ok(ToSqlOutput::Owned(value))
+            }
+        }
+    };
+}
+
+to_sql_numeric_array!(f32, Float);
+to_sql_numeric_array!(f64, Double);
+to_sql_numeric_array!(i8, TinyInt);
+to_sql_numeric_array!(i16, SmallInt);
+to_sql_numeric_array!(i32, Int);
+to_sql_numeric_array!(i64, BigInt);
+to_sql_numeric_array!(u16, USmallInt);
+to_sql_numeric_array!(u32, UInt);
+to_sql_numeric_array!(u64, UBigInt);
 
 #[cfg(test)]
 mod test {
@@ -240,49 +294,47 @@ mod test {
     }
 
     #[test]
-    fn test_value_to_sql_rejects_unsupported_variants() {
-        use crate::{
-            Error,
-            types::{OrderedMap, Value},
-        };
+    fn test_value_to_sql_preserves_owned_for_containers() {
+        use crate::types::{OrderedMap, Value};
 
-        let cases: &[(&str, Value)] = &[
-            ("List", Value::List(vec![Value::Int(1)])),
-            ("Array", Value::Array(vec![Value::Int(1)])),
-            (
-                "Struct",
-                Value::Struct(OrderedMap::from(vec![("k".to_string(), Value::Int(1))])),
-            ),
-            (
-                "Map",
-                Value::Map(OrderedMap::from(vec![(Value::Int(1), Value::Int(2))])),
-            ),
-            ("Union", Value::Union(Box::new(Value::Int(1)))),
-            ("Enum", Value::Enum("variant".to_string())),
+        let containers: &[Value] = &[
+            Value::List(vec![Value::Int(1)]),
+            Value::Array(vec![Value::Int(1)]),
+            Value::Struct(OrderedMap::from(vec![("k".to_string(), Value::Int(1))])),
+            Value::Map(OrderedMap::from(vec![(Value::Int(1), Value::Int(2))])),
         ];
 
-        for (variant, value) in cases {
+        for value in containers {
             match value.to_sql() {
-                Err(Error::ToSqlConversionFailure(e)) => {
-                    let msg = e.to_string();
-                    assert!(
-                        msg.contains(&format!("binding {variant} parameters is not yet supported")),
-                        "{variant}: unexpected message {msg}"
-                    );
-                }
-                Err(other) => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
-                Ok(_) => panic!("{variant}: expected error, got Ok"),
+                Ok(ToSqlOutput::Owned(v)) => assert_eq!(v, *value, "container should round-trip as Owned"),
+                other => panic!("expected ToSqlOutput::Owned for {:?}, got {other:?}", value),
             }
-            match ToSqlOutput::Owned(value.clone()).to_sql() {
-                Err(Error::ToSqlConversionFailure(e)) => {
+        }
+    }
+
+    #[test]
+    fn test_enum_and_union_values_reject_at_bind() {
+        use crate::{Connection, Error, types::Value};
+
+        let cases: &[(&str, Value)] = &[
+            ("Enum", Value::Enum("variant".to_string())),
+            ("Union", Value::Union(Box::new(Value::Int(1)))),
+        ];
+
+        let conn = Connection::open_in_memory().unwrap();
+        for (variant, value) in cases {
+            let err = conn
+                .query_row("SELECT ?", [value.clone()], |r| r.get::<_, Value>(0))
+                .unwrap_err();
+            match err {
+                Error::ToSqlConversionFailure(e) => {
                     let msg = e.to_string();
                     assert!(
                         msg.contains(&format!("binding {variant} parameters is not yet supported")),
                         "{variant}: unexpected message {msg}"
                     );
                 }
-                Err(other) => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
-                Ok(_) => panic!("{variant}: expected error, got Ok"),
+                other => panic!("{variant}: expected ToSqlConversionFailure, got {other:?}"),
             }
         }
     }

--- a/crates/duckdb/src/types/value.rs
+++ b/crates/duckdb/src/types/value.rs
@@ -253,9 +253,12 @@ where
 
 impl Value {
     /// Returns DuckDB fundamental datatype.
-    #[inline]
+    ///
+    /// For container variants the child type is derived from the first
+    /// element/entry and falls back to [`Type::Null`] for empty containers,
+    /// since DuckDB's logical type metadata is not carried on [`Value`].
     pub fn data_type(&self) -> Type {
-        match *self {
+        match self {
             Self::Null => Type::Null,
             Self::Boolean(_) => Type::Boolean,
             Self::TinyInt(_) => Type::TinyInt,
@@ -278,8 +281,25 @@ impl Value {
             Self::Date32(_) => Type::Date32,
             Self::Time64(..) => Type::Time64,
             Self::Interval { .. } => Type::Interval,
-            Self::Union(..) | Self::Struct(..) | Self::List(..) | Self::Array(..) | Self::Map(..) => todo!(),
             Self::Enum(..) => Type::Enum,
+            Self::List(items) => Type::List(Box::new(container_child_type(items))),
+            Self::Array(items) => Type::Array(Box::new(container_child_type(items)), items.len() as u32),
+            Self::Struct(fields) => Type::Struct(fields.iter().map(|(k, v)| (k.clone(), v.data_type())).collect()),
+            Self::Map(entries) => {
+                let (key, value) = entries
+                    .iter()
+                    .next()
+                    .map(|(k, v)| (k.data_type(), v.data_type()))
+                    .unwrap_or((Type::Null, Type::Null));
+                Type::Map(Box::new(key), Box::new(value))
+            }
+            Self::Union(_) => Type::Union,
         }
     }
+}
+
+/// Derives the element [`Type`] for a container [`Value`], falling back to
+/// [`Type::Null`] when the container is empty.
+fn container_child_type(items: &[Value]) -> Type {
+    items.first().map(Value::data_type).unwrap_or(Type::Null)
 }

--- a/crates/duckdb/src/types/value_ffi.rs
+++ b/crates/duckdb/src/types/value_ffi.rs
@@ -1,0 +1,414 @@
+//! Recursive conversion of [`Value`] into a `duckdb_value` handle.
+//!
+//! Container variants ([`Value::List`], [`Value::Array`], [`Value::Struct`],
+//! [`Value::Map`]) cannot be represented as a [`ValueRef`](crate::types::ValueRef)
+//! built from an owned [`Value`] because that path has no Arrow backing array.
+//! Instead the bind/append sites route those values through [`FfiValue`], which
+//! builds a `duckdb_value` recursively via DuckDB's C value API
+//! (`duckdb_create_list_value`, `duckdb_create_array_value`,
+//! `duckdb_create_struct_value`, `duckdb_create_map_value`).
+//!
+//! Ownership: the `duckdb_create_*_value` functions *copy* the child values
+//! (verified in DuckDB's `duckdb_value-c.cpp`: `unwrapped_values.push_back(value)`
+//! invokes the copy constructor). [`FfiValueArray`] therefore owns and destroys
+//! every child it builds, even after a successful `create_*_value` call.
+
+use std::ffi::CString;
+
+use crate::{
+    Error, Result,
+    core::{LogicalTypeHandle, LogicalTypeId},
+    ffi,
+    types::{OrderedMap, TimeUnit, Value, to_duckdb_decimal, to_duckdb_hugeint, to_duckdb_uhugeint},
+};
+
+/// RAII guard owning a `duckdb_value`. Calls `duckdb_destroy_value` on drop.
+#[derive(Debug)]
+pub(crate) struct FfiValue {
+    ptr: ffi::duckdb_value,
+}
+
+impl FfiValue {
+    /// Recursively builds a `duckdb_value` from a Rust [`Value`], including
+    /// nested containers (`List`, `Array`, `Struct`, `Map`).
+    pub(crate) fn from_value(value: &Value) -> Result<Self> {
+        let ptr = build(value)?;
+        if ptr.is_null() {
+            return Err(Error::ToSqlConversionFailure(
+                format!("duckdb value construction failed for {}", value.data_type()).into(),
+            ));
+        }
+        Ok(Self { ptr })
+    }
+
+    /// Returns the raw `duckdb_value` pointer. The guard still owns it and
+    /// destroys it on drop, so callers must not free it themselves.
+    pub(crate) fn ptr(&self) -> ffi::duckdb_value {
+        self.ptr
+    }
+}
+
+impl Drop for FfiValue {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe { ffi::duckdb_destroy_value(&mut self.ptr) };
+        }
+    }
+}
+
+/// Returns `true` when `value` is a container that must be routed through
+/// [`FfiValue::from_value`] instead of the [`ValueRef`](crate::types::ValueRef)
+/// bind/append path.
+pub(crate) fn is_bindable_container(value: &Value) -> bool {
+    matches!(
+        value,
+        Value::List(_) | Value::Array(_) | Value::Struct(_) | Value::Map(_)
+    )
+}
+
+/// Owns a flat array of `duckdb_value` children and destroys them on drop.
+struct FfiValueArray {
+    values: Vec<ffi::duckdb_value>,
+}
+
+impl FfiValueArray {
+    /// Builds a flat child array from `items`, recursing via [`build`]. On
+    /// error, any children already constructed are destroyed.
+    fn build<'a>(items: impl IntoIterator<Item = &'a Value>) -> Result<Self> {
+        let mut values = Vec::new();
+        for item in items {
+            let ptr = build(item)?;
+            if ptr.is_null() {
+                for built in &mut values {
+                    unsafe { ffi::duckdb_destroy_value(built) };
+                }
+                return Err(Error::ToSqlConversionFailure(
+                    format!("failed to build child value of type {}", item.data_type()).into(),
+                ));
+            }
+            values.push(ptr);
+        }
+        Ok(Self { values })
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut ffi::duckdb_value {
+        self.values.as_mut_ptr()
+    }
+
+    fn len(&self) -> ffi::idx_t {
+        self.values.len() as ffi::idx_t
+    }
+}
+
+impl Drop for FfiValueArray {
+    fn drop(&mut self) {
+        for value in &mut self.values {
+            if !value.is_null() {
+                unsafe { ffi::duckdb_destroy_value(value) };
+            }
+        }
+    }
+}
+
+fn build(value: &Value) -> Result<ffi::duckdb_value> {
+    let ptr = match value {
+        Value::Null => unsafe { ffi::duckdb_create_null_value() },
+        Value::Boolean(b) => unsafe { ffi::duckdb_create_bool(*b) },
+        Value::TinyInt(i) => unsafe { ffi::duckdb_create_int8(*i) },
+        Value::SmallInt(i) => unsafe { ffi::duckdb_create_int16(*i) },
+        Value::Int(i) => unsafe { ffi::duckdb_create_int32(*i) },
+        Value::BigInt(i) => unsafe { ffi::duckdb_create_int64(*i) },
+        Value::HugeInt(i) => unsafe { ffi::duckdb_create_hugeint(to_duckdb_hugeint(*i)) },
+        Value::UHugeInt(i) => unsafe { ffi::duckdb_create_uhugeint(to_duckdb_uhugeint(*i)) },
+        Value::UTinyInt(i) => unsafe { ffi::duckdb_create_uint8(*i) },
+        Value::USmallInt(i) => unsafe { ffi::duckdb_create_uint16(*i) },
+        Value::UInt(i) => unsafe { ffi::duckdb_create_uint32(*i) },
+        Value::UBigInt(i) => unsafe { ffi::duckdb_create_uint64(*i) },
+        Value::Float(f) => unsafe { ffi::duckdb_create_float(*f) },
+        Value::Double(d) => unsafe { ffi::duckdb_create_double(*d) },
+        Value::Decimal(d) => unsafe { ffi::duckdb_create_decimal(to_duckdb_decimal(*d)) },
+        Value::Text(s) => {
+            let c = CString::new(s.as_str()).map_err(|e| Error::ToSqlConversionFailure(e.into()))?;
+            unsafe { ffi::duckdb_create_varchar_length(c.as_ptr(), s.len() as ffi::idx_t) }
+        }
+        Value::Blob(b) | Value::Geometry(b) => unsafe { ffi::duckdb_create_blob(b.as_ptr(), b.len() as ffi::idx_t) },
+        Value::Timestamp(unit, i) => unsafe {
+            ffi::duckdb_create_timestamp(ffi::duckdb_timestamp {
+                micros: unit.to_micros(*i),
+            })
+        },
+        Value::Date32(days) => unsafe { ffi::duckdb_create_date(ffi::duckdb_date { days: *days }) },
+        Value::Time64(unit, i) => unsafe {
+            ffi::duckdb_create_time(ffi::duckdb_time {
+                micros: unit.to_micros(*i),
+            })
+        },
+        Value::Interval { months, days, nanos } => unsafe {
+            ffi::duckdb_create_interval(ffi::duckdb_interval {
+                months: *months,
+                days: *days,
+                micros: *nanos / 1_000,
+            })
+        },
+        Value::List(items) => return build_list(items),
+        Value::Array(items) => return build_array(items),
+        Value::Struct(fields) => return build_struct(fields),
+        Value::Map(entries) => return build_map(entries),
+        Value::Enum(_) | Value::Union(_) => {
+            return Err(Error::ToSqlConversionFailure(
+                format!(
+                    "binding {} parameters is not supported via the duckdb_value API",
+                    variant_name(value)
+                )
+                .into(),
+            ));
+        }
+    };
+    Ok(ptr)
+}
+
+fn build_list(items: &[Value]) -> Result<ffi::duckdb_value> {
+    let child_type = homogeneous_child_logical_type(items, "list")?;
+    let mut children = FfiValueArray::build(items.iter())?;
+    let ptr = unsafe { ffi::duckdb_create_list_value(child_type.ptr, children.as_mut_ptr(), children.len()) };
+    Ok(ptr)
+}
+
+fn build_array(items: &[Value]) -> Result<ffi::duckdb_value> {
+    let child_type = homogeneous_child_logical_type(items, "array")?;
+    let mut children = FfiValueArray::build(items.iter())?;
+    let ptr = unsafe { ffi::duckdb_create_array_value(child_type.ptr, children.as_mut_ptr(), children.len()) };
+    Ok(ptr)
+}
+
+fn build_struct(fields: &OrderedMap<String, Value>) -> Result<ffi::duckdb_value> {
+    let field_types: Vec<(&str, LogicalTypeHandle)> = fields
+        .iter()
+        .map(|(k, v)| Ok((k.as_str(), value_logical_type(v)?)))
+        .collect::<Result<_>>()?;
+    let struct_type = LogicalTypeHandle::struct_type(&field_types);
+    let mut children = FfiValueArray::build(fields.values())?;
+    let ptr = unsafe { ffi::duckdb_create_struct_value(struct_type.ptr, children.as_mut_ptr()) };
+    Ok(ptr)
+}
+
+fn build_map(entries: &OrderedMap<Value, Value>) -> Result<ffi::duckdb_value> {
+    let (key_type, value_type) = map_key_value_types(entries)?;
+    let map_type = LogicalTypeHandle::map(&key_type, &value_type);
+    let mut keys = FfiValueArray::build(entries.keys())?;
+    let mut values = FfiValueArray::build(entries.values())?;
+    let ptr = unsafe {
+        ffi::duckdb_create_map_value(
+            map_type.ptr,
+            keys.as_mut_ptr(),
+            values.as_mut_ptr(),
+            entries.len() as ffi::idx_t,
+        )
+    };
+    Ok(ptr)
+}
+
+/// Derives the element logical type for a homogeneous container. Returns a
+/// clear error for empty containers, where the element type cannot be inferred
+/// from the value alone.
+fn homogeneous_child_logical_type(items: &[Value], kind: &str) -> Result<LogicalTypeHandle> {
+    let first = items.first().ok_or_else(|| {
+        Error::ToSqlConversionFailure(
+            format!(
+                "cannot infer element type for an empty {kind}; bind at least one element or \
+                 cast the parameter in SQL"
+            )
+            .into(),
+        )
+    })?;
+    let child_type = value_logical_type(first)?;
+    let child_category = first.data_type();
+    for item in &items[1..] {
+        if item.data_type() != child_category {
+            return Err(Error::ToSqlConversionFailure(
+                format!("heterogeneous {kind} elements are not supported").into(),
+            ));
+        }
+    }
+    Ok(child_type)
+}
+
+fn map_key_value_types(entries: &OrderedMap<Value, Value>) -> Result<(LogicalTypeHandle, LogicalTypeHandle)> {
+    let (key, value) = entries.iter().next().ok_or_else(|| {
+        Error::ToSqlConversionFailure(
+            "cannot infer key/value types for an empty map; bind at least one entry or cast in SQL".into(),
+        )
+    })?;
+    Ok((value_logical_type(key)?, value_logical_type(value)?))
+}
+
+/// Builds the [`LogicalTypeHandle`] that matches a [`Value`], preserving full
+/// type fidelity (e.g. decimal width/scale and nested container shapes).
+fn value_logical_type(value: &Value) -> Result<LogicalTypeHandle> {
+    Ok(match value {
+        Value::Null => LogicalTypeHandle::from(LogicalTypeId::SqlNull),
+        Value::Boolean(_) => LogicalTypeHandle::from(LogicalTypeId::Boolean),
+        Value::TinyInt(_) => LogicalTypeHandle::from(LogicalTypeId::Tinyint),
+        Value::SmallInt(_) => LogicalTypeHandle::from(LogicalTypeId::Smallint),
+        Value::Int(_) => LogicalTypeHandle::from(LogicalTypeId::Integer),
+        Value::BigInt(_) => LogicalTypeHandle::from(LogicalTypeId::Bigint),
+        Value::HugeInt(_) => LogicalTypeHandle::from(LogicalTypeId::Hugeint),
+        Value::UHugeInt(_) => LogicalTypeHandle::from(LogicalTypeId::UHugeint),
+        Value::UTinyInt(_) => LogicalTypeHandle::from(LogicalTypeId::UTinyint),
+        Value::USmallInt(_) => LogicalTypeHandle::from(LogicalTypeId::USmallint),
+        Value::UInt(_) => LogicalTypeHandle::from(LogicalTypeId::UInteger),
+        Value::UBigInt(_) => LogicalTypeHandle::from(LogicalTypeId::UBigint),
+        Value::Float(_) => LogicalTypeHandle::from(LogicalTypeId::Float),
+        Value::Double(_) => LogicalTypeHandle::from(LogicalTypeId::Double),
+        Value::Decimal(d) => LogicalTypeHandle::decimal(d.width(), d.scale()),
+        Value::Text(_) => LogicalTypeHandle::from(LogicalTypeId::Varchar),
+        Value::Blob(_) | Value::Geometry(_) => LogicalTypeHandle::from(LogicalTypeId::Blob),
+        Value::Timestamp(unit, _) => LogicalTypeHandle::from(timestamp_logical_id(*unit)),
+        Value::Date32(_) => LogicalTypeHandle::from(LogicalTypeId::Date),
+        Value::Time64(unit, _) => LogicalTypeHandle::from(time_logical_id(*unit)),
+        Value::Interval { .. } => LogicalTypeHandle::from(LogicalTypeId::Interval),
+        Value::List(items) => {
+            let child = homogeneous_child_logical_type(items, "list")?;
+            LogicalTypeHandle::list(&child)
+        }
+        Value::Array(items) => {
+            let child = homogeneous_child_logical_type(items, "array")?;
+            LogicalTypeHandle::array(&child, items.len() as u64)
+        }
+        Value::Struct(fields) => {
+            let field_types: Vec<(&str, LogicalTypeHandle)> = fields
+                .iter()
+                .map(|(k, v)| Ok((k.as_str(), value_logical_type(v)?)))
+                .collect::<Result<_>>()?;
+            LogicalTypeHandle::struct_type(&field_types)
+        }
+        Value::Map(entries) => {
+            let (key, value) = map_key_value_types(entries)?;
+            LogicalTypeHandle::map(&key, &value)
+        }
+        Value::Enum(_) | Value::Union(_) => {
+            return Err(Error::ToSqlConversionFailure(
+                format!(
+                    "binding {} parameters is not supported via the duckdb_value API",
+                    variant_name(value)
+                )
+                .into(),
+            ));
+        }
+    })
+}
+
+fn timestamp_logical_id(unit: TimeUnit) -> LogicalTypeId {
+    match unit {
+        TimeUnit::Second => LogicalTypeId::TimestampS,
+        TimeUnit::Millisecond => LogicalTypeId::TimestampMs,
+        TimeUnit::Microsecond => LogicalTypeId::Timestamp,
+        TimeUnit::Nanosecond => LogicalTypeId::TimestampNs,
+    }
+}
+
+fn time_logical_id(unit: TimeUnit) -> LogicalTypeId {
+    match unit {
+        TimeUnit::Second | TimeUnit::Millisecond | TimeUnit::Microsecond => LogicalTypeId::Time,
+        TimeUnit::Nanosecond => LogicalTypeId::TimeNs,
+    }
+}
+
+fn variant_name(value: &Value) -> &'static str {
+    match value {
+        Value::Enum(_) => "Enum",
+        Value::Union(_) => "Union",
+        _ => "container",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{OrderedMap, Type};
+
+    #[test]
+    fn data_type_of_float_array() {
+        let v = Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]);
+        assert_eq!(v.data_type(), Type::Array(Box::new(Type::Float), 2));
+    }
+
+    #[test]
+    fn data_type_of_empty_list_falls_back_to_null_child() {
+        let v = Value::List(vec![]);
+        assert_eq!(v.data_type(), Type::List(Box::new(Type::Null)));
+    }
+
+    #[test]
+    fn data_type_of_struct_preserves_fields() {
+        let fields = OrderedMap::from(vec![
+            ("a".to_string(), Value::Int(1)),
+            ("b".to_string(), Value::Float(2.0)),
+        ]);
+        let v = Value::Struct(fields);
+        assert_eq!(
+            v.data_type(),
+            Type::Struct(vec![("a".to_string(), Type::Int), ("b".to_string(), Type::Float)])
+        );
+    }
+
+    #[test]
+    fn data_type_of_map_uses_first_entry() {
+        let entries = OrderedMap::from(vec![(Value::Text("k".to_string()), Value::Int(7))]);
+        let v = Value::Map(entries);
+        assert_eq!(v.data_type(), Type::Map(Box::new(Type::Text), Box::new(Type::Int)));
+    }
+
+    #[test]
+    fn ffi_value_supports_float_array() {
+        let v = Value::Array(vec![Value::Float(1.5), Value::Float(2.5), Value::Float(3.5)]);
+        let ffi_value = FfiValue::from_value(&v).expect("array should convert");
+        assert!(!ffi_value.ptr().is_null());
+    }
+
+    #[test]
+    fn ffi_value_rejects_empty_list() {
+        let v = Value::List(vec![]);
+        let err = FfiValue::from_value(&v).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("empty list"), "unexpected message: {msg}");
+    }
+
+    #[test]
+    fn ffi_value_supports_array_of_structs() {
+        let row = OrderedMap::from(vec![
+            ("x".to_string(), Value::Int(1)),
+            ("y".to_string(), Value::Float(2.0)),
+        ]);
+        let v = Value::Array(vec![Value::Struct(row.clone()), Value::Struct(row)]);
+        let ffi_value = FfiValue::from_value(&v).expect("array-of-struct should convert");
+        assert!(!ffi_value.ptr().is_null());
+    }
+
+    #[test]
+    fn ffi_value_supports_map() {
+        let entries = OrderedMap::from(vec![
+            (Value::Text("a".to_string()), Value::Int(1)),
+            (Value::Text("b".to_string()), Value::Int(2)),
+        ]);
+        let v = Value::Map(entries);
+        let ffi_value = FfiValue::from_value(&v).expect("map should convert");
+        assert!(!ffi_value.ptr().is_null());
+    }
+
+    #[test]
+    fn ffi_value_rejects_enum() {
+        let v = Value::Enum("variant".to_string());
+        assert!(FfiValue::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn ffi_value_supports_nested_list() {
+        let v = Value::List(vec![
+            Value::List(vec![Value::Int(1), Value::Int(2)]),
+            Value::List(vec![Value::Int(3)]),
+        ]);
+        let ffi_value = FfiValue::from_value(&v).expect("nested list should convert");
+        assert!(!ffi_value.ptr().is_null());
+    }
+}

--- a/crates/duckdb/src/types/value_ref.rs
+++ b/crates/duckdb/src/types/value_ref.rs
@@ -573,4 +573,147 @@ mod tests {
 
         Ok(())
     }
+    #[test]
+    fn test_bind_and_read_float_vector() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let bound = vec![1.5_f32, 2.5, 3.5];
+
+        let read_back: Vec<f32> = conn.query_row("SELECT ?::FLOAT[3]", [bound.clone()], |r| r.get(0))?;
+        assert_eq!(read_back, bound);
+
+        let as_value: Value = conn.query_row("SELECT ?::FLOAT[3]", [bound.clone()], |r| r.get(0))?;
+        assert_eq!(as_value.data_type(), Type::Array(Box::new(Type::Float), 3));
+        match as_value {
+            Value::Array(items) => {
+                assert_eq!(items.len(), 3);
+                assert_eq!(items[0], Value::Float(1.5));
+            }
+            other => panic!("expected Value::Array, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_fixed_size_array() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let bound = [1.0_f32, 2.0, 3.0, 4.0];
+
+        let read_back: [f32; 4] = conn.query_row("SELECT ?::FLOAT[4]", [bound], |r| r.get(0))?;
+        assert_eq!(read_back, bound);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_vec_bind_errors() {
+        use crate::Error;
+
+        let conn = Connection::open_in_memory().unwrap();
+        let empty: Vec<f32> = vec![];
+        let err = conn
+            .query_row::<Value, _, _>("SELECT ?", [empty], |r| r.get(0))
+            .unwrap_err();
+        assert!(matches!(err, Error::ToSqlConversionFailure(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn test_bind_value_struct_and_map() -> Result<()> {
+        use crate::types::OrderedMap;
+
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE s(row STRUCT(x INTEGER, y FLOAT));")?;
+
+        let row = OrderedMap::from(vec![
+            ("x".to_string(), Value::Int(7)),
+            ("y".to_string(), Value::Float(1.5)),
+        ]);
+        conn.execute("INSERT INTO s VALUES (?)", [Value::Struct(row.clone())])?;
+
+        let read: Value = conn.query_row("SELECT row FROM s", [], |r| r.get(0))?;
+        match read {
+            Value::Struct(map) => {
+                assert_eq!(map.get(&"x".to_string()), Some(&Value::Int(7)));
+                assert_eq!(map.get(&"y".to_string()), Some(&Value::Float(1.5)));
+            }
+            other => panic!("expected Value::Struct, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_value_list() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let list = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        let read: Value = conn.query_row("SELECT ?::INT[]", [list.clone()], |r| r.get(0))?;
+        match read {
+            Value::List(items) => assert_eq!(items, vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
+            other => panic!("expected Value::List, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_vector_search_with_array_distance() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE vecs(id INTEGER, v FLOAT[3]);
+             INSERT INTO vecs VALUES (1, [1.0, 2.0, 3.0]), (2, [4.0, 5.0, 6.0]);",
+        )?;
+
+        let query = vec![3.9_f32, 5.0, 6.0];
+        let mut stmt = conn.prepare("SELECT id FROM vecs ORDER BY array_distance(v, ?::FLOAT[3]) LIMIT 1")?;
+        let id: i32 = stmt.query_row([query], |r| r.get(0))?;
+        assert_eq!(id, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_appender_binds_float_vector() -> Result<()> {
+        use crate::params;
+
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("CREATE TABLE vecs(id INTEGER, v FLOAT[3]);")?;
+
+        {
+            let mut app = conn.appender("vecs")?;
+            app.append_row(params![1i32, vec![1.0_f32, 2.0, 3.0]])?;
+            app.append_row(params![2i32, vec![4.0_f32, 5.0, 6.0]])?;
+            app.flush()?;
+        }
+
+        let read: Vec<f32> = conn.query_row("SELECT v FROM vecs WHERE id = 1", [], |r| r.get(0))?;
+        assert_eq!(read, vec![1.0, 2.0, 3.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_array_of_structs() -> Result<()> {
+        use crate::types::OrderedMap;
+
+        let conn = Connection::open_in_memory()?;
+        let point = OrderedMap::from(vec![("x".to_string(), Value::Int(1)), ("y".to_string(), Value::Int(2))]);
+        let array = Value::Array(vec![Value::Struct(point.clone()), Value::Struct(point)]);
+
+        let read: Value = conn.query_row("SELECT ?::STRUCT(x INTEGER, y INTEGER)[2]", [array.clone()], |r| {
+            r.get(0)
+        })?;
+        match read {
+            Value::Array(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(items[0], Value::Struct(_)));
+            }
+            other => panic!("expected Value::Array of structs, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_bind_double_vector() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let bound = vec![1.25_f64, 2.5, 3.75];
+
+        let read_back: Vec<f64> = conn.query_row("SELECT ?::DOUBLE[3]", [bound.clone()], |r| r.get(0))?;
+        assert_eq!(read_back, bound);
+        Ok(())
+    }
 }


### PR DESCRIPTION
DuckDB vectors (embeddings) are the `ARRAY` type (`FLOAT[768]`). Reading `ARRAY`/`LIST`/`STRUCT`/`MAP` worked via Arrow, but **binding/appending** them was rejected, forcing SQL casts. This PR wires up binding + ergonomic conversions + a serde bridge. No DuckDB upgrade needed (required C symbols already bound).

## What

- **Container binding** (`types/value_ffi.rs`): recursive `Value -> duckdb_value` for `List`/`Array`/`Struct`/`Map` and any nesting, via `duckdb_bind_value` / `duckdb_append_value`. DuckDB copies children (verified), so an RAII guard frees each built value. `Value::data_type()` for containers (was `todo!()`).
- **Ergonomic vectors**: `ToSql`/`FromSql` for `Vec<f32>`/`Vec<f64>`/`[T; N]` (+ integer vecs). Empty -> error; `NULL` via `Option<T>`. `Vec<u8>` stays `BLOB`.
- **`ndarray` feature** (in `modern-full`): `Array1<f32>`/`Array1<f64>`.
- **`serde` feature** (in `modern-full`): `Struct<T>` wrapper -> `impl<T: Serialize> ToSql` + `FromSql for Struct<T: DeserializeOwned>`. Structs/maps -> `STRUCT`, `Vec` -> `LIST`, unit enums -> `VARCHAR`. Wrapper (not blanket) to dodge coherence overlap with scalar `Serialize` impls.

## Usage

```rust
// vector search
let id: i32 = conn.query_row(
    "SELECT id FROM vecs ORDER BY array_distance(v, ?::FLOAT[3]) LIMIT 1",
    [vec![3.9_f32, 5.0, 6.0]], |r| r.get(0))?;

// serde STRUCT round-trip
#[derive(Serialize, Deserialize)] struct Point { x: i32, y: f64 }
conn.execute("INSERT INTO t VALUES (?)", [Struct(&Point { x: 3, y: 4.5 })])?;
let Struct(p): Struct<Point> = conn.query_row("SELECT p FROM t", [], |r| r.get(0))?;
```

## Caveats

`Value::Enum`/`Value::Union` still unbindable (no tag/type). Borrowed `ValueRef::List` (from Arrow) still rejected — only **owned** container `Value`s use the new path. Arrow appender remains the fast lane for bulk loads.

## Connected Issues

Fixing #540 
Fixing #329 