### PR TITLE
Download nightly artifacts from staging

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -68,40 +68,16 @@ jobs:
       - name: Download nightly artifact
         id: artifact
         if: ${{ !cancelled() && steps.upgrade.outcome == 'success' }}
-        env:
-          GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
         run: |
-          # Select the matching CI run by SHA. artifacts.duckdb.org does not
-          # support SHA-addressed downloads, and latest can advance to binaries
-          # from a different commit.
-          artifact_name=duckdb-binaries-linux-amd64
-          run_id=
-          candidate_ids=$(gh api --method GET \
-            repos/duckdb/duckdb/actions/workflows/InvokeCI.yml/runs \
-            -f head_sha="${DUCKDB_SHA,,}" \
-            -f status=completed \
-            -f per_page=100 \
-            --jq '.workflow_runs | sort_by(.created_at) | reverse | .[].id')
-          while read -r candidate_id; do
-            [[ -n "$candidate_id" ]] || continue
-            artifact_count=$(gh api --method GET \
-              "repos/duckdb/duckdb/actions/runs/$candidate_id/artifacts" \
-              -f name="$artifact_name" \
-              --jq '[.artifacts[] | select(.expired == false)] | length')
-            if (( artifact_count > 0 )); then
-              run_id=$candidate_id
-              break
-            fi
-          done <<< "$candidate_ids"
-          if [[ -z "$run_id" ]]; then
-            echo "::error::No completed InvokeCI run with $artifact_name found for DuckDB commit $DUCKDB_SHA"
+          staging_key_length=10
+          staging_key=${DUCKDB_SHA:0:$staging_key_length}
+          artifact_url="https://duckdb-staging.duckdb.org/$staging_key/duckdb/duckdb/github_release/libduckdb-linux-amd64.zip"
+          artifact_path="$RUNNER_TEMP/libduckdb-linux-amd64.zip"
+          curl --fail --location --retry 5 --output "$artifact_path" "$artifact_url" || {
+            echo "::error::No staging artifact at $artifact_url"
             exit 1
-          fi
-          gh run download "$run_id" \
-            --repo duckdb/duckdb \
-            --name "$artifact_name" \
-            --dir "$RUNNER_TEMP/duckdb-artifact"
-          unzip -q "$RUNNER_TEMP/duckdb-artifact/libduckdb-linux-amd64.zip" -d "$RUNNER_TEMP/libduckdb"
+          }
+          unzip -q "$artifact_path" -d "$RUNNER_TEMP/libduckdb"
           {
             echo "DUCKDB_LIB_DIR=$RUNNER_TEMP/libduckdb"
             echo "DUCKDB_INCLUDE_DIR=$RUNNER_TEMP/libduckdb"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,8 +210,8 @@ published release binaries are needed.
 
 Both regenerate bundled sources and bindings, but do not run tests. Validate
 locally, or rely on the nightly workflow and CI to cover the bundled backends.
-The nightly workflow also downloads the matching upstream CI artifact, generates
-bindings from its header, and tests those bindings against that library.
+The nightly workflow also downloads the matching upstream nightly library,
+generates bindings from its header, and tests those bindings against it.
 Release-based CI jobs (`DUCKDB_DOWNLOAD_LIB`, the Windows release zip) stay red
 until DuckDB publishes the release binaries. If the planned release command
 above already bumped versions and download URLs, finalize the bundled sources


### PR DESCRIPTION
Turns out there's a better alternative to artifacts.duckdb.org that supports SHA-addressed downloads.

Follow-up to #829 

refs https://github.com/duckdblabs/duckdb-internal/issues/7516