### PR TITLE
Fix DuckDB linking with custom target dirs

### DIFF
--- a/crates/libduckdb-sys/build.rs
+++ b/crates/libduckdb-sys/build.rs
@@ -3,6 +3,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
+#[cfg(not(feature = "bundled"))]
+#[path = "src/build_paths.rs"]
+mod build_paths;
+
 /// Tells whether we're building for Windows. This is more suitable than a plain
 /// `cfg!(windows)`, since the latter does not properly handle cross-compilation
 ///
@@ -146,10 +150,7 @@ mod build_linked {
     use super::bindings;
 
     use super::{HeaderLocation, is_compiler, is_loadable_extension, win_target};
-    use std::{
-        env, fs, io,
-        path::{Path, PathBuf},
-    };
+    use std::{env, fs, io, path::Path};
 
     pub fn main(out_dir: &str, out_path: &Path) {
         // We need this to config the LD_LIBRARY_PATH
@@ -240,7 +241,7 @@ mod build_linked {
         }
 
         if should_download_libduckdb() {
-            return download_libduckdb(out_dir).unwrap_or_else(|err| panic!("Failed to download libduckdb: {err}"));
+            return download_libduckdb(out_dir).unwrap_or_else(|err| panic!("Failed to set up libduckdb: {err}"));
         }
 
         if let Some(header) = try_vcpkg() {
@@ -303,8 +304,16 @@ mod build_linked {
 
         let version = duckdb_version_from_pkg_version(env!("CARGO_PKG_VERSION"));
 
-        // Cache downloads in target/duckdb-download/<target>/<version> so successive builds reuse them
-        let download_dir = workspace_download_dir(out_dir)?.join(&target).join(&version);
+        // Cache downloads beside the profile directory so successive builds reuse them.
+        let download_dir = crate::build_paths::download_root(Path::new(out_dir))
+            .ok_or_else(|| {
+                format!(
+                    "Could not determine DuckDB download directory from Cargo OUT_DIR '{out_dir}'. \
+                     Set DUCKDB_LIB_DIR to use an existing DuckDB library."
+                )
+            })?
+            .join(&target)
+            .join(&version);
         fs::create_dir_all(&download_dir)?;
 
         let archive_path = download_dir.join(archive.archive_name);
@@ -374,8 +383,12 @@ mod build_linked {
         lib_filename: &str,
         out_dir: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let Some(deps_dir) = profile_deps_dir(out_dir) else {
-            return Err("Could not determine target/deps directory for runtime lib copy".into());
+        let Some(deps_dir) = crate::build_paths::profile_deps_dir(Path::new(out_dir)) else {
+            return Err(format!(
+                "Could not determine runtime library directory from Cargo OUT_DIR '{out_dir}'. \
+                 Set DUCKDB_LIB_DIR to use an existing DuckDB library."
+            )
+            .into());
         };
         fs::create_dir_all(&deps_dir)?;
         let source = download_dir.join(lib_filename);
@@ -386,24 +399,6 @@ mod build_linked {
         fs::copy(&source, &dest)?;
         println!("cargo:warning=Copied libduckdb to {}", dest.display());
         Ok(())
-    }
-
-    // Finds target/ so downloads survive rebuilds. Respects CARGO_TARGET_DIR if set.
-    fn workspace_download_dir(out_dir: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
-        if let Ok(dir) = env::var("CARGO_TARGET_DIR") {
-            return Ok(PathBuf::from(dir).join("duckdb-download"));
-        }
-        let target_root = Path::new(out_dir)
-            .ancestors()
-            .find(|ancestor| {
-                ancestor
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .is_some_and(|name| name == "target")
-            })
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|| PathBuf::from("target"));
-        Ok(target_root.join("duckdb-download"))
     }
 
     fn duckdb_version_from_pkg_version(pkg_version: &str) -> String {
@@ -418,19 +413,6 @@ mod build_linked {
         let duckdb_minor = (encoded / 100) % 100;
         let duckdb_patch = encoded % 100;
         format!("{duckdb_major}.{duckdb_minor}.{duckdb_patch}")
-    }
-
-    // Mirrors Cargo's actual target/<triple>/<profile>/deps (or target/<profile>/deps)
-    // layout by deriving it from OUT_DIR.
-    fn profile_deps_dir(out_dir: &str) -> Option<PathBuf> {
-        let build_dir = Path::new(out_dir).ancestors().find(|ancestor| {
-            ancestor
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name == "build")
-        })?;
-        let profile_dir = build_dir.parent()?;
-        Some(profile_dir.join("deps"))
     }
 
     struct LibduckdbArchive {

--- a/crates/libduckdb-sys/src/build_paths.rs
+++ b/crates/libduckdb-sys/src/build_paths.rs
@@ -1,0 +1,113 @@
+//! Derives reusable paths from Cargo's `OUT_DIR` layout.
+//!
+//! Cargo currently uses
+//! `<target-dir>/[<triple>/]<profile>/build/<pkg>-<hash>/out`. This is an
+//! implementation detail, so these helpers return `None` for unrecognized
+//! layouts. The download root is one level above the profile directory so
+//! debug and release builds share a cache.
+
+use std::path::{Path, PathBuf};
+
+fn profile_dir(out_dir: &Path) -> Option<&Path> {
+    if out_dir.file_name()? != "out" {
+        return None;
+    }
+
+    let build_dir = out_dir.parent()?.parent()?;
+    if build_dir.file_name()? != "build" {
+        return None;
+    }
+
+    build_dir.parent()
+}
+
+pub(crate) fn download_root(out_dir: &Path) -> Option<PathBuf> {
+    Some(profile_dir(out_dir)?.parent()?.join("duckdb-download"))
+}
+
+pub(crate) fn profile_deps_dir(out_dir: &Path) -> Option<PathBuf> {
+    Some(profile_dir(out_dir)?.join("deps"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_paths_from_default_out_dir() {
+        let out_dir = Path::new("/workspace/target/debug/build/libduckdb-sys-1234567890abcdef/out");
+
+        assert_eq!(
+            download_root(out_dir),
+            Some(PathBuf::from("/workspace/target/duckdb-download")),
+        );
+        assert_eq!(
+            profile_deps_dir(out_dir),
+            Some(PathBuf::from("/workspace/target/debug/deps")),
+        );
+    }
+
+    #[test]
+    fn resolves_paths_from_triple_named_target_dir() {
+        let out_dir = Path::new("/workspace/aarch64-apple-darwin/debug/build/libduckdb-sys-1234567890abcdef/out");
+
+        assert_eq!(
+            download_root(out_dir),
+            Some(PathBuf::from("/workspace/aarch64-apple-darwin/duckdb-download")),
+        );
+        assert_eq!(
+            profile_deps_dir(out_dir),
+            Some(PathBuf::from("/workspace/aarch64-apple-darwin/debug/deps")),
+        );
+    }
+
+    #[test]
+    fn resolves_paths_from_cross_target_out_dir() {
+        let out_dir = Path::new(
+            "/workspace/custom-target/x86_64-unknown-linux-gnu/release/build/libduckdb-sys-1234567890abcdef/out",
+        );
+
+        assert_eq!(
+            download_root(out_dir),
+            Some(PathBuf::from(
+                "/workspace/custom-target/x86_64-unknown-linux-gnu/duckdb-download"
+            )),
+        );
+        assert_eq!(
+            profile_deps_dir(out_dir),
+            Some(PathBuf::from(
+                "/workspace/custom-target/x86_64-unknown-linux-gnu/release/deps"
+            )),
+        );
+    }
+
+    #[test]
+    fn rejects_non_cargo_out_dir_with_build_ancestor() {
+        let out_dir = Path::new("/var/jenkins/build/workspace/project/generated/out");
+
+        assert_eq!(download_root(out_dir), None);
+        assert_eq!(profile_deps_dir(out_dir), None);
+    }
+
+    #[test]
+    fn rejects_out_dir_without_build_component() {
+        let out_dir = Path::new("/workspace/generated/libduckdb-sys/out");
+
+        assert_eq!(download_root(out_dir), None);
+        assert_eq!(profile_deps_dir(out_dir), None);
+    }
+
+    #[test]
+    fn ignores_upstream_build_directory() {
+        let out_dir = Path::new("/home/ci/build/project/target/debug/build/libduckdb-sys-1234567890abcdef/out");
+
+        assert_eq!(
+            download_root(out_dir),
+            Some(PathBuf::from("/home/ci/build/project/target/duckdb-download")),
+        );
+        assert_eq!(
+            profile_deps_dir(out_dir),
+            Some(PathBuf::from("/home/ci/build/project/target/debug/deps")),
+        );
+    }
+}

--- a/crates/libduckdb-sys/src/lib.rs
+++ b/crates/libduckdb-sys/src/lib.rs
@@ -8,6 +8,10 @@
 mod arrow_c_data;
 pub use arrow_c_data::{ArrowArray, ArrowSchema};
 
+// Build-script helper mounted here so cargo test runs its unit tests.
+#[cfg(test)]
+mod build_paths;
+
 #[allow(clippy::all, unsafe_op_in_unsafe_fn)]
 mod bindings {
     // Bindgen preserves DuckDB's C API comments verbatim. Some of those comments


### PR DESCRIPTION
Derive DuckDB download and runtime library paths from Cargo's absolute `OUT_DIR`, fixing linking with custom target directories.

Unsupported layouts now fail with actionable `OUT_DIR` and `DUCKDB_LIB_DIR` guidance. Existing cross-build caches are not reused, so the first cross build after upgrading downloads DuckDB again.