### PR TITLE
Fix Arrow query parameter memory leak

### DIFF
--- a/crates/duckdb/examples/arrow_vtab.rs
+++ b/crates/duckdb/examples/arrow_vtab.rs
@@ -12,24 +12,24 @@ use duckdb::{
         record_batch::RecordBatch,
         util::pretty::print_batches,
     },
-    vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params},
+    vtab::arrow::{ArrowBatchRegistration, ArrowVTab},
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
     let conn = Connection::open_in_memory()?;
     conn.register_table_function::<ArrowVTab>("arrow")?;
 
-    let params = arrow_recordbatch_to_query_params(cities_batch()?);
+    let reg = ArrowBatchRegistration::new(cities_batch()?);
     let batches: Vec<RecordBatch> = conn
         .prepare(
             "
             SELECT city, population
-            FROM arrow(?, ?)
+            FROM arrow(?)
             WHERE coastal AND population >= 500000
             ORDER BY population DESC
             ",
         )?
-        .query_arrow(params)?
+        .query_arrow([&reg])?
         .collect();
 
     print_batches(&batches)?;

--- a/crates/duckdb/src/arrow_interop/tests/mod.rs
+++ b/crates/duckdb/src/arrow_interop/tests/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     Connection, Result,
     arrow_interop::test_support::{ARROW_EXTENSION_NAME_KEY, uuid_field, uuid_metadata},
     core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId},
-    vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params},
+    vtab::arrow::{ArrowBatchRegistration, ArrowVTab},
 };
 use arrow::{
     array::{
@@ -222,9 +222,9 @@ where
     let schema = Schema::new(vec![Field::new("a", input_array.data_type().clone(), true)]);
 
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(input_array.clone())])?;
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_any_array = rb.column(0);
     match (output_any_array.data_type(), expected_array.data_type()) {
@@ -267,9 +267,9 @@ where
     let schema = Schema::new(vec![Field::new("a", arry.data_type().clone(), true)]);
 
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arry.clone())])?;
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_any_array = rb.column(0);
     assert!(
@@ -309,9 +309,9 @@ where
     let schema = Schema::new(vec![Field::new("a", arry_in.data_type().clone(), false)]);
 
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(arry_in.clone())])?;
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_any_array = rb.column(0);
 
@@ -342,9 +342,9 @@ fn roundtrip_single_array(array: ArrayRef) -> Result<ArrayRef, Box<dyn Error>> {
 
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![array])?;
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     Ok(rb.column(0).clone())
 }
@@ -422,9 +422,9 @@ fn test_fixed_array_roundtrip() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), false)]);
 
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_any_array = rb.column(0);
     assert!(
@@ -661,10 +661,10 @@ fn test_decimal128_rejects_out_of_precision_values() -> Result<(), Box<dyn Error
     let schema = Schema::new(vec![Field::new("d", DataType::Decimal128(5, 2), true)]);
     let array = Decimal128Array::from(vec![i128::from(999999)]).with_data_type(DataType::Decimal128(5, 2));
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array) as ArrayRef])?;
-    let param = arrow_recordbatch_to_query_params(batch);
+    let reg = ArrowBatchRegistration::new(batch);
 
     let err = db
-        .query_row("SELECT d FROM arrow(?, ?)", param, |row| {
+        .query_row("SELECT d FROM arrow(?)", [&reg], |row| {
             row.get::<_, crate::types::Value>(0)
         })
         .unwrap_err();
@@ -684,10 +684,10 @@ fn test_decimal128_rejects_invalid_type_without_values() -> Result<(), Box<dyn E
     let schema = Schema::new(vec![Field::new("d", DataType::Decimal128(5, 10), true)]);
     let array = Decimal128Array::from(vec![None::<i128>]).with_data_type(DataType::Decimal128(5, 10));
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array) as ArrayRef])?;
-    let param = arrow_recordbatch_to_query_params(batch);
+    let reg = ArrowBatchRegistration::new(batch);
 
     let err = db
-        .query_row("SELECT d FROM arrow(?, ?)", param, |row| {
+        .query_row("SELECT d FROM arrow(?)", [&reg], |row| {
             row.get::<_, crate::types::Value>(0)
         })
         .unwrap_err();
@@ -760,9 +760,9 @@ fn test_timestamp_tz_insert() -> Result<(), Box<dyn Error>> {
 
     // Since we cant get TIMESTAMP_TZ from the rust client yet, we just check that we can insert it properly here.
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)]).expect("failed to create record batch");
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select typeof(a)::VARCHAR from arrow(?, ?)")?;
-    let mut arr = stmt.query_arrow(param)?;
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select typeof(a)::VARCHAR from arrow(?)")?;
+    let mut arr = stmt.query_arrow([&reg])?;
     let rb = arr.next().expect("no record batch");
     assert_eq!(rb.num_columns(), 1);
     let column = rb.column(0).as_any().downcast_ref::<StringArray>().unwrap();
@@ -778,9 +778,9 @@ fn test_arrow_error() {
     let db = Connection::open_in_memory().unwrap();
     db.register_table_function::<ArrowVTab>("arrow").unwrap();
 
-    let mut stmt = db.prepare("SELECT * FROM arrow(?, ?)").unwrap();
+    let mut stmt = db.prepare("SELECT * FROM arrow(?)").unwrap();
 
-    let res = stmt.execute(arrow_recordbatch_to_query_params(batch)).err().unwrap();
+    let res = stmt.execute([&ArrowBatchRegistration::new(batch)]).err().unwrap();
 
     assert_eq!(
         res,
@@ -806,9 +806,9 @@ fn test_arrow_binary() {
     let db = Connection::open_in_memory().unwrap();
     db.register_table_function::<ArrowVTab>("arrow").unwrap();
 
-    let mut stmt = db.prepare("SELECT * FROM arrow(?, ?)").unwrap();
+    let mut stmt = db.prepare("SELECT * FROM arrow(?)").unwrap();
 
-    let mut arr = stmt.query_arrow(arrow_recordbatch_to_query_params(batch)).unwrap();
+    let mut arr = stmt.query_arrow([&ArrowBatchRegistration::new(batch)]).unwrap();
     let rb = arr.next().expect("no record batch");
 
     let column = rb.column(0).as_any().downcast_ref::<BinaryArray>().unwrap();
@@ -842,9 +842,9 @@ fn test_string_view_roundtrip() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), false)]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
 
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_array = rb
         .column(0)
@@ -873,9 +873,9 @@ fn test_binary_view_roundtrip() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), false)]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
 
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_array = rb
         .column(0)
@@ -900,9 +900,9 @@ fn test_string_view_nulls_roundtrip() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
 
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_array = rb
         .column(0)
@@ -929,9 +929,9 @@ fn test_binary_view_nulls_roundtrip() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
 
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_array = rb
         .column(0)
@@ -958,9 +958,9 @@ fn test_large_binary_nulls_roundtrip() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array.clone())])?;
 
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select a from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select a from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
 
     let output_array = rb
         .column(0)

--- a/crates/duckdb/src/arrow_interop/tests/nested.rs
+++ b/crates/duckdb/src/arrow_interop/tests/nested.rs
@@ -649,9 +649,9 @@ fn test_irregular_nested_list_cast_uses_recorded_child_counts() -> Result<(), Bo
 
     let schema = Schema::new(vec![Field::new("a", list_of_lists.data_type().clone(), true)]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_of_lists) as ArrayRef])?;
-    let param = arrow_recordbatch_to_query_params(batch);
-    let mut stmt = db.prepare("SELECT a::VARCHAR FROM arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
+    let reg = ArrowBatchRegistration::new(batch);
+    let mut stmt = db.prepare("SELECT a::VARCHAR FROM arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
     let output = rb.column(0).as_any().downcast_ref::<StringArray>().unwrap();
 
     assert_eq!(output.value(0), "[[1, 2], [], [3, NULL, 5]]");
@@ -695,9 +695,9 @@ fn test_array_of_structs() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
 
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("SELECT a[1].foo, a[2].foo FROM arrow(?, ?)")?;
-    let mut arr = stmt.query_arrow(param)?;
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("SELECT a[1].foo, a[2].foo FROM arrow(?)")?;
+    let mut arr = stmt.query_arrow([&reg])?;
     let rb = arr.next().expect("no record batch");
 
     let first_item = rb.column(0).as_any().downcast_ref::<Int64Array>().unwrap();

--- a/crates/duckdb/src/row.rs
+++ b/crates/duckdb/src/row.rs
@@ -1220,7 +1220,7 @@ mod tests {
     #[test]
     #[cfg(feature = "vtab-arrow")]
     fn test_fixed_size_binary_via_arrow() -> Result<()> {
-        use crate::vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params};
+        use crate::vtab::arrow::{ArrowBatchRegistration, ArrowVTab};
         use arrow::array::{Array, ArrayRef, BinaryArray, FixedSizeBinaryArray};
         use arrow::datatypes::{DataType, Field, Schema};
         use arrow::record_batch::RecordBatch;
@@ -1241,8 +1241,8 @@ mod tests {
         let schema = Schema::new(vec![Field::new("data", DataType::FixedSizeBinary(16), false)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![arc]).unwrap();
 
-        let mut stmt = conn.prepare("SELECT data FROM arrow(?, ?)")?;
-        let mut arr = stmt.query_arrow(arrow_recordbatch_to_query_params(batch))?;
+        let mut stmt = conn.prepare("SELECT data FROM arrow(?)")?;
+        let mut arr = stmt.query_arrow([&ArrowBatchRegistration::new(batch)])?;
         let rb = arr.next().expect("no record batch");
 
         // DuckDB converts FixedSizeBinary to regular Binary
@@ -1264,7 +1264,7 @@ mod tests {
     #[test]
     #[cfg(feature = "vtab-arrow")]
     fn test_fixed_size_binary_with_nulls_via_arrow() -> Result<()> {
-        use crate::vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params};
+        use crate::vtab::arrow::{ArrowBatchRegistration, ArrowVTab};
         use arrow::array::{Array, ArrayRef, BinaryArray, FixedSizeBinaryArray};
         use arrow::datatypes::{DataType, Field, Schema};
         use arrow::record_batch::RecordBatch;
@@ -1285,8 +1285,8 @@ mod tests {
         let schema = Schema::new(vec![Field::new("data", DataType::FixedSizeBinary(8), true)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![arc]).unwrap();
 
-        let mut stmt = conn.prepare("SELECT data FROM arrow(?, ?)")?;
-        let mut arr = stmt.query_arrow(arrow_recordbatch_to_query_params(batch))?;
+        let mut stmt = conn.prepare("SELECT data FROM arrow(?)")?;
+        let mut arr = stmt.query_arrow([&ArrowBatchRegistration::new(batch)])?;
         let rb = arr.next().expect("no record batch");
 
         let column = rb.column(0).as_any().downcast_ref::<BinaryArray>().unwrap();
@@ -1303,7 +1303,7 @@ mod tests {
     #[test]
     #[cfg(feature = "vtab-arrow")]
     fn test_fixed_size_binary_different_sizes_via_arrow() -> Result<()> {
-        use crate::vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params};
+        use crate::vtab::arrow::{ArrowBatchRegistration, ArrowVTab};
         use arrow::array::{ArrayRef, FixedSizeBinaryArray};
         use arrow::datatypes::{DataType, Field, Schema};
         use arrow::record_batch::RecordBatch;
@@ -1320,8 +1320,8 @@ mod tests {
         let schema = Schema::new(vec![Field::new("data", DataType::FixedSizeBinary(4), false)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![arc]).unwrap();
 
-        let mut stmt = conn.prepare("SELECT data FROM arrow(?, ?)")?;
-        let mut rows = stmt.query(arrow_recordbatch_to_query_params(batch))?;
+        let mut stmt = conn.prepare("SELECT data FROM arrow(?)")?;
+        let mut rows = stmt.query([&ArrowBatchRegistration::new(batch)])?;
 
         // Read via Row interface
         let row = rows.next()?.unwrap();
@@ -1339,7 +1339,7 @@ mod tests {
     #[cfg(feature = "vtab-arrow")]
     fn test_fixed_size_binary_value_ref_via_arrow() -> Result<()> {
         use crate::types::ValueRef;
-        use crate::vtab::arrow::{ArrowVTab, arrow_recordbatch_to_query_params};
+        use crate::vtab::arrow::{ArrowBatchRegistration, ArrowVTab};
         use arrow::array::{ArrayRef, FixedSizeBinaryArray};
         use arrow::datatypes::{DataType, Field, Schema};
         use arrow::record_batch::RecordBatch;
@@ -1355,8 +1355,8 @@ mod tests {
         let schema = Schema::new(vec![Field::new("data", DataType::FixedSizeBinary(4), true)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![arc]).unwrap();
 
-        let mut stmt = conn.prepare("SELECT data FROM arrow(?, ?)")?;
-        let mut rows = stmt.query(arrow_recordbatch_to_query_params(batch))?;
+        let mut stmt = conn.prepare("SELECT data FROM arrow(?)")?;
+        let mut rows = stmt.query([&ArrowBatchRegistration::new(batch)])?;
 
         // First row - non-null
         let row = rows.next()?.unwrap();

--- a/crates/duckdb/src/vtab/arrow/mod.rs
+++ b/crates/duckdb/src/vtab/arrow/mod.rs
@@ -2,25 +2,29 @@
 mod tests;
 
 use super::{BindInfo, DataChunkHandle, InitInfo, LogicalTypeHandle, TableFunctionInfo, VTab};
-use std::sync::{Arc, Mutex, OnceLock, atomic::AtomicUsize};
+use std::{
+    collections::HashMap,
+    sync::{
+        LazyLock, Mutex, MutexGuard, PoisonError,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+};
 
 use arrow::{
     array::{ArrayData, StructArray},
+    datatypes::DataType,
     ffi::{FFI_ArrowArray, FFI_ArrowSchema},
     record_batch::RecordBatch,
 };
 
 pub use crate::arrow_interop::*;
-use crate::core::LogicalTypeId;
+use crate::{ToSql, core::LogicalTypeId, types::ToSqlOutput};
 
-/// The Arrow record batch for the table function.
+/// The registered Arrow record batch resolved during bind.
 ///
-/// Bind data is shared across `func` calls and should be treated as read-only.
-/// That is enough for `RecordBatch`: Arrow batches are immutable containers of
-/// shared array data, and the `VTab::BindData: Send + Sync` bound requires this
-/// value to be safe to share. The mutable scan position lives in
-/// `ArrowInitData.offset`, so the batch itself does not need a `Mutex`.
-#[repr(C)]
+/// Keeping the batch in bind data lets a bound scan finish after its
+/// registration is dropped. Scan position remains isolated in
+/// [`ArrowInitData`].
 pub struct ArrowBindData {
     rb: RecordBatch,
 }
@@ -34,7 +38,6 @@ pub struct ArrowBindData {
 /// lets each call slice the next window of rows, so batches larger than the
 /// vector size are streamed across multiple calls instead of overflowing a
 /// single chunk.
-#[repr(C)]
 pub struct ArrowInitData {
     offset: AtomicUsize,
     vector_size: usize,
@@ -47,9 +50,14 @@ struct RowSlice {
 }
 
 impl ArrowInitData {
-    fn take_slice(&self, num_rows: usize) -> Option<RowSlice> {
-        use std::sync::atomic::Ordering::Relaxed;
+    fn new(vector_size: usize) -> Self {
+        Self {
+            offset: AtomicUsize::new(0),
+            vector_size,
+        }
+    }
 
+    fn take_slice(&self, num_rows: usize) -> Option<RowSlice> {
         let vector_size = self.vector_size;
         // DuckDB currently drives this scan serially, but if parallel scans are
         // enabled later, this atomic read-modify-write makes each claimed row
@@ -57,7 +65,7 @@ impl ArrowInitData {
         // self-contained and no other shared state is published through the atomic.
         let offset = self
             .offset
-            .fetch_update(Relaxed, Relaxed, |offset| {
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |offset| {
                 if offset >= num_rows {
                     None
                 } else {
@@ -77,64 +85,18 @@ impl ArrowInitData {
 /// The Arrow table function.
 pub struct ArrowVTab;
 
-const ARROW_QUERY_PARAMS_MARKER: usize = 0x4152_5257; // "ARRW"
-fn arrow_record_batch_store() -> &'static Mutex<Vec<Arc<RecordBatch>>> {
-    static STORE: OnceLock<Mutex<Vec<Arc<RecordBatch>>>> = OnceLock::new();
-    STORE.get_or_init(|| Mutex::new(Vec::new()))
-}
+// Registrations are not associated with a connection, so batches share a
+// process-global registry. A registration owns its map entry, and binding a
+// scan clones the cheap, Arc-backed RecordBatch into bind data.
+static BATCHES: LazyLock<Mutex<HashMap<u64, RecordBatch>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+// Start tokens in the upper half so ordinary small UBIGINT literals do not
+// accidentally select registrations during any realistic process lifetime.
+// Tokens are registry identifiers, not secrets.
+const ARROW_BATCH_TOKEN_START: u64 = 1 << 63;
+static NEXT_TOKEN: AtomicU64 = AtomicU64::new(ARROW_BATCH_TOKEN_START);
 
-fn register_arrow_record_batch(rb: RecordBatch) -> [usize; 2] {
-    // Views can rebind long after creation, so the RecordBatch allocation must
-    // remain valid for the process lifetime. The Arc keeps the pointee stable
-    // across Vec growth, while the static store keeps it visible to
-    // LeakSanitizer as reachable process-lifetime storage.
-    let mut store = arrow_record_batch_store()
-        .lock()
-        .expect("ArrowVTab record batch store poisoned");
-    let rb = Arc::new(rb);
-    let ptr = Arc::as_ptr(&rb);
-    store.push(rb);
-    [ptr as usize, ARROW_QUERY_PARAMS_MARKER]
-}
-
-fn arrow_query_param_usize(bind: &BindInfo, index: u64, name: &str) -> Result<usize, Box<dyn std::error::Error>> {
-    let value = bind.get_parameter(index);
-    if value.is_null() {
-        return Err(format!("ArrowVTab {name} parameter must not be NULL").into());
-    }
-
-    let logical_type = value.logical_type_id();
-    if logical_type != LogicalTypeId::UBigint {
-        return Err(format!("ArrowVTab {name} parameter must be UBIGINT, got {logical_type:?}").into());
-    }
-
-    usize::try_from(value.to_uint64()).map_err(|_| format!("ArrowVTab {name} parameter does not fit in usize").into())
-}
-
-/// Imports a record batch from the current opaque ArrowVTab query parameters.
-///
-/// # Safety
-///
-/// `address` must be a non-null pointer returned by
-/// [`arrow_recordbatch_to_query_params`], and `marker` must be the matching
-/// layout marker returned with it. The marker catches common misuse only and
-/// does not make stale or forged pointers safe to dereference.
-unsafe fn address_to_arrow_record_batch(
-    address: usize,
-    marker: usize,
-) -> Result<RecordBatch, Box<dyn std::error::Error>> {
-    let ptr = address as *const RecordBatch;
-    if ptr.is_null() {
-        return Err("invalid ArrowVTab record batch address".into());
-    }
-
-    if marker != ARROW_QUERY_PARAMS_MARKER {
-        return Err("ArrowVTab query parameter marker mismatch; use arrow_recordbatch_to_query_params".into());
-    }
-
-    // SAFETY: The caller guarantees that `ptr` is the RecordBatch allocation
-    // retained by `register_arrow_record_batch`.
-    Ok(unsafe { (*ptr).clone() })
+fn lock_batches() -> MutexGuard<'static, HashMap<u64, RecordBatch>> {
+    BATCHES.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 impl VTab for ArrowVTab {
@@ -142,18 +104,19 @@ impl VTab for ArrowVTab {
     type InitData = ArrowInitData;
 
     fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
-        let param_count = bind.get_parameter_count();
-        if param_count != 2 {
-            return Err(format!("Bad param count: {param_count}, expected 2").into());
+        let value = bind.get_parameter(0);
+        if value.is_null() {
+            return Err("ArrowVTab record batch token parameter must not be NULL".into());
         }
-        let address = arrow_query_param_usize(bind, 0, "record batch address")?;
-        let marker = arrow_query_param_usize(bind, 1, "marker")?;
-
-        // SAFETY: ArrowVTab's raw-parameter API relies on callers passing
-        // values returned unchanged by `arrow_recordbatch_to_query_params`.
-        // Validation above catches nulls, type mismatches, and layout marker
-        // mismatches, but cannot validate forged addresses.
-        let rb = unsafe { address_to_arrow_record_batch(address, marker)? };
+        let logical_type = value.logical_type_id();
+        if logical_type != LogicalTypeId::UBigint {
+            return Err(format!("ArrowVTab record batch token parameter must be UBIGINT, got {logical_type:?}").into());
+        }
+        let token = value.to_uint64();
+        let rb = lock_batches()
+            .get(&token)
+            .cloned()
+            .ok_or_else(|| format!("ArrowVTab record batch token {token} is not registered"))?;
         for f in rb.schema().fields() {
             let name = f.name();
             let logical_type = to_duckdb_logical_type_for_field(f)?;
@@ -169,17 +132,12 @@ impl VTab for ArrowVTab {
             return Err("DuckDB vector size must be greater than zero".into());
         }
 
-        Ok(ArrowInitData {
-            offset: AtomicUsize::new(0),
-            vector_size,
-        })
+        Ok(ArrowInitData::new(vector_size))
     }
 
     fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
         let init_info = func.get_init_data();
-        let bind_info = func.get_bind_data();
-
-        let rb = &bind_info.rb;
+        let rb = &func.get_bind_data().rb;
         let num_rows = rb.num_rows();
         let Some(slice) = init_info.take_slice(num_rows) else {
             output.set_len(0);
@@ -193,64 +151,106 @@ impl VTab for ArrowVTab {
     }
 
     fn parameters() -> Option<Vec<LogicalTypeHandle>> {
-        Some(vec![
-            LogicalTypeHandle::from(LogicalTypeId::UBigint), // record batch address
-            LogicalTypeHandle::from(LogicalTypeId::UBigint), // query parameter marker
-        ])
+        Some(vec![LogicalTypeHandle::from(LogicalTypeId::UBigint)])
     }
 }
 
-/// Pass a RecordBatch to DuckDB.
+/// An Arrow [`RecordBatch`] registration for [`ArrowVTab`].
 ///
-/// This returns opaque query parameters for [`ArrowVTab`].
+/// Pass a reference as one element of a parameter list, such as
+/// `statement.query_arrow([&registration])`. A registration can back multiple
+/// scans and executions while it is alive. Each bound scan retains the batch,
+/// so it can execute after the registration is dropped. Dropping the
+/// registration releases its batch from the registry and prevents future
+/// scans, including stored views, from binding it. Registrations use a
+/// process-global registry and are not scoped to a connection.
 ///
-/// Each call permanently retains one [`RecordBatch`] allocation in a
-/// process-global arena that is never freed, so stored views can rebind the same
-/// parameters later. Memory grows monotonically. Do not call this per row or
-/// per query. Create these parameters once per logical table or view.
+/// Registrations must not be passed by value:
 ///
-/// # Panics
+/// ```compile_fail
+/// use duckdb::{Statement, vtab::arrow::ArrowBatchRegistration};
 ///
-/// Panics if the process-global ArrowVTab record batch store mutex is poisoned.
-pub fn arrow_recordbatch_to_query_params(rb: RecordBatch) -> [usize; 2] {
-    register_arrow_record_batch(rb)
+/// fn query_with_owned_registration(
+///     statement: &mut Statement<'_>,
+///     registration: ArrowBatchRegistration,
+/// ) {
+///     let _ = statement.query_arrow([registration]);
+/// }
+/// ```
+///
+/// A reference to this type implements [`ToSql`] only to pass its opaque token
+/// to `arrow(...)`. Using it in another SQL position binds that implementation
+/// detail as a `UBIGINT`; the value has no stable meaning and should not be
+/// stored or otherwise used as data.
+///
+/// With DuckDB 1.5.5, dropping a stream returned by
+/// [`crate::Statement::stream_arrow`]
+/// before consuming it can retain the batch even after the statement and
+/// registration are dropped. Another query on the same connection, or closing
+/// the connection, releases it.
+#[derive(Debug)]
+#[must_use = "dropping the registration releases its Arrow record batch"]
+pub struct ArrowBatchRegistration {
+    token: u64,
 }
 
-/// Pass ArrayData to DuckDB.
-///
-/// This converts the [`ArrayData`] to a [`RecordBatch`] immediately. Like
-/// [`arrow_recordbatch_to_query_params`], each call permanently retains one
-/// [`RecordBatch`] allocation in a process-global arena that is never freed.
-///
-/// # Panics
-///
-/// Panics if the process-global ArrowVTab record batch store mutex is poisoned.
-pub fn arrow_arraydata_to_query_params(data: ArrayData) -> [usize; 2] {
-    let struct_array = StructArray::from(data);
-    arrow_recordbatch_to_query_params(RecordBatch::from(&struct_array))
+impl ArrowBatchRegistration {
+    /// Registers `rb` until this value is dropped.
+    pub fn new(rb: RecordBatch) -> Self {
+        let token = NEXT_TOKEN.fetch_add(1, Ordering::Relaxed);
+        lock_batches().insert(token, rb);
+        Self { token }
+    }
+
+    /// Converts a struct [`ArrayData`] into a registration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` does not describe a struct array or if the struct array
+    /// contains top-level nulls, which a [`RecordBatch`] cannot represent.
+    pub fn from_array_data(data: ArrayData) -> Self {
+        // StructArray::from does not check the data type, so a non-struct input
+        // would otherwise reach an unreachable!() inside StructArray::into_parts.
+        assert!(
+            matches!(data.data_type(), DataType::Struct(_)),
+            "ArrowVTab registration requires a struct array, got {:?}",
+            data.data_type()
+        );
+        let struct_array = StructArray::from(data);
+        Self::new(RecordBatch::from(&struct_array))
+    }
+
+    /// Imports an Arrow FFI struct array into a registration.
+    ///
+    /// # Safety
+    ///
+    /// `array` and `schema` must describe the same valid, unreleased Arrow
+    /// struct array and satisfy [`arrow::ffi::from_ffi`]'s C Data Interface
+    /// contract. Ownership is transferred to this function. The backing memory
+    /// and release callback must be safe to use from any thread.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the FFI values cannot be imported, if they do not describe a
+    /// struct array, or if that array contains top-level nulls, which a
+    /// [`RecordBatch`] cannot represent.
+    pub unsafe fn from_ffi(array: FFI_ArrowArray, schema: FFI_ArrowSchema) -> Self {
+        // SAFETY: The caller guarantees matching, valid C Data Interface values.
+        let data = unsafe { arrow::ffi::from_ffi(array, &schema) }.expect("failed to import Arrow FFI data");
+        Self::from_array_data(data)
+    }
 }
 
-/// Pass array and schema to DuckDB.
-///
-/// This imports the FFI values immediately. Like
-/// [`arrow_recordbatch_to_query_params`], each call permanently retains one
-/// [`RecordBatch`] allocation in a process-global arena that is never freed.
-///
-/// # Safety
-///
-/// `array` and `schema` must describe the same valid, unreleased Arrow struct
-/// array and satisfy [`arrow::ffi::from_ffi`]'s C Data Interface contract,
-/// including valid pointers, buffer lengths, and release callbacks. Ownership
-/// of both values is transferred to this function. The array's backing memory
-/// must remain valid and immutable until its release callback runs.
-///
-/// # Panics
-///
-/// Panics if the FFI values cannot be imported as a struct array, or if the
-/// process-global ArrowVTab record batch store mutex is poisoned.
-pub unsafe fn arrow_ffi_to_query_params(array: FFI_ArrowArray, schema: FFI_ArrowSchema) -> [usize; 2] {
-    // SAFETY: The caller guarantees matching, valid C Data Interface values.
-    // The importer takes ownership of the array and retains its release callback.
-    let array_data = unsafe { arrow::ffi::from_ffi(array, &schema) }.expect("failed to import Arrow FFI data");
-    arrow_arraydata_to_query_params(array_data)
+impl ToSql for &ArrowBatchRegistration {
+    fn to_sql(&self) -> crate::Result<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(self.token))
+    }
+}
+
+impl Drop for ArrowBatchRegistration {
+    fn drop(&mut self) {
+        // Keep the removed batch alive until the registry guard has dropped so
+        // foreign Arrow release callbacks do not run while holding the mutex.
+        let _removed = lock_batches().remove(&self.token);
+    }
 }

--- a/crates/duckdb/src/vtab/arrow/mod.rs
+++ b/crates/duckdb/src/vtab/arrow/mod.rs
@@ -13,6 +13,7 @@ use std::{
 use arrow::{
     array::{ArrayData, StructArray},
     datatypes::DataType,
+    error::ArrowError,
     ffi::{FFI_ArrowArray, FFI_ArrowSchema},
     record_batch::RecordBatch,
 };
@@ -108,10 +109,6 @@ impl VTab for ArrowVTab {
         if value.is_null() {
             return Err("ArrowVTab record batch token parameter must not be NULL".into());
         }
-        let logical_type = value.logical_type_id();
-        if logical_type != LogicalTypeId::UBigint {
-            return Err(format!("ArrowVTab record batch token parameter must be UBIGINT, got {logical_type:?}").into());
-        }
         let token = value.to_uint64();
         let rb = lock_batches()
             .get(&token)
@@ -167,7 +164,7 @@ impl VTab for ArrowVTab {
 ///
 /// Registrations must not be passed by value:
 ///
-/// ```compile_fail
+/// ```compile_fail,E0277
 /// use duckdb::{Statement, vtab::arrow::ArrowBatchRegistration};
 ///
 /// fn query_with_owned_registration(
@@ -183,11 +180,11 @@ impl VTab for ArrowVTab {
 /// detail as a `UBIGINT`; the value has no stable meaning and should not be
 /// stored or otherwise used as data.
 ///
-/// With DuckDB 1.5.5, dropping a stream returned by
-/// [`crate::Statement::stream_arrow`]
-/// before consuming it can retain the batch even after the statement and
-/// registration are dropped. Another query on the same connection, or closing
-/// the connection, releases it.
+/// DuckDB 1.5.5 can retain the batch after an unconsumed stream returned by
+/// [`crate::Statement::stream_arrow`] is dropped. Another query on the same
+/// connection, or closing the connection, releases it; see [duckdb-rs#853].
+///
+/// [duckdb-rs#853]: https://github.com/duckdb/duckdb-rs/pull/853
 #[derive(Debug)]
 #[must_use = "dropping the registration releases its Arrow record batch"]
 pub struct ArrowBatchRegistration {
@@ -204,20 +201,26 @@ impl ArrowBatchRegistration {
 
     /// Converts a struct [`ArrayData`] into a registration.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `data` does not describe a struct array or if the struct array
-    /// contains top-level nulls, which a [`RecordBatch`] cannot represent.
-    pub fn from_array_data(data: ArrayData) -> Self {
-        // StructArray::from does not check the data type, so a non-struct input
-        // would otherwise reach an unreachable!() inside StructArray::into_parts.
-        assert!(
-            matches!(data.data_type(), DataType::Struct(_)),
-            "ArrowVTab registration requires a struct array, got {:?}",
-            data.data_type()
-        );
+    /// Returns an error if `data` does not describe a struct array or if the
+    /// struct array contains top-level nulls, which a [`RecordBatch`] cannot
+    /// represent.
+    pub fn from_array_data(data: ArrayData) -> Result<Self, ArrowError> {
+        if !matches!(data.data_type(), DataType::Struct(_)) {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "ArrowVTab registration requires a struct array, got {:?}",
+                data.data_type()
+            )));
+        }
+        if data.null_count() != 0 {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "ArrowVTab registration does not support {} top-level nulls",
+                data.null_count()
+            )));
+        }
         let struct_array = StructArray::from(data);
-        Self::new(RecordBatch::from(&struct_array))
+        Ok(Self::new(RecordBatch::from(struct_array)))
     }
 
     /// Imports an Arrow FFI struct array into a registration.
@@ -229,14 +232,14 @@ impl ArrowBatchRegistration {
     /// contract. Ownership is transferred to this function. The backing memory
     /// and release callback must be safe to use from any thread.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the FFI values cannot be imported, if they do not describe a
-    /// struct array, or if that array contains top-level nulls, which a
-    /// [`RecordBatch`] cannot represent.
-    pub unsafe fn from_ffi(array: FFI_ArrowArray, schema: FFI_ArrowSchema) -> Self {
+    /// Returns an error if the FFI values cannot be imported, if they do not
+    /// describe a struct array, or if that array contains top-level nulls,
+    /// which a [`RecordBatch`] cannot represent.
+    pub unsafe fn from_ffi(array: FFI_ArrowArray, schema: FFI_ArrowSchema) -> Result<Self, ArrowError> {
         // SAFETY: The caller guarantees matching, valid C Data Interface values.
-        let data = unsafe { arrow::ffi::from_ffi(array, &schema) }.expect("failed to import Arrow FFI data");
+        let data = unsafe { arrow::ffi::from_ffi(array, &schema) }?;
         Self::from_array_data(data)
     }
 }
@@ -249,8 +252,12 @@ impl ToSql for &ArrowBatchRegistration {
 
 impl Drop for ArrowBatchRegistration {
     fn drop(&mut self) {
-        // Keep the removed batch alive until the registry guard has dropped so
-        // foreign Arrow release callbacks do not run while holding the mutex.
-        let _removed = lock_batches().remove(&self.token);
+        // Remove under the lock, then run any foreign Arrow release callback
+        // only after the registry guard has been dropped.
+        let removed = {
+            let mut batches = lock_batches();
+            batches.remove(&self.token)
+        };
+        drop(removed);
     }
 }

--- a/crates/duckdb/src/vtab/arrow/tests/mod.rs
+++ b/crates/duckdb/src/vtab/arrow/tests/mod.rs
@@ -1,7 +1,4 @@
-use super::{
-    ArrowInitData, ArrowVTab, RowSlice, arrow_arraydata_to_query_params, arrow_ffi_to_query_params,
-    arrow_recordbatch_to_query_params,
-};
+use super::{ArrowBatchRegistration, ArrowInitData, ArrowVTab, RowSlice};
 use crate::arrow_interop::test_support::{uuid_array, uuid_field};
 use crate::{Connection, Result};
 use arrow::{
@@ -15,9 +12,11 @@ use arrow::{
 };
 use std::{
     error::Error,
-    sync::{Arc, Barrier, atomic::AtomicUsize},
+    sync::{Arc, Barrier},
 };
 use uuid::Uuid;
+
+mod registration;
 
 fn example_record_batch() -> RecordBatch {
     let schema = Schema::new(vec![
@@ -52,10 +51,10 @@ fn test_arrow_uuid_extension_roundtrip() -> Result<(), Box<dyn Error>> {
         Arc::new(schema),
         vec![Arc::new(uuid_array(&uuids, Some(vec![true, true, false, true]))) as ArrayRef],
     )?;
-    let param = arrow_recordbatch_to_query_params(batch);
+    let reg = ArrowBatchRegistration::new(batch);
 
-    let mut stmt = db.prepare("SELECT id::VARCHAR, typeof(id) FROM arrow(?, ?)")?;
-    let rows = stmt.query_map(param, |row| {
+    let mut stmt = db.prepare("SELECT id::VARCHAR, typeof(id) FROM arrow(?)")?;
+    let rows = stmt.query_map([&reg], |row| {
         Ok((row.get::<_, Option<String>>(0)?, row.get::<_, String>(1)?))
     })?;
     let observed: std::result::Result<Vec<_>, _> = rows.collect();
@@ -101,10 +100,10 @@ fn test_arrow_uuid_extension_roundtrip_in_struct() -> Result<(), Box<dyn Error>>
         true,
     )]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(struct_array) as ArrayRef])?;
-    let param = arrow_recordbatch_to_query_params(batch);
+    let reg = ArrowBatchRegistration::new(batch);
 
-    let mut stmt = db.prepare("SELECT payload.id::VARCHAR, typeof(payload.id) FROM arrow(?, ?)")?;
-    let rows = stmt.query_map(param, |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+    let mut stmt = db.prepare("SELECT payload.id::VARCHAR, typeof(payload.id) FROM arrow(?)")?;
+    let rows = stmt.query_map([&reg], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
     let observed: std::result::Result<Vec<_>, _> = rows.collect();
 
     assert_eq!(
@@ -136,10 +135,10 @@ fn test_arrow_uuid_extension_roundtrip_in_list() -> Result<(), Box<dyn Error>> {
     );
     let schema = Schema::new(vec![Field::new("ids", list_array.data_type().clone(), true)]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(list_array) as ArrayRef])?;
-    let param = arrow_recordbatch_to_query_params(batch);
+    let reg = ArrowBatchRegistration::new(batch);
 
-    let mut stmt = db.prepare("SELECT ids[1]::VARCHAR, typeof(ids[1]) FROM arrow(?, ?)")?;
-    let rows = stmt.query_map(param, |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+    let mut stmt = db.prepare("SELECT ids[1]::VARCHAR, typeof(ids[1]) FROM arrow(?)")?;
+    let rows = stmt.query_map([&reg], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
     let observed: std::result::Result<Vec<_>, _> = rows.collect();
 
     assert_eq!(
@@ -182,10 +181,10 @@ fn test_arrow_uuid_extension_roundtrip_in_map() -> Result<(), Box<dyn Error>> {
     );
     let schema = Schema::new(vec![Field::new("lookup", map_array.data_type().clone(), true)]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array) as ArrayRef])?;
-    let param = arrow_recordbatch_to_query_params(batch);
+    let reg = ArrowBatchRegistration::new(batch);
 
-    let mut stmt = db.prepare("SELECT lookup['alpha']::VARCHAR, lookup['beta']::VARCHAR FROM arrow(?, ?)")?;
-    let rows = stmt.query_map(param, |row| {
+    let mut stmt = db.prepare("SELECT lookup['alpha']::VARCHAR, lookup['beta']::VARCHAR FROM arrow(?)")?;
+    let rows = stmt.query_map([&reg], |row| {
         Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?))
     })?;
     let observed: std::result::Result<Vec<_>, _> = rows.collect();
@@ -203,17 +202,17 @@ fn test_query_record_batch_with_arrow_vtab() -> Result<(), Box<dyn Error>> {
     let db = Connection::open_in_memory()?;
     db.register_table_function::<ArrowVTab>("arrow")?;
 
-    let params = arrow_recordbatch_to_query_params(example_record_batch());
+    let reg = ArrowBatchRegistration::new(example_record_batch());
     let batches: Vec<RecordBatch> = db
         .prepare(
             "
                 SELECT id, upper(name) AS name, is_odd
-                FROM arrow(?, ?)
+                FROM arrow(?)
                 WHERE is_odd
                 ORDER BY id
                 ",
         )?
-        .query_arrow(params)?
+        .query_arrow([&reg])?
         .collect();
 
     assert_eq!(batches.len(), 1);
@@ -266,13 +265,10 @@ fn large_record_batch(n: usize, vector_size: usize) -> RecordBatch {
 }
 
 #[test]
-fn test_arrow_init_data_take_slice_partitions_rows_concurrently() {
+fn test_arrow_init_data_partitions_rows_concurrently() {
     let num_rows = 10_000usize;
     let thread_count = 16;
-    let init = Arc::new(ArrowInitData {
-        offset: AtomicUsize::new(0),
-        vector_size: 1,
-    });
+    let init = Arc::new(ArrowInitData::new(1));
     let start = Arc::new(Barrier::new(thread_count));
 
     let mut handles = Vec::new();
@@ -310,11 +306,8 @@ fn test_arrow_init_data_take_slice_partitions_rows_concurrently() {
 }
 
 #[test]
-fn test_arrow_init_data_take_slice_handles_partial_tail() {
-    let init = ArrowInitData {
-        offset: AtomicUsize::new(0),
-        vector_size: 4,
-    };
+fn test_arrow_init_data_handles_partial_tail() {
+    let init = ArrowInitData::new(4);
 
     assert_eq!(init.take_slice(9), Some(RowSlice { offset: 0, len: 4 }));
     assert_eq!(init.take_slice(9), Some(RowSlice { offset: 4, len: 4 }));
@@ -322,10 +315,7 @@ fn test_arrow_init_data_take_slice_handles_partial_tail() {
     assert_eq!(init.take_slice(9), None);
     assert_eq!(init.take_slice(9), None);
 
-    let empty = ArrowInitData {
-        offset: AtomicUsize::new(0),
-        vector_size: 4,
-    };
+    let empty = ArrowInitData::new(4);
     assert_eq!(empty.take_slice(0), None);
     assert_eq!(empty.take_slice(0), None);
 }
@@ -339,9 +329,9 @@ fn test_vtab_arrow() -> Result<(), Box<dyn Error>> {
         .prepare("SELECT * FROM read_parquet('./examples/int32_decimal.parquet');")?
         .query_arrow([])?
         .collect();
-    let param = arrow_recordbatch_to_query_params(rbs.into_iter().next().unwrap());
-    let mut stmt = db.prepare("select sum(value) from arrow(?, ?)")?;
-    let mut arr = stmt.query_arrow(param)?;
+    let reg = ArrowBatchRegistration::new(rbs.into_iter().next().unwrap());
+    let mut stmt = db.prepare("select sum(value) from arrow(?)")?;
+    let mut arr = stmt.query_arrow([&reg])?;
     let rb = arr.next().expect("no record batch");
     assert_eq!(rb.num_columns(), 1);
     let column = rb.column(0).as_any().downcast_ref::<Decimal128Array>().unwrap();
@@ -373,10 +363,10 @@ fn test_vtab_arrow_large_record_batch() -> Result<(), Box<dyn Error>> {
         two_vectors,
         with_tail,
     ] {
-        let param = arrow_recordbatch_to_query_params(large_record_batch(n, vector_size));
+        let reg = ArrowBatchRegistration::new(large_record_batch(n, vector_size));
         let rbs: Vec<RecordBatch> = db
-            .prepare("SELECT id, val FROM arrow(?, ?) ORDER BY id")?
-            .query_arrow(param)?
+            .prepare("SELECT id, val FROM arrow(?) ORDER BY id")?
+            .query_arrow([&reg])?
             .collect();
 
         let total: usize = rbs.iter().map(|rb| rb.num_rows()).sum();
@@ -439,110 +429,13 @@ fn test_vtab_arrow_rust_array() -> Result<(), Box<dyn Error>> {
     let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
     let array = Int32Array::from(vec![1, 2, 3, 4, 5]);
     let rb = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)]).expect("failed to create record batch");
-    let param = arrow_recordbatch_to_query_params(rb);
-    let mut stmt = db.prepare("select sum(a)::int32 from arrow(?, ?)")?;
-    let mut arr = stmt.query_arrow(param)?;
+    let reg = ArrowBatchRegistration::new(rb);
+    let mut stmt = db.prepare("select sum(a)::int32 from arrow(?)")?;
+    let mut arr = stmt.query_arrow([&reg])?;
     let rb = arr.next().expect("no record batch");
     assert_eq!(rb.num_columns(), 1);
     let column = rb.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
     assert_eq!(column.len(), 1);
     assert_eq!(column.value(0), 15);
     Ok(())
-}
-
-#[test]
-fn test_vtab_arrow_view_can_rebind_record_batch() -> Result<(), Box<dyn Error>> {
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-
-    let batch = example_record_batch();
-    let param = arrow_recordbatch_to_query_params(batch.clone());
-    db.execute(
-        &format!(
-            "CREATE VIEW arrow_view AS SELECT * FROM arrow({}::UBIGINT, {}::UBIGINT)",
-            param[0], param[1]
-        ),
-        [],
-    )?;
-
-    for _ in 0..2 {
-        let rbs: Vec<RecordBatch> = db.prepare("SELECT * FROM arrow_view")?.query_arrow([])?.collect();
-        assert_eq!(vec![batch.clone()], rbs);
-    }
-
-    Ok(())
-}
-
-#[test]
-fn test_vtab_arrow_arraydata_query_params() -> Result<(), Box<dyn Error>> {
-    let batch = example_record_batch();
-    let struct_array = StructArray::from(batch);
-    let param = arrow_arraydata_to_query_params(struct_array.to_data());
-
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-    let mut stmt = db.prepare("select sum(id)::int32 from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
-    let column = rb.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
-    assert_eq!(column.value(0), 10);
-    Ok(())
-}
-
-#[test]
-fn test_vtab_arrow_ffi_query_params() -> Result<(), Box<dyn Error>> {
-    let batch = example_record_batch();
-    let struct_array = StructArray::from(batch);
-    let array = FFI_ArrowArray::new(&struct_array.to_data());
-    let schema = FFI_ArrowSchema::try_from(struct_array.data_type())?;
-    drop(struct_array);
-    // SAFETY: Both values were exported from the same valid struct array, and
-    // the FFI array owns the backing buffers through its release callback.
-    let param = unsafe { arrow_ffi_to_query_params(array, schema) };
-
-    let db = Connection::open_in_memory()?;
-    db.register_table_function::<ArrowVTab>("arrow")?;
-    let mut stmt = db.prepare("select sum(id)::int32 from arrow(?, ?)")?;
-    let rb = stmt.query_arrow(param)?.next().expect("no record batch");
-    let column = rb.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
-    assert_eq!(column.value(0), 10);
-    Ok(())
-}
-
-#[test]
-fn test_arrow_null_query_params_error() {
-    let db = Connection::open_in_memory().unwrap();
-    db.register_table_function::<ArrowVTab>("arrow").unwrap();
-
-    let err = db.prepare("SELECT * FROM arrow(NULL, NULL)").err().unwrap();
-    assert!(
-        err.to_string()
-            .contains("ArrowVTab record batch address parameter must not be NULL"),
-        "unexpected error: {err}"
-    );
-}
-
-#[test]
-fn test_arrow_zero_address_query_params_error() {
-    let db = Connection::open_in_memory().unwrap();
-    db.register_table_function::<ArrowVTab>("arrow").unwrap();
-
-    let valid = arrow_recordbatch_to_query_params(example_record_batch());
-    let sql = format!("SELECT * FROM arrow(0::UBIGINT, {}::UBIGINT)", valid[1]);
-    let err = db.prepare(&sql).err().unwrap();
-    assert!(
-        err.to_string().contains("invalid ArrowVTab record batch address"),
-        "unexpected error: {err}"
-    );
-}
-
-#[test]
-fn test_arrow_marker_mismatch_query_params_error() {
-    let db = Connection::open_in_memory().unwrap();
-    db.register_table_function::<ArrowVTab>("arrow").unwrap();
-
-    let err = db.prepare("SELECT * FROM arrow(1::UBIGINT, 2::UBIGINT)").err().unwrap();
-    assert!(
-        err.to_string().contains("query parameter marker mismatch"),
-        "unexpected error: {err}"
-    );
 }

--- a/crates/duckdb/src/vtab/arrow/tests/registration.rs
+++ b/crates/duckdb/src/vtab/arrow/tests/registration.rs
@@ -1,20 +1,39 @@
 //! Lifetime and binding behaviour of [`ArrowBatchRegistration`].
 
 use super::*;
+use arrow::buffer::NullBuffer;
 
 // Constructors.
 
 #[test]
-#[should_panic(expected = "ArrowVTab registration requires a struct array")]
 fn test_from_array_data_rejects_non_struct_array() {
-    let _ = ArrowBatchRegistration::from_array_data(Int32Array::from(vec![1, 2, 3]).to_data());
+    let err = ArrowBatchRegistration::from_array_data(Int32Array::from(vec![1, 2, 3]).to_data())
+        .expect_err("registered a non-struct array");
+    assert!(
+        err.to_string().contains("requires a struct array"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_from_array_data_rejects_top_level_nulls() {
+    let batch = example_record_batch();
+    let struct_array = StructArray::new(
+        batch.schema().fields().clone(),
+        batch.columns().to_vec(),
+        Some(NullBuffer::from([true, false, true, true].as_slice())),
+    );
+
+    let err = ArrowBatchRegistration::from_array_data(struct_array.to_data())
+        .expect_err("registered a struct array with top-level nulls");
+    assert!(err.to_string().contains("top-level nulls"), "unexpected error: {err}");
 }
 
 #[test]
 fn test_vtab_arrow_arraydata_registration() -> Result<(), Box<dyn Error>> {
     let batch = example_record_batch();
     let struct_array = StructArray::from(batch);
-    let reg = ArrowBatchRegistration::from_array_data(struct_array.to_data());
+    let reg = ArrowBatchRegistration::from_array_data(struct_array.to_data())?;
 
     let db = Connection::open_in_memory()?;
     db.register_table_function::<ArrowVTab>("arrow")?;
@@ -22,6 +41,23 @@ fn test_vtab_arrow_arraydata_registration() -> Result<(), Box<dyn Error>> {
     let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
     let column = rb.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
     assert_eq!(column.value(0), 10);
+    Ok(())
+}
+
+#[test]
+fn test_from_ffi_rejects_non_struct_array() -> Result<(), Box<dyn Error>> {
+    let data = Int32Array::from(vec![1, 2, 3]).to_data();
+    let array = FFI_ArrowArray::new(&data);
+    let schema = FFI_ArrowSchema::try_from(data.data_type())?;
+
+    // SAFETY: Both values were exported from the same valid array, and the FFI
+    // array owns the backing buffers through its release callback.
+    let err =
+        unsafe { ArrowBatchRegistration::from_ffi(array, schema) }.expect_err("registered a non-struct FFI array");
+    assert!(
+        err.to_string().contains("requires a struct array"),
+        "unexpected error: {err}"
+    );
     Ok(())
 }
 
@@ -34,7 +70,7 @@ fn test_vtab_arrow_ffi_registration() -> Result<(), Box<dyn Error>> {
     drop(struct_array);
     // SAFETY: Both values were exported from the same valid struct array, and
     // the FFI array owns the backing buffers through its release callback.
-    let reg = unsafe { ArrowBatchRegistration::from_ffi(array, schema) };
+    let reg = unsafe { ArrowBatchRegistration::from_ffi(array, schema) }?;
 
     let db = Connection::open_in_memory()?;
     db.register_table_function::<ArrowVTab>("arrow")?;
@@ -46,6 +82,24 @@ fn test_vtab_arrow_ffi_registration() -> Result<(), Box<dyn Error>> {
 }
 
 // Token parameter validation.
+
+#[test]
+fn test_arrow_rejects_non_ubigint_before_bind() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+
+    for argument in ["'abc'", "1", "1.5"] {
+        let err = db
+            .prepare(&format!("SELECT * FROM arrow({argument})"))
+            .expect_err("non-UBIGINT argument reached ArrowVTab::bind");
+        assert!(
+            err.to_string().contains("No function matches"),
+            "unexpected error: {err}"
+        );
+    }
+
+    Ok(())
+}
 
 #[test]
 fn test_arrow_null_query_params_error() {

--- a/crates/duckdb/src/vtab/arrow/tests/registration.rs
+++ b/crates/duckdb/src/vtab/arrow/tests/registration.rs
@@ -1,0 +1,275 @@
+//! Lifetime and binding behaviour of [`ArrowBatchRegistration`].
+
+use super::*;
+
+// Constructors.
+
+#[test]
+#[should_panic(expected = "ArrowVTab registration requires a struct array")]
+fn test_from_array_data_rejects_non_struct_array() {
+    let _ = ArrowBatchRegistration::from_array_data(Int32Array::from(vec![1, 2, 3]).to_data());
+}
+
+#[test]
+fn test_vtab_arrow_arraydata_registration() -> Result<(), Box<dyn Error>> {
+    let batch = example_record_batch();
+    let struct_array = StructArray::from(batch);
+    let reg = ArrowBatchRegistration::from_array_data(struct_array.to_data());
+
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let mut stmt = db.prepare("select sum(id)::int32 from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
+    let column = rb.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(column.value(0), 10);
+    Ok(())
+}
+
+#[test]
+fn test_vtab_arrow_ffi_registration() -> Result<(), Box<dyn Error>> {
+    let batch = example_record_batch();
+    let struct_array = StructArray::from(batch);
+    let array = FFI_ArrowArray::new(&struct_array.to_data());
+    let schema = FFI_ArrowSchema::try_from(struct_array.data_type())?;
+    drop(struct_array);
+    // SAFETY: Both values were exported from the same valid struct array, and
+    // the FFI array owns the backing buffers through its release callback.
+    let reg = unsafe { ArrowBatchRegistration::from_ffi(array, schema) };
+
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let mut stmt = db.prepare("select sum(id)::int32 from arrow(?)")?;
+    let rb = stmt.query_arrow([&reg])?.next().expect("no record batch");
+    let column = rb.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+    assert_eq!(column.value(0), 10);
+    Ok(())
+}
+
+// Token parameter validation.
+
+#[test]
+fn test_arrow_null_query_params_error() {
+    let db = Connection::open_in_memory().unwrap();
+    db.register_table_function::<ArrowVTab>("arrow").unwrap();
+
+    let err = db.prepare("SELECT * FROM arrow(NULL)").err().unwrap();
+    assert!(
+        err.to_string()
+            .contains("ArrowVTab record batch token parameter must not be NULL"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_arrow_unknown_token_query_params_error() {
+    let db = Connection::open_in_memory().unwrap();
+    db.register_table_function::<ArrowVTab>("arrow").unwrap();
+
+    let err = db.prepare("SELECT * FROM arrow(0::UBIGINT)").err().unwrap();
+    assert!(
+        err.to_string().contains("record batch token 0 is not registered"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_small_literal_does_not_select_registered_batch() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let reg = ArrowBatchRegistration::new(example_record_batch());
+
+    let err = db
+        .query_row("SELECT name FROM arrow(1::UBIGINT)", [], |row| row.get::<_, String>(0))
+        .expect_err("a small literal selected a registered batch");
+    assert!(err.to_string().contains("is not registered"), "unexpected error: {err}");
+
+    let observed: String = db.query_row("SELECT name FROM arrow(?)", [&reg], |row| row.get(0))?;
+    assert_eq!(observed, "apple");
+    Ok(())
+}
+
+// Reuse across scans and executions.
+
+#[test]
+fn test_registration_can_be_reused_across_executions() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+
+    let reg = ArrowBatchRegistration::new(example_record_batch());
+    let mut stmt = db.prepare("SELECT * FROM arrow(?)")?;
+    let batches: Vec<RecordBatch> = stmt.query_arrow([&reg])?.collect();
+    assert_eq!(batches, vec![example_record_batch()]);
+
+    let batches: Vec<RecordBatch> = stmt.query_arrow([&reg])?.collect();
+    assert_eq!(batches, vec![example_record_batch()]);
+
+    Ok(())
+}
+
+#[test]
+fn test_registration_can_back_two_scans() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let reg = ArrowBatchRegistration::new(example_record_batch());
+    let mut stmt = db.prepare(
+        "SELECT lhs.name || rhs.name
+         FROM arrow($1) lhs
+         CROSS JOIN arrow($1) rhs",
+    )?;
+
+    let observed = stmt.query_row([&reg], |row| row.get::<_, String>(0))?;
+    assert_eq!(observed, "appleapple");
+    Ok(())
+}
+
+#[test]
+fn test_registration_parameter_composes_with_other_parameters() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let left = ArrowBatchRegistration::new(RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(StringArray::from(vec!["left"])) as ArrayRef,
+    )])?);
+    let right = ArrowBatchRegistration::new(RecordBatch::try_from_iter(vec![(
+        "value",
+        Arc::new(StringArray::from(vec!["right"])) as ArrayRef,
+    )])?);
+    let mut stmt = db.prepare(
+        "SELECT lhs.value || ':' || rhs.value
+         FROM arrow($1) lhs
+         CROSS JOIN arrow($2) rhs
+         WHERE $3 = 42",
+    )?;
+
+    let observed: String = stmt.query_row((&left, &right, 42), |row| row.get(0))?;
+
+    assert_eq!(observed, "left:right");
+    Ok(())
+}
+
+#[test]
+fn test_prepared_statement_accepts_a_new_registration() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let mut stmt = db.prepare("SELECT name FROM arrow(?)")?;
+
+    for expected in ["first", "second"] {
+        let batch =
+            RecordBatch::try_from_iter(vec![("name", Arc::new(StringArray::from(vec![expected])) as ArrayRef)])?;
+        let reg = ArrowBatchRegistration::new(batch);
+        let observed: String = stmt.query_row([&reg], |row| row.get(0))?;
+        assert_eq!(observed, expected);
+    }
+
+    Ok(())
+}
+
+// Registry lifetime.
+
+#[test]
+fn test_unbound_registration_releases_batch() -> Result<(), Box<dyn Error>> {
+    let array = Arc::new(StringArray::from(vec!["unbound allocation"]));
+    let weak_array = Arc::downgrade(&array);
+    let batch = RecordBatch::try_from_iter(vec![("value", array as ArrayRef)])?;
+    let reg = ArrowBatchRegistration::new(batch);
+
+    assert!(weak_array.upgrade().is_some());
+    drop(reg);
+    assert!(weak_array.upgrade().is_none(), "the unbound batch is still retained");
+    Ok(())
+}
+
+#[test]
+fn test_temporary_registration_releases_completed_insert_batches() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    db.execute("CREATE TABLE target(value VARCHAR)", [])?;
+
+    for value in ["first allocation", "second allocation", "third allocation"] {
+        let array = Arc::new(StringArray::from(vec![value]));
+        let weak_array = Arc::downgrade(&array);
+        let batch = RecordBatch::try_from_iter(vec![("value", array as ArrayRef)])?;
+
+        db.execute(
+            "INSERT INTO target SELECT * FROM arrow(?)",
+            [&ArrowBatchRegistration::new(batch)],
+        )?;
+
+        assert!(
+            weak_array.upgrade().is_none(),
+            "the completed query still retains {value}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_temporary_registration_releases_batch_after_parse_error() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let array = Arc::new(StringArray::from(vec!["failed query allocation"]));
+    let weak_array = Arc::downgrade(&array);
+    let batch = RecordBatch::try_from_iter(vec![("value", array as ArrayRef)])?;
+
+    let err = db
+        .execute("SELECT * FROM arrow(?) WHERE", [&ArrowBatchRegistration::new(batch)])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("Parser Error"), "unexpected error: {err}");
+    assert!(
+        weak_array.upgrade().is_none(),
+        "the failed query still retains its batch"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_active_stream_outlives_registration() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let reg = ArrowBatchRegistration::new(example_record_batch());
+    let mut stmt = db.prepare("SELECT * FROM arrow(?)")?;
+    let stream = stmt.stream_arrow([&reg])?;
+
+    drop(reg);
+
+    assert_eq!(stream.collect::<Vec<_>>(), vec![example_record_batch()]);
+    Ok(())
+}
+
+#[test]
+fn test_bound_statement_outlives_registration() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let reg = ArrowBatchRegistration::new(example_record_batch());
+    let mut stmt = db.prepare(&format!("SELECT * FROM arrow({}::UBIGINT)", reg.token))?;
+
+    drop(reg);
+
+    let batches: Vec<RecordBatch> = stmt.query_arrow([])?.collect();
+    assert_eq!(batches, vec![example_record_batch()]);
+    Ok(())
+}
+
+#[test]
+fn test_stored_view_follows_registration_lifetime() -> Result<(), Box<dyn Error>> {
+    let db = Connection::open_in_memory()?;
+    db.register_table_function::<ArrowVTab>("arrow")?;
+    let reg = ArrowBatchRegistration::new(example_record_batch());
+    db.execute(
+        &format!("CREATE VIEW arrow_view AS SELECT * FROM arrow({}::UBIGINT)", reg.token),
+        [],
+    )?;
+
+    let count: i64 = db.query_row("SELECT count(*) FROM arrow_view", [], |row| row.get(0))?;
+    assert_eq!(count, 4);
+
+    drop(reg);
+
+    let err = db
+        .prepare("SELECT * FROM arrow_view")
+        .expect_err("stale view was rebound");
+    assert!(err.to_string().contains("is not registered"), "unexpected error: {err}");
+    Ok(())
+}

--- a/crates/duckdb/src/vtab/mod.rs
+++ b/crates/duckdb/src/vtab/mod.rs
@@ -40,8 +40,8 @@ mod value;
 pub mod arrow;
 #[cfg(feature = "vtab-arrow")]
 pub use self::arrow::{
-    arrow_arraydata_to_query_params, arrow_ffi_to_query_params, arrow_recordbatch_to_query_params,
-    record_batch_to_duckdb_data_chunk, to_duckdb_logical_type, to_duckdb_logical_type_for_field, to_duckdb_type_id,
+    ArrowBatchRegistration, record_batch_to_duckdb_data_chunk, to_duckdb_logical_type,
+    to_duckdb_logical_type_for_field, to_duckdb_type_id,
 };
 pub use function::{BindInfo, InitInfo, TableFunction, TableFunctionInfo};
 pub use value::Value;


### PR DESCRIPTION
`ArrowVTab` query parameters retained every record batch for the process lifetime by passing a raw pointer through SQL and pinning its allocation in a global arena (introduced in a1410845).

This replaces that path with `ArrowBatchRegistration`, which holds a batch in a private registry for as long as the registration is alive. Binding resolves the token once and clones the `Arc`-backed batch into bind data, so one registration can back repeated scans and executions, and a bound statement still runs after its registration is dropped. Scan position stays isolated in per-scan init data. Dropping the registration releases the batch, and later binds, including from stored views, fail with an error instead of dereferencing a stale pointer. That also removes the unsafe import path.

Registrations bind by reference only, as in `query_arrow([&reg])`. `Params::__bind_in` consumes the parameter list and drops it before the statement executes, so an owned registration would release its registry entry before DuckDB invokes the binder. A `compile_fail,E0277` doctest covers the by-value case.

Tokens are monotonic and start in the upper half of the `u64` namespace, so `Value::to_uint64`'s zero fallback and small SQL literals cannot select a registered batch. They are registry identifiers rather than secrets, and the registry is process-global, not scoped to a connection. Argument type validation is left to the declared `UBIGINT` signature, since DuckDB's binder rejects every other type before `bind` runs, so only `NULL` needs an explicit check.

`from_array_data` and `from_ffi` return `Result<_, ArrowError>` instead of panicking. They reject a non-struct input, which previously reached an `unreachable!()` inside `StructArray::into_parts`, and a struct array with top-level nulls, which a `RecordBatch` cannot represent.

### Breaking change

`arrow_recordbatch_to_query_params`, `arrow_arraydata_to_query_params`, and `arrow_ffi_to_query_params` are removed. Use `ArrowBatchRegistration::new`, `from_array_data`, or `from_ffi`, then pass `&reg` to `arrow(?)`.

`from_array_data` and `from_ffi` return `Result<Self, ArrowError>`, so callers replacing `arrow_arraydata_to_query_params` and `arrow_ffi_to_query_params` have to handle the error. `from_ffi` stays `unsafe`. `ArrowError` is reachable through the crate's own re-export as `duckdb::arrow::error::ArrowError`.

The table function takes one parameter now, so `arrow(?, ?)` becomes `arrow(?)`.

```diff
-let params = arrow_recordbatch_to_query_params(batch);   // [addr, marker], leaks forever
-let mut stmt = conn.prepare("SELECT * FROM arrow(?, ?)")?;
-stmt.query_arrow(params)?;
+let reg = ArrowBatchRegistration::new(batch);            // owns a registry entry
+let mut stmt = conn.prepare("SELECT * FROM arrow(?)")?;
+stmt.query_arrow([&reg])?;                               // by reference only
+// drop(reg) releases the batch
```

### Known issue

With DuckDB 1.5.5, dropping an unconsumed `stream_arrow` stream can retain the batch until another query runs on the connection or the connection closes. `ArrowBatchRegistration`'s rustdoc links here for this caveat.
