### PR TITLE
Replace reqwest with ureq for the libduckdb download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1681,11 +1680,11 @@ dependencies = [
  "pkg-config",
  "prettyplease",
  "quote",
- "reqwest",
  "serde",
  "serde_json",
  "syn 2.0.118",
  "tar",
+ "ureq",
  "vcpkg",
  "which",
  "zip",
@@ -2974,7 +2973,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -3007,7 +3005,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3127,6 +3124,7 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3858,6 +3856,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,6 +3894,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/crates/libduckdb-sys/Cargo.toml
+++ b/crates/libduckdb-sys/Cargo.toml
@@ -45,14 +45,11 @@ flate2 = { workspace = true }
 pkg-config = { workspace = true, optional = true }
 prettyplease = { workspace = true, optional = true }
 quote = { workspace = true, optional = true }
-reqwest = { version = "0.12", default-features = false, features = [
-    "blocking",
-    "rustls-tls",
-] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 syn = { workspace = true, optional = true }
 tar = { workspace = true }
+ureq = { version = "3", default-features = false, features = ["rustls"] }
 vcpkg = { workspace = true, optional = true }
 which = { version = "8", optional = true }
 zip = { version = "6", default-features = false, features = ["deflate"] }

--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -313,9 +313,8 @@ mod build_linked {
         if lib_marker.exists() {
             println!("cargo:warning=Reusing libduckdb from {}", download_dir.display());
         } else {
-            let client = http_client()?;
             let url = archive.download_url(&version);
-            ensure_libduckdb(&client, &url, &archive_path)?;
+            ensure_libduckdb(&url, &archive_path)?;
             extract_libduckdb(&archive_path, &download_dir)?;
             if !lib_marker.exists() {
                 return Err(format!(
@@ -391,11 +390,7 @@ mod build_linked {
 
     // Ensures the libduckdb archive exists: reuses an existing zip or
     // downloads it into a temp file and atomically renames it into place.
-    fn ensure_libduckdb(
-        client: &reqwest::blocking::Client,
-        url: &str,
-        archive_path: &Path,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn ensure_libduckdb(url: &str, archive_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         if archive_path.exists() {
             println!("cargo:warning=libduckdb already present at {}", archive_path.display());
             return Ok(());
@@ -404,9 +399,9 @@ mod build_linked {
         if let Some(parent) = archive_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let mut response = client.get(url).send()?.error_for_status()?;
+        let mut response = http_client().get(url).call()?;
         let mut tmp_file = fs::File::create(&tmp_path)?;
-        io::copy(&mut response, &mut tmp_file)?;
+        io::copy(&mut response.body_mut().as_reader(), &mut tmp_file)?;
         fs::rename(&tmp_path, archive_path)?;
         println!("cargo:warning=Downloaded libduckdb from {url}");
         Ok(())
@@ -526,15 +521,17 @@ mod build_linked {
         }
     }
 
-    fn http_client() -> Result<reqwest::blocking::Client, reqwest::Error> {
+    fn http_client() -> ureq::Agent {
         let timeout = env::var("CARGO_HTTP_TIMEOUT")
             .or_else(|_| env::var("HTTP_TIMEOUT"))
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(90);
-        reqwest::blocking::Client::builder()
-            .timeout(std::time::Duration::from_secs(timeout))
-            .build()
+        ureq::Agent::new_with_config(
+            ureq::Agent::config_builder()
+                .timeout_global(Some(std::time::Duration::from_secs(timeout)))
+                .build(),
+        )
     }
 }
 


### PR DESCRIPTION
reqwest is a non-optional build-dependency, so every build compiles the tokio/hyper async stack just to GET one zip. ureq is sync-native, keeps the same TLS posture (rustls + ring + webpki-roots), and streams large bodies unlimited. Non-2xx-as-error and redirect handling match reqwest's defaults.

Closes #798, whose reqwest 0.13 upgrade would have forced aws-lc-rs onto every build.