### PR TITLE
Test nightly DuckDB artifacts in CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,4 +1,5 @@
 name: Nightly
+run-name: Nightly - ${{ inputs.duckdb-sha }}
 
 on:
   # Triggered from DuckDB's NotifyExternalRepositories workflow.
@@ -14,6 +15,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.duckdb-sha }}
   cancel-in-progress: true
@@ -23,6 +27,7 @@ jobs:
     name: DuckDB nightly
     runs-on: ubuntu-latest
     env:
+      DUCKDB_SHA: ${{ inputs.duckdb-sha }}
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
@@ -39,8 +44,6 @@ jobs:
 
       - name: Upgrade bundled DuckDB to nightly commit
         id: upgrade
-        env:
-          DUCKDB_SHA: ${{ inputs.duckdb-sha }}
         run: ./upgrade.sh --sha "$DUCKDB_SHA"
 
       - name: Show generated upgrade diff
@@ -61,3 +64,58 @@ jobs:
       - name: Test bundled-cmake backend
         if: ${{ !cancelled() && steps.upgrade.outcome == 'success' }}
         run: cargo test -p duckdb --features bundled-cmake
+
+      - name: Download nightly artifact
+        id: artifact
+        if: ${{ !cancelled() && steps.upgrade.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
+        run: |
+          # Select the matching CI run by SHA. artifacts.duckdb.org does not
+          # support SHA-addressed downloads, and latest can advance to binaries
+          # from a different commit.
+          artifact_name=duckdb-binaries-linux-amd64
+          run_id=
+          candidate_ids=$(gh api --method GET \
+            repos/duckdb/duckdb/actions/workflows/InvokeCI.yml/runs \
+            -f head_sha="${DUCKDB_SHA,,}" \
+            -f status=completed \
+            -f per_page=100 \
+            --jq '.workflow_runs | sort_by(.created_at) | reverse | .[].id')
+          while read -r candidate_id; do
+            [[ -n "$candidate_id" ]] || continue
+            artifact_count=$(gh api --method GET \
+              "repos/duckdb/duckdb/actions/runs/$candidate_id/artifacts" \
+              -f name="$artifact_name" \
+              --jq '[.artifacts[] | select(.expired == false)] | length')
+            if (( artifact_count > 0 )); then
+              run_id=$candidate_id
+              break
+            fi
+          done <<< "$candidate_ids"
+          if [[ -z "$run_id" ]]; then
+            echo "::error::No completed InvokeCI run with $artifact_name found for DuckDB commit $DUCKDB_SHA"
+            exit 1
+          fi
+          gh run download "$run_id" \
+            --repo duckdb/duckdb \
+            --name "$artifact_name" \
+            --dir "$RUNNER_TEMP/duckdb-artifact"
+          unzip -q "$RUNNER_TEMP/duckdb-artifact/libduckdb-linux-amd64.zip" -d "$RUNNER_TEMP/libduckdb"
+          {
+            echo "DUCKDB_LIB_DIR=$RUNNER_TEMP/libduckdb"
+            echo "DUCKDB_INCLUDE_DIR=$RUNNER_TEMP/libduckdb"
+            echo "LD_LIBRARY_PATH=$RUNNER_TEMP/libduckdb${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          } >> "$GITHUB_ENV"
+
+      - name: Test nightly artifact
+        if: ${{ !cancelled() && steps.artifact.outcome == 'success' }}
+        run: |
+          cargo test -p duckdb --features buildtime_bindgen \
+            --test nightly links_against_requested_duckdb_commit -- --exact --ignored
+          cargo test -p duckdb --features buildtime_bindgen
+
+      - name: Test nightly extension installation
+        if: ${{ !cancelled() && steps.artifact.outcome == 'success' }}
+        run: cargo test -p duckdb --features buildtime_bindgen
+          --test nightly can_install_and_load_httpfs -- --exact --ignored

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,9 @@ published release binaries are needed.
 
 Both regenerate bundled sources and bindings, but do not run tests. Validate
 locally, or rely on the nightly workflow and CI to cover the bundled backends.
-Download-based CI jobs (`DUCKDB_DOWNLOAD_LIB`, the Windows release zip) stay red
+The nightly workflow also downloads the matching upstream CI artifact, generates
+bindings from its header, and tests those bindings against that library.
+Release-based CI jobs (`DUCKDB_DOWNLOAD_LIB`, the Windows release zip) stay red
 until DuckDB publishes the release binaries. If the planned release command
 above already bumped versions and download URLs, finalize the bundled sources
 and bindings from the tag with `./crates/libduckdb-sys/upgrade.sh v1.5.4`.

--- a/crates/duckdb/tests/nightly.rs
+++ b/crates/duckdb/tests/nightly.rs
@@ -1,0 +1,78 @@
+use duckdb::{Config, Connection, OptionalExt};
+
+const MIN_DUCKDB_SOURCE_ID_LEN: usize = 7;
+
+fn source_id_matches(expected_sha: &str, source_id: &str) -> bool {
+    let expected_sha = expected_sha.to_ascii_lowercase();
+    let source_id = source_id.to_ascii_lowercase();
+
+    expected_sha.len() == 40
+        && expected_sha.chars().all(|character| character.is_ascii_hexdigit())
+        && source_id.len() >= MIN_DUCKDB_SOURCE_ID_LEN
+        && expected_sha.starts_with(&source_id)
+}
+
+#[test]
+#[ignore = "requires network access and matching nightly DuckDB extension artifacts"]
+fn can_install_and_load_httpfs() -> Result<(), Box<dyn std::error::Error>> {
+    let extension_directory = tempfile::tempdir()?;
+    let config = Config::default().with("extension_directory", extension_directory.path().to_string_lossy())?;
+    let connection = Connection::open_in_memory_with_flags(config)?;
+
+    connection.execute_batch("FORCE INSTALL httpfs; LOAD httpfs;")?;
+
+    let extension_state = connection
+        .query_row(
+            "SELECT installed, loaded FROM duckdb_extensions() WHERE extension_name = 'httpfs'",
+            [],
+            |row| Ok((row.get::<_, bool>(0)?, row.get::<_, bool>(1)?)),
+        )
+        .optional()?
+        .expect("httpfs should be listed after FORCE INSTALL and LOAD");
+    assert_eq!(extension_state, (true, true), "httpfs should be installed and loaded");
+
+    Ok(())
+}
+
+/// CI points the build at a libduckdb artifact built from `DUCKDB_SHA`.
+/// Assert we actually linked it and not a stray system library.
+#[test]
+#[ignore = "requires the nightly libduckdb artifact selected by DUCKDB_SHA"]
+fn links_against_requested_duckdb_commit() -> Result<(), Box<dyn std::error::Error>> {
+    let expected_sha = std::env::var("DUCKDB_SHA")
+        .expect("DUCKDB_SHA must be set; this test only runs in the nightly workflow")
+        .to_ascii_lowercase();
+    let source_id: String =
+        Connection::open_in_memory()?.query_row("SELECT source_id FROM pragma_version()", [], |row| row.get(0))?;
+
+    assert!(
+        source_id_matches(&expected_sha, &source_id),
+        "linked DuckDB reports source_id {source_id}, expected a hexadecimal prefix of at least 7 characters matching {expected_sha}"
+    );
+    Ok(())
+}
+
+mod tests {
+    use super::source_id_matches;
+
+    #[test]
+    fn source_id_match_is_case_insensitive() {
+        assert!(source_id_matches(
+            "14da6e6a4622b67d72fdeb21ed786a4f3ad9b063",
+            "14DA6E6A46"
+        ));
+    }
+
+    #[test]
+    fn source_id_match_accepts_longer_git_abbreviations() {
+        assert!(source_id_matches(
+            "14da6e6a4622b67d72fdeb21ed786a4f3ad9b063",
+            "14da6e6a462"
+        ));
+    }
+
+    #[test]
+    fn source_id_match_rejects_short_prefixes() {
+        assert!(!source_id_matches("14da6e6a4622b67d72fdeb21ed786a4f3ad9b063", "1"));
+    }
+}


### PR DESCRIPTION
Validate duckdb-rs against a SHA-matched upstream nightly build. `artifacts.duckdb.org` has no SHA-addressed downloads, and `latest` can advance to binaries from a different commit.

- Download the libduckdb artifact from the newest completed `InvokeCI` run that still holds it for the requested SHA
- Regenerate bindings from the artifact's own header via `buildtime_bindgen` rather than only link-checking against it
- Assert the linked source ID in Rust before the rest of the suite, accepting any Git abbreviation width but rejecting short prefixes
- Install `httpfs` from a clean extension directory with `FORCE INSTALL`, in its own step, so extension publication failures are identifiable
- Document the pre-tag artifact coverage

Example run: https://github.com/duckdb/duckdb-rs/actions/runs/31372122539/job/93403206889

refs https://github.com/duckdblabs/duckdb-internal/issues/7516